### PR TITLE
Add da1469x_hal

### DIFF
--- a/smartbond/CMakeLists.txt
+++ b/smartbond/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(sdk/bsp/include)
+zephyr_include_directories(da1469x_hal)
+add_subdirectory(da1469x_hal)

--- a/smartbond/da1469x_hal/CMakeLists.txt
+++ b/smartbond/da1469x_hal/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources(
+  da1469x_clock.c
+  da1469x_otp.c
+  da1469x_pd.c
+  da1469x_pdc.c
+  da1469x_trimv.c
+)

--- a/smartbond/da1469x_hal/da1469x_clock.c
+++ b/smartbond/da1469x_hal/da1469x_clock.c
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <DA1469xAB.h>
+#include <da1469x_config.h>
+#include <da1469x_clock.h>
+#include <da1469x_pd.h>
+#include <da1469x_pdc.h>
+
+#define XTAL32M_FREQ    32000000
+#define RC32M_FREQ      32000000
+#define PLL_FREQ        96000000
+#define XTAL32K_FREQ       32768
+
+static uint32_t g_mcu_clock_rcx_freq;
+static uint32_t g_mcu_clock_rc32k_freq;
+static uint32_t g_mcu_clock_rc32m_freq;
+
+uint32_t SystemCoreClock = RC32M_FREQ;
+
+static inline bool
+da1469x_clock_is_xtal32m_settled(void)
+{
+    return ((*(volatile uint32_t *)0x5001001c & 0xff00) == 0) &&
+           ((*(volatile uint32_t *)0x50010054 & 0x000f) != 0xb);
+}
+
+void
+da1469x_clock_sys_xtal32m_init(void)
+{
+    uint32_t reg;
+    int xtalrdy_cnt;
+
+    /*
+     * Number of 256kHz clock cycles (~4.085us) assuming worst case when actual frequency is 244800.
+     * RC32M is in range <30.6, 32.6> so 256Khz can ba as low as 30.6MHz / 125 = 244.8kHz.
+     */
+    xtalrdy_cnt = 1000 * 1000 / 4085;
+
+    reg = CRG_XTAL->XTALRDY_CTRL_REG;
+    reg &= ~(CRG_XTAL_XTALRDY_CTRL_REG_XTALRDY_CNT_Msk);
+    reg |= CRG_XTAL_XTALRDY_CTRL_REG_XTALRDY_CLK_SEL_Msk;
+    reg |= xtalrdy_cnt;
+    CRG_XTAL->XTALRDY_CTRL_REG = reg;
+}
+
+void
+da1469x_clock_sys_xtal32m_enable(void)
+{
+    int idx;
+
+    idx = da1469x_pdc_find(MCU_PDC_TRIGGER_SW_TRIGGER, MCU_PDC_MASTER_M33,
+                           MCU_PDC_EN_XTAL);
+    if (idx < 0) {
+        idx = da1469x_pdc_add(MCU_PDC_TRIGGER_SW_TRIGGER, MCU_PDC_MASTER_M33,
+                              MCU_PDC_EN_XTAL);
+    }
+    assert(idx >= 0);
+
+    da1469x_pdc_set(idx);
+    da1469x_pdc_ack(idx);
+}
+
+void
+da1469x_clock_sys_xtal32m_switch(void)
+{
+    if (CRG_TOP->CLK_CTRL_REG & CRG_TOP_CLK_CTRL_REG_RUNNING_AT_RC32M_Msk) {
+        CRG_TOP->CLK_SWITCH2XTAL_REG = CRG_TOP_CLK_SWITCH2XTAL_REG_SWITCH2XTAL_Msk;
+    } else {
+        CRG_TOP->CLK_CTRL_REG &= ~CRG_TOP_CLK_CTRL_REG_SYS_CLK_SEL_Msk;
+    }
+
+    while (!(CRG_TOP->CLK_CTRL_REG & CRG_TOP_CLK_CTRL_REG_RUNNING_AT_XTAL32M_Msk));
+
+    SystemCoreClock = XTAL32M_FREQ;
+}
+
+void
+da1469x_clock_sys_xtal32m_wait_to_settle(void)
+{
+    uint32_t primask;
+
+    primask = DA1469X_IRQ_DISABLE();
+    while (!da1469x_clock_is_xtal32m_settled()) {
+        __WFE();
+        __SEV();
+        __WFE();
+    }
+    DA1469X_IRQ_ENABLE(primask);
+}
+
+void
+da1469x_clock_sys_xtal32m_switch_safe(void)
+{
+    da1469x_clock_sys_xtal32m_wait_to_settle();
+
+    da1469x_clock_sys_xtal32m_switch();
+}
+
+void
+da1469x_clock_sys_rc32m_disable(void)
+{
+    CRG_TOP->CLK_RC32M_REG &= ~CRG_TOP_CLK_RC32M_REG_RC32M_ENABLE_Msk;
+}
+
+void
+da1469x_clock_lp_xtal32k_enable(void)
+{
+    CRG_TOP->CLK_XTAL32K_REG |= CRG_TOP_CLK_XTAL32K_REG_XTAL32K_ENABLE_Msk;
+}
+
+void
+da1469x_clock_lp_xtal32k_switch(void)
+{
+    CRG_TOP->CLK_CTRL_REG = (CRG_TOP->CLK_CTRL_REG &
+                             ~CRG_TOP_CLK_CTRL_REG_LP_CLK_SEL_Msk) |
+                            (2 << CRG_TOP_CLK_CTRL_REG_LP_CLK_SEL_Pos);
+    /* If system is running on LP clock update SystemCoreClock */
+    if (CRG_TOP->CLK_CTRL_REG & CRG_TOP_CLK_CTRL_REG_RUNNING_AT_LP_CLK_Msk) {
+        SystemCoreClock = XTAL32K_FREQ;
+    }
+}
+
+void
+da1469x_clock_lp_rcx_enable(void)
+{
+    CRG_TOP->CLK_RCX_REG  |= CRG_TOP_CLK_RCX_REG_RCX_ENABLE_Msk;
+}
+
+void
+da1469x_clock_lp_rcx_switch(void)
+{
+    CRG_TOP->CLK_CTRL_REG = (CRG_TOP->CLK_CTRL_REG &
+                             ~CRG_TOP_CLK_CTRL_REG_LP_CLK_SEL_Msk) |
+                            (1 << CRG_TOP_CLK_CTRL_REG_LP_CLK_SEL_Pos);
+
+    /* If system is running on LP clock update SystemCoreClock */
+    if (CRG_TOP->CLK_CTRL_REG & CRG_TOP_CLK_CTRL_REG_RUNNING_AT_LP_CLK_Msk) {
+        SystemCoreClock = g_mcu_clock_rcx_freq;
+    }
+}
+
+/**
+ * Measure clock frequency
+ *
+ * @param clock_sel - clock to measure
+ *                  0 - RC32K
+ *                  1 - RC32M
+ *                  2 - XTAL32K
+ *                  3 - RCX
+ *                  4 - RCOSC
+ * @param ref_cnt - number of cycles used for measurement.
+ * @return  clock frequency
+ */
+static uint32_t
+da1469x_clock_calibrate(uint8_t clock_sel, uint16_t ref_cnt)
+{
+    uint32_t ref_val;
+
+    da1469x_pd_acquire(MCU_PD_DOMAIN_PER);
+
+    assert(CRG_TOP->CLK_CTRL_REG & CRG_TOP_CLK_CTRL_REG_RUNNING_AT_XTAL32M_Msk);
+    assert(!(ANAMISC_BIF->CLK_REF_SEL_REG & ANAMISC_BIF_CLK_REF_SEL_REG_REF_CAL_START_Msk));
+
+    ANAMISC_BIF->CLK_REF_CNT_REG = ref_cnt;
+    ANAMISC_BIF->CLK_REF_SEL_REG = (clock_sel << ANAMISC_BIF_CLK_REF_SEL_REG_REF_CLK_SEL_Pos) |
+                                   ANAMISC_BIF_CLK_REF_SEL_REG_REF_CAL_START_Msk;
+
+    while (ANAMISC_BIF->CLK_REF_SEL_REG & ANAMISC_BIF_CLK_REF_SEL_REG_REF_CAL_START_Msk);
+
+    ref_val = ANAMISC_BIF->CLK_REF_VAL_REG;
+
+    da1469x_pd_release(MCU_PD_DOMAIN_PER);
+
+    return 32000000 * ref_cnt / ref_val;
+}
+
+void
+da1469x_clock_lp_rcx_calibrate(void)
+{
+    g_mcu_clock_rcx_freq = da1469x_clock_calibrate(3, MCU_RCX_CAL_REF_CNT);
+}
+
+void
+da1469x_clock_lp_rc32k_calibrate(void)
+{
+    g_mcu_clock_rc32k_freq = da1469x_clock_calibrate(0, 100);
+}
+
+void
+da1469x_clock_lp_rc32m_calibrate(void)
+{
+    g_mcu_clock_rc32m_freq = da1469x_clock_calibrate(1, 100);
+}
+
+uint32_t
+da1469x_clock_lp_rcx_freq_get(void)
+{
+    assert(g_mcu_clock_rcx_freq);
+
+    return g_mcu_clock_rcx_freq;
+}
+
+uint32_t
+da1469x_clock_lp_rc32k_freq_get(void)
+{
+    assert(g_mcu_clock_rc32k_freq);
+
+    return g_mcu_clock_rc32k_freq;
+}
+
+uint32_t
+da1469x_clock_lp_rc32m_freq_get(void)
+{
+    assert(g_mcu_clock_rc32m_freq);
+
+    return g_mcu_clock_rc32m_freq;
+}
+
+void
+da1469x_clock_lp_rcx_disable(void)
+{
+    CRG_TOP->CLK_RCX_REG &= ~CRG_TOP_CLK_RCX_REG_RCX_ENABLE_Msk;
+}
+
+static void
+da1469x_delay_us(uint32_t delay_us)
+{
+    /*
+     * SysTick runs on ~32 MHz clock while PLL is not started.
+     * so multiplying by 32 to convert from us to SysTicks.
+     */
+    SysTick->LOAD = delay_us * 32;
+    SysTick->VAL = 0UL;
+    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_ENABLE_Msk;
+    while (0 == (SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk));
+    SysTick->CTRL = 0;
+}
+
+/**
+ * Enable PLL96
+ */
+void
+da1469x_clock_sys_pll_enable(void)
+{
+    /* Start PLL LDO if not done yet */
+    if ((CRG_XTAL->PLL_SYS_STATUS_REG & CRG_XTAL_PLL_SYS_STATUS_REG_LDO_PLL_OK_Msk) == 0) {
+        CRG_XTAL->PLL_SYS_CTRL1_REG |= CRG_XTAL_PLL_SYS_CTRL1_REG_LDO_PLL_ENABLE_Msk;
+        /* Wait for XTAL LDO to settle */
+        da1469x_delay_us(20);
+    }
+    if ((CRG_XTAL->PLL_SYS_STATUS_REG & CRG_XTAL_PLL_SYS_STATUS_REG_PLL_LOCK_FINE_Msk) == 0) {
+        /* Enables DXTAL for the system PLL */
+        CRG_XTAL->XTAL32M_CTRL0_REG |= CRG_XTAL_XTAL32M_CTRL0_REG_XTAL32M_DXTAL_SYSPLL_ENABLE_Msk;
+        /* Use internal VCO current setting to enable precharge */
+        CRG_XTAL->PLL_SYS_CTRL1_REG |= CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_SEL_MIN_CUR_INT_Msk;
+        /* Enable precharge */
+        CRG_XTAL->PLL_SYS_CTRL2_REG |= CRG_XTAL_PLL_SYS_CTRL2_REG_PLL_RECALIB_Msk;
+        /* Start the SYSPLL */
+        CRG_XTAL->PLL_SYS_CTRL1_REG |= CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_EN_Msk;
+        /* Precharge loopfilter (Vtune) */
+        da1469x_delay_us(10);
+        /* Disable precharge */
+        CRG_XTAL->PLL_SYS_CTRL2_REG &= ~CRG_XTAL_PLL_SYS_CTRL2_REG_PLL_RECALIB_Msk;
+        /* Extra wait time */
+        da1469x_delay_us(5);
+        /* Take external VCO current setting */
+        CRG_XTAL->PLL_SYS_CTRL1_REG &= ~CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_SEL_MIN_CUR_INT_Msk;
+    }
+}
+
+void
+da1469x_clock_sys_pll_disable(void)
+{
+    while (CRG_TOP->CLK_CTRL_REG & CRG_TOP_CLK_CTRL_REG_RUNNING_AT_PLL96M_Msk) {
+        CRG_TOP->CLK_SWITCH2XTAL_REG = CRG_TOP_CLK_SWITCH2XTAL_REG_SWITCH2XTAL_Msk;
+
+        SystemCoreClock = XTAL32M_FREQ;
+    }
+
+    CRG_XTAL->PLL_SYS_CTRL1_REG &= ~(CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_EN_Msk |
+                                     CRG_XTAL_PLL_SYS_CTRL1_REG_LDO_PLL_ENABLE_Msk);
+}
+
+void
+da1469x_clock_pll_wait_to_lock(void)
+{
+    uint32_t primask;
+
+    primask = DA1469X_IRQ_DISABLE();
+
+    NVIC_ClearPendingIRQ(PLL_LOCK_IRQn);
+
+    if (!da1469x_clock_is_pll_locked()) {
+        NVIC_EnableIRQ(PLL_LOCK_IRQn);
+        while (!NVIC_GetPendingIRQ(PLL_LOCK_IRQn)) {
+            __WFI();
+        }
+        NVIC_DisableIRQ(PLL_LOCK_IRQn);
+    }
+
+    DA1469X_IRQ_ENABLE(primask);
+}
+
+void
+da1469x_clock_sys_pll_switch(void)
+{
+    /* CLK_SEL_Msk == 3 means PLL */
+    CRG_TOP->CLK_CTRL_REG |= CRG_TOP_CLK_CTRL_REG_SYS_CLK_SEL_Msk;
+
+    while (!(CRG_TOP->CLK_CTRL_REG & CRG_TOP_CLK_CTRL_REG_RUNNING_AT_PLL96M_Msk));
+
+    SystemCoreClock = PLL_FREQ;
+}

--- a/smartbond/da1469x_hal/da1469x_clock.h
+++ b/smartbond/da1469x_hal/da1469x_clock.h
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __DA1469X_CLOCK_H_
+#define __DA1469X_CLOCK_H_
+
+#include <stdint.h>
+#include <da1469x_config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize XTAL32M
+ */
+void da1469x_clock_sys_xtal32m_init(void);
+
+/**
+ * Enable XTAL32M
+ */
+void da1469x_clock_sys_xtal32m_enable(void);
+
+/**
+ * Wait for XTAL32M to settle
+ */
+void da1469x_clock_sys_xtal32m_wait_to_settle(void);
+
+/**
+ * Switch sys_clk to XTAL32M
+ *
+ * Caller shall ensure that XTAL32M is already settled.
+ */
+void da1469x_clock_sys_xtal32m_switch(void);
+
+/**
+ * Switch sys_clk to XTAL32M
+ *
+ * Waits for XTAL32M to settle before switching.
+ */
+void da1469x_clock_sys_xtal32m_switch_safe(void);
+
+/**
+ * Disable RC32M
+ */
+void da1469x_clock_sys_rc32m_disable(void);
+
+/**
+ * Enable XTAL32K
+ */
+void da1469x_clock_lp_xtal32k_enable(void);
+
+/**
+ * Switch lp_clk to XTAL32K
+ *
+ * Caller shall ensure XTAL32K is already settled.
+ */
+void da1469x_clock_lp_xtal32k_switch(void);
+
+/**
+ * Enable RCX
+ */
+void da1469x_clock_lp_rcx_enable(void);
+
+/**
+ * Switch lp_clk to RCX
+ *
+ * Caller shall ensure RCX is already settled.
+ */
+void da1469x_clock_lp_rcx_switch(void);
+
+/**
+ * Calibrate RCX
+ */
+void da1469x_clock_lp_rcx_calibrate(void);
+
+/**
+ * Calibrate RC32K
+ */
+void da1469x_clock_lp_rc32k_calibrate(void);
+
+/**
+ * Calibrate RC32M
+ */
+void da1469x_clock_lp_rc32m_calibrate(void);
+
+/**
+ * Get calibrated (measured) RCX frequency
+ */
+uint32_t da1469x_clock_lp_rcx_freq_get(void);
+
+/**
+ * Get calibrated (measured) RC32K frequency
+ */
+uint32_t da1469x_clock_lp_rc32k_freq_get(void);
+
+/**
+ * Get calibrated (measured) RC32M frequency
+ */
+uint32_t da1469x_clock_lp_rc32m_freq_get(void);
+
+/**
+ * Disable RCX
+ */
+void da1469x_clock_lp_rcx_disable(void);
+
+/**
+ * Enable AMBA clock(s)
+ *
+ * @param mask
+ */
+static inline void
+da1469x_clock_amba_enable(uint32_t mask)
+{
+    uint32_t primask;
+
+    primask = DA1469X_IRQ_DISABLE();
+    CRG_TOP->CLK_AMBA_REG |= mask;
+    DA1469X_IRQ_ENABLE(primask);
+}
+
+/**
+ * Disable AMBA clock(s)
+ *
+ * @param uint32_t mask
+ */
+static inline void
+da1469x_clock_amba_disable(uint32_t mask)
+{
+    uint32_t primask;
+
+    primask = DA1469X_IRQ_DISABLE();
+    CRG_TOP->CLK_AMBA_REG &= ~mask;
+    DA1469X_IRQ_ENABLE(primask);
+}
+
+/**
+ * Enable PLL96
+ */
+void da1469x_clock_sys_pll_enable(void);
+
+/**
+ * Disable PLL96
+ *
+ * If PLL was used as SYS_CLOCK switches to XTAL32M.
+ */
+void da1469x_clock_sys_pll_disable(void);
+
+/**
+ * Checks whether PLL96 is locked and can be use as system clock or USB clock
+ *
+ * @return 0 if PLL is off, non-0 it its running
+ */
+static inline int
+da1469x_clock_is_pll_locked(void)
+{
+    return 0 != (CRG_XTAL->PLL_SYS_STATUS_REG & CRG_XTAL_PLL_SYS_STATUS_REG_PLL_LOCK_FINE_Msk);
+}
+
+/**
+ * Waits for PLL96 to lock.
+ */
+void da1469x_clock_pll_wait_to_lock(void);
+
+/**
+ * Switches system clock to PLL96
+ *
+ * Caller shall ensure that PLL is already locked.
+ */
+void da1469x_clock_sys_pll_switch(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_DA1469X_CLOCK_H_ */

--- a/smartbond/da1469x_hal/da1469x_config.h
+++ b/smartbond/da1469x_hal/da1469x_config.h
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __DA1469X_CONFIG_H_
+#define __DA1469X_CONFIG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/irq.h>
+
+#define MCU_OTPM_BASE 			(0x30080000UL)
+#define MCU_OTPM_SIZE 			(4096)
+#define MCU_OTPM_CS_OFFSET		(0x0c00)
+#define MCU_OTPM_CS_LENGTH		(0x0400)
+
+#define MCU_TRIMV_GROUP_ID_MAX		(18)
+
+#define MCU_RCX_CAL_REF_CNT		(100)
+
+#define DA1469X_IRQ_DISABLE()		irq_lock()
+#define DA1469X_IRQ_ENABLE(_key)	irq_unlock(_key)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __DA1469X_CONFIG_H_ */

--- a/smartbond/da1469x_hal/da1469x_otp.c
+++ b/smartbond/da1469x_hal/da1469x_otp.c
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#include <assert.h>
+#include <DA1469xAB.h>
+#include <da1469x_config.h>
+#include <da1469x_otp.h>
+
+static inline void
+da1469x_clock_amba_enable(uint32_t mask)
+{
+    uint32_t primask;
+
+    primask = DA1469X_IRQ_DISABLE();
+    CRG_TOP->CLK_AMBA_REG |= mask;
+    DA1469X_IRQ_ENABLE(primask);
+}
+
+static inline void
+da1469x_clock_amba_disable(uint32_t mask)
+{
+    uint32_t primask;
+
+    primask = DA1469X_IRQ_DISABLE();
+    CRG_TOP->CLK_AMBA_REG &= ~mask;
+    DA1469X_IRQ_ENABLE(primask);
+}
+
+int
+da1469x_otp_read(uint32_t offset, void *dst, uint32_t num_bytes)
+{
+    uint32_t *src_addr = (uint32_t *)(MCU_OTPM_BASE + offset);
+    uint32_t *dst_addr = dst;
+
+    if (offset >= MCU_OTPM_SIZE || (offset + num_bytes) > MCU_OTPM_SIZE) {
+       return OTP_ERR_INVALID_ADDRESS;
+    }
+
+    if (num_bytes & 0x3) {
+       return OTP_ERR_INVALID_SIZE_ALIGNMENT;
+    }
+
+    /* Enable OTP clock and set mode to standby */
+    da1469x_clock_amba_enable(CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk);
+
+    da1469x_otp_set_mode(OTPC_MODE_READ);
+
+    for (; num_bytes; dst_addr++, src_addr++, num_bytes -= 4) {
+        *dst_addr = *src_addr;
+    }
+
+    da1469x_otp_set_mode(OTPC_MODE_DSTBY);
+
+    /* Disable OTP clock */
+    da1469x_clock_amba_disable(CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk);
+    return 0;
+}
+
+int
+da1469x_otp_write(uint32_t offset, const void *src, uint32_t num_bytes)
+{
+    uint32_t *dst_addr = (uint32_t *)(MCU_OTPM_BASE + offset);
+    const uint32_t *src_addr = src;
+    int ret = 0;
+
+    if (offset >= MCU_OTPM_SIZE || (offset + num_bytes) > MCU_OTPM_SIZE) {
+       return OTP_ERR_INVALID_ADDRESS;
+    }
+
+    if (num_bytes & 0x3) {
+       return OTP_ERR_INVALID_SIZE_ALIGNMENT;
+    }
+
+    /* Enable OTP clock and set mode to standby */
+    da1469x_clock_amba_enable(CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk);
+
+    do {
+        da1469x_otp_set_mode(OTPC_MODE_PROG);
+
+        /* wait for programming to go idle and data buffer to be empty */
+        while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_PRDY_Msk));
+        while (!(OTPC->OTPC_STAT_REG &
+                 OTPC_OTPC_STAT_REG_OTPC_STAT_PBUF_EMPTY_Msk));
+
+        /* fill data buffer with a word and trigger via the PADDR reg */
+        OTPC->OTPC_PWORD_REG = *src_addr;
+        OTPC->OTPC_PADDR_REG = ((uint32_t)dst_addr >> 2) &
+                               OTPC_OTPC_PADDR_REG_OTPC_PADDR_Msk;
+
+        while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_PRDY_Msk));
+
+        /* set mode to verify */
+        da1469x_otp_set_mode(OTPC_MODE_PVFY);
+
+        /* read data and compare to source */
+        if (*dst_addr != *src_addr) {
+            ret = OTP_ERR_PROGRAM_VERIFY_FAILED;
+            goto fail_write;
+        }
+
+        da1469x_otp_set_mode(OTPC_MODE_STBY);
+        num_bytes -= 4;
+        src_addr++;
+        dst_addr++;
+    } while (num_bytes);
+
+fail_write:
+
+    /* Disable OTP clock */
+    da1469x_clock_amba_disable(CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk);
+
+    return ret;
+}
+
+void
+da1469x_otp_init(void)
+{
+    /* Enable OTP clock and set mode to standby */
+    da1469x_clock_amba_enable(CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk);
+
+    da1469x_otp_set_mode(OTPC_MODE_STBY);
+
+    /* set clk timing */
+    switch (SystemCoreClock) {
+    default:
+        /* Unsupported sys_clk value, fall-through to default 32MHz */
+        assert(0);
+    case 32000000:
+        OTPC->OTPC_TIM1_REG = 0x0999101f;
+        break;
+    case 96000000:
+        OTPC->OTPC_TIM1_REG = 0x0999515f;
+        break;
+    }
+
+    OTPC->OTPC_TIM2_REG = 0xa4040409;
+
+    /* Disable OTP clock */
+    da1469x_clock_amba_disable(CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk);
+}

--- a/smartbond/da1469x_hal/da1469x_otp.h
+++ b/smartbond/da1469x_hal/da1469x_otp.h
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __DA1469X_OTP_H_
+#define __DA1469X_OTP_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OTP_ERR_INVALID_SIZE_ALIGNMENT -1
+#define OTP_ERR_INVALID_ADDRESS -2
+#define OTP_ERR_PROGRAM_VERIFY_FAILED -3
+
+#define OTP_SEGMENT_CONFIG          0xc00
+#define OTP_SEGMENT_QSPI_FW_KEYS    0xb00
+#define OTP_SEGMENT_USER_DATA_KEYS  0xa00
+#define OTP_SEGMENT_SIGNATURE_KEYS  0x8c0
+#define OTP_SEGMENT_USER_DATA_LEN   0x100
+
+#define OTP_ADDRESS_RANGE_USER_DATA_KEYS(x) \
+    (((uint32_t)(x) >= (uint32_t)MCU_OTPM_BASE + OTP_SEGMENT_USER_DATA_KEYS) && \
+     ((uint32_t)(x) < (uint32_t)MCU_OTPM_BASE + OTP_SEGMENT_USER_DATA_KEYS + OTP_SEGMENT_USER_DATA_LEN))
+
+enum otpc_mode_val {
+    OTPC_MODE_PDOWN = 0,
+    OTPC_MODE_DSTBY,
+    OTPC_MODE_STBY,
+    OTPC_MODE_READ,
+    OTPC_MODE_PROG,
+    OTPC_MODE_PVFY,
+    OTPC_MODE_RINI,
+};
+
+static inline void
+da1469x_otp_set_mode(enum otpc_mode_val mode)
+{
+    OTPC->OTPC_MODE_REG = (OTPC->OTPC_MODE_REG &
+                           ~OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Msk) |
+                          (mode << OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Pos);
+    while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_MRDY_Msk));
+}
+
+int da1469x_otp_write(uint32_t address, const void *src,
+                             uint32_t num_bytes);
+
+int da1469x_otp_read(uint32_t address, void *dst, uint32_t num_bytes);
+
+void da1469x_otp_init(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_DA1469X_OTP_H_ */

--- a/smartbond/da1469x_hal/da1469x_pd.c
+++ b/smartbond/da1469x_hal/da1469x_pd.c
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <DA1469xAB.h>
+#include <da1469x_config.h>
+#include <da1469x_pd.h>
+#include <da1469x_trimv.h>
+
+/* This shall be defined for each MCU separately */
+extern void da1469x_pd_apply_preferred(uint8_t pd);
+
+#define PD_COUNT    (sizeof(g_da1469x_pd_desc) / sizeof(g_da1469x_pd_desc[0]))
+
+struct da1469x_pd_desc {
+    uint8_t pmu_sleep_bit;
+    uint8_t stat_down_bit; /* up is +1 */
+};
+
+struct da1469x_pd_data {
+    uint8_t refcnt;
+    uint8_t trimv_count;
+    uint32_t *trimv_words;
+};
+
+/* Only include controllable power domains here */
+static const struct da1469x_pd_desc g_da1469x_pd_desc[] = {
+    [MCU_PD_DOMAIN_SYS] = { CRG_TOP_PMU_CTRL_REG_SYS_SLEEP_Pos,
+                            CRG_TOP_SYS_STAT_REG_SYS_IS_DOWN_Pos },
+    [MCU_PD_DOMAIN_PER] = { CRG_TOP_PMU_CTRL_REG_PERIPH_SLEEP_Pos,
+                            CRG_TOP_SYS_STAT_REG_PER_IS_DOWN_Pos },
+    [MCU_PD_DOMAIN_TIM] = { CRG_TOP_PMU_CTRL_REG_TIM_SLEEP_Pos,
+                            CRG_TOP_SYS_STAT_REG_TIM_IS_DOWN_Pos },
+    [MCU_PD_DOMAIN_COM] = { CRG_TOP_PMU_CTRL_REG_COM_SLEEP_Pos,
+                            CRG_TOP_SYS_STAT_REG_COM_IS_DOWN_Pos},
+};
+
+static struct da1469x_pd_data g_da1469x_pd_data[PD_COUNT];
+
+static void
+da1469x_pd_load_trimv(uint8_t pd, uint8_t group)
+{
+    struct da1469x_pd_data *pdd;
+
+    assert(pd < PD_COUNT);
+
+    pdd = &g_da1469x_pd_data[pd];
+    pdd->trimv_count = da1469x_trimv_group_num_words_get(group);
+    if (pdd->trimv_count == 0) {
+        return;
+    }
+
+    pdd->trimv_words = calloc(pdd->trimv_count, 4);
+    if (!pdd->trimv_words) {
+        pdd->trimv_count = 0;
+        assert(0);
+        return;
+    }
+
+    pdd->trimv_count = da1469x_trimv_group_read(group, pdd->trimv_words,
+                                                pdd->trimv_count);
+    pdd->trimv_count /= 2;
+}
+
+static void
+da1469x_pd_apply_trimv(uint8_t pd)
+{
+    struct da1469x_pd_data *pdd;
+    volatile uint32_t *reg;
+    uint32_t val;
+    int idx;
+
+    assert(pd < PD_COUNT);
+
+    pdd = &g_da1469x_pd_data[pd];
+    if (pdd->trimv_count == 0) {
+        return;
+    }
+
+    for (idx = 0; idx < pdd->trimv_count; idx++) {
+        reg = (uint32_t *) pdd->trimv_words[idx * 2];
+        val = pdd->trimv_words[idx * 2 + 1];
+        *reg = val;
+    }
+}
+
+int
+da1469x_pd_init(void)
+{
+    /*
+     * Apply now for always-on domain which, as name suggests, is always on so
+     * need to do this only once.
+     */
+    da1469x_pd_apply_preferred(MCU_PD_DOMAIN_AON);
+
+    da1469x_pd_load_trimv(MCU_PD_DOMAIN_SYS, 1);
+    da1469x_pd_load_trimv(MCU_PD_DOMAIN_COM, 2);
+    da1469x_pd_load_trimv(MCU_PD_DOMAIN_TIM, 4);
+    da1469x_pd_load_trimv(MCU_PD_DOMAIN_PER, 5);
+
+    return 0;
+}
+
+int
+da1469x_pd_get_ref_cnt(uint8_t pd)
+{
+    struct da1469x_pd_data *pdd;
+
+    assert(pd < PD_COUNT);
+
+    pdd = &g_da1469x_pd_data[pd];
+
+    return pdd->refcnt;
+}
+
+static int
+da1469x_pd_acquire_internal(uint8_t pd, bool load)
+{
+    struct da1469x_pd_data *pdd;
+    uint32_t primask;
+    uint32_t bitmask;
+    int ret = 0;
+
+    assert(pd < PD_COUNT);
+
+    pdd = &g_da1469x_pd_data[pd];
+
+    primask = DA1469X_IRQ_DISABLE();
+
+    assert(pdd->refcnt < UINT8_MAX);
+
+    if (pdd->refcnt++ == 0) {
+        bitmask = 1 << g_da1469x_pd_desc[pd].pmu_sleep_bit;
+        CRG_TOP->PMU_CTRL_REG &= ~bitmask;
+
+        bitmask = 1 << (g_da1469x_pd_desc[pd].stat_down_bit + 1);
+        while ((CRG_TOP->SYS_STAT_REG & bitmask) == 0);
+
+        if (load) {
+            da1469x_pd_apply_trimv(pd);
+            da1469x_pd_apply_preferred(pd);
+        }
+
+        ret = 1;
+    }
+
+    DA1469X_IRQ_ENABLE(primask);
+
+    return ret;
+}
+
+int
+da1469x_pd_acquire(uint8_t pd)
+{
+    return da1469x_pd_acquire_internal(pd, true);
+}
+
+int
+da1469x_pd_acquire_noconf(uint8_t pd)
+{
+    return da1469x_pd_acquire_internal(pd, false);
+}
+
+static int
+da1469x_pd_release_internal(uint8_t pd, bool wait)
+{
+    struct da1469x_pd_data *pdd;
+    uint32_t primask;
+    uint32_t bitmask;
+    int ret = 0;
+
+    assert(pd < PD_COUNT);
+
+    pdd = &g_da1469x_pd_data[pd];
+
+    primask = DA1469X_IRQ_DISABLE();
+
+    assert(pdd->refcnt > 0);
+
+    if (--pdd->refcnt == 0) {
+        bitmask = 1 << g_da1469x_pd_desc[pd].pmu_sleep_bit;
+        CRG_TOP->PMU_CTRL_REG |= bitmask;
+
+        if (wait) {
+            bitmask = 1 << g_da1469x_pd_desc[pd].stat_down_bit;
+            while ((CRG_TOP->SYS_STAT_REG & bitmask) == 0);
+        }
+
+        ret = 1;
+    }
+
+    DA1469X_IRQ_ENABLE(primask);;
+
+    return ret;
+}
+
+int
+da1469x_pd_release(uint8_t pd)
+{
+    return da1469x_pd_release_internal(pd, true);
+}
+
+int
+da1469x_pd_release_nowait(uint8_t pd)
+{
+    return da1469x_pd_release_internal(pd, false);
+}

--- a/smartbond/da1469x_hal/da1469x_pd.h
+++ b/smartbond/da1469x_hal/da1469x_pd.h
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __DA1469X_PD_H_
+#define __DA1469X_PD_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Note: Make sure that controllable (i.e. those that can be acquired/released)
+ * power domains are listed before other domains. This allows to save space in
+ * control structures since non-controllable domains are not included there.
+ */
+
+/* Available (controllable) power domains */
+#define MCU_PD_DOMAIN_SYS           0
+#define MCU_PD_DOMAIN_PER           1
+#define MCU_PD_DOMAIN_TIM           2
+#define MCU_PD_DOMAIN_COM           3
+/* Remaining (non-controllable) power domains */
+#define MCU_PD_DOMAIN_AON           4
+#define MCU_PD_DOMAIN_RAD           5
+
+int da1469x_pd_init(void);
+int da1469x_pd_get_ref_cnt(uint8_t pd);
+int da1469x_pd_acquire(uint8_t pd);
+int da1469x_pd_acquire_noconf(uint8_t pd);
+int da1469x_pd_release(uint8_t pd);
+int da1469x_pd_release_nowait(uint8_t pd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_DA1469X_PD_H_ */

--- a/smartbond/da1469x_hal/da1469x_pdc.c
+++ b/smartbond/da1469x_hal/da1469x_pdc.c
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <DA1469xAB.h>
+#include <da1469x_config.h>
+#include <da1469x_pdc.h>
+
+int
+da1469x_pdc_add(uint8_t source, uint8_t master, uint8_t en)
+{
+    int idx;
+    uint8_t select;
+
+    select = source >> 5;
+    source &= 0x1f;
+
+    for (idx = 0; idx < MCU_PDC_CTRL_REGS_COUNT; idx++) {
+        if (!(MCU_PDC_CTRL_REGS(idx) & PDC_PDC_CTRL0_REG_PDC_MASTER_Msk)) {
+            MCU_PDC_CTRL_REGS(idx) = (select << PDC_PDC_CTRL0_REG_TRIG_SELECT_Pos) |
+                                 (source << PDC_PDC_CTRL0_REG_TRIG_ID_Pos) |
+                                 (master << PDC_PDC_CTRL0_REG_PDC_MASTER_Pos) |
+                                 (en << PDC_PDC_CTRL0_REG_EN_XTAL_Pos);
+            return idx;
+        }
+    }
+
+    assert(0);
+
+    return -ENOENT;
+}
+
+void
+da1469x_pdc_del(int idx)
+{
+    assert((idx >= 0) && (idx < MCU_PDC_CTRL_REGS_COUNT));
+    assert(MCU_PDC_CTRL_REGS(idx) & PDC_PDC_CTRL0_REG_PDC_MASTER_Msk);
+
+    MCU_PDC_CTRL_REGS(idx) &= ~PDC_PDC_CTRL0_REG_PDC_MASTER_Msk;
+}
+
+int
+da1469x_pdc_find(int trigger, int master, uint8_t en)
+{
+    int idx;
+    uint32_t mask;
+    uint32_t value;
+
+    mask = en << PDC_PDC_CTRL0_REG_EN_XTAL_Pos;
+    value = en << PDC_PDC_CTRL0_REG_EN_XTAL_Pos;
+    if (trigger >= 0) {
+        mask |= PDC_PDC_CTRL0_REG_TRIG_SELECT_Msk | PDC_PDC_CTRL0_REG_TRIG_ID_Msk;
+        value |= ((trigger >> 5) << PDC_PDC_CTRL0_REG_TRIG_SELECT_Pos) |
+                 ((trigger & 0x1f) << PDC_PDC_CTRL0_REG_TRIG_ID_Pos);
+    }
+    if (master > 0) {
+        mask |= PDC_PDC_CTRL0_REG_PDC_MASTER_Msk;
+        value |= master << PDC_PDC_CTRL0_REG_PDC_MASTER_Pos;
+    }
+    assert(mask);
+
+    for (idx = 0; idx < MCU_PDC_CTRL_REGS_COUNT; idx++) {
+        if ((MCU_PDC_CTRL_REGS(idx) & mask) == value) {
+            return idx;
+        }
+    }
+
+    return -ENOENT;
+}
+
+void
+da1469x_pdc_reset(void)
+{
+    int idx;
+
+    for (idx = 0; idx < MCU_PDC_CTRL_REGS_COUNT; idx++) {
+        MCU_PDC_CTRL_REGS(idx) = 0;
+        da1469x_pdc_ack(idx);
+    }
+}
+
+void
+da1469x_pdc_ack_all_m33(void)
+{
+    int idx;
+
+    for (idx = 0; idx < MCU_PDC_CTRL_REGS_COUNT; idx++) {
+        if (PDC->PDC_PENDING_CM33_REG & (1 << idx)) {
+            da1469x_pdc_ack(idx);
+        }
+    }
+}

--- a/smartbond/da1469x_hal/da1469x_pdc.h
+++ b/smartbond/da1469x_hal/da1469x_pdc.h
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __DA1469X_PDC_H_
+#define __DA1469X_PDC_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MCU_PDC_CTRL_REGS(_i)       (((__IO uint32_t*)&PDC->PDC_CTRL0_REG)[_i])
+#define MCU_PDC_CTRL_REGS_COUNT     16
+
+/* PDC trigger can be either a GPIO number or one of following values */
+#define MCU_PDC_TRIGGER_TIMER               (0x40 | 0)
+#define MCU_PDC_TRIGGER_TIMER2              (0x40 | 1)
+#define MCU_PDC_TRIGGER_TIMER3              (0x40 | 2)
+#define MCU_PDC_TRIGGER_TIMER4              (0x40 | 3)
+#define MCU_PDC_TRIGGER_RTC_ALARM           (0x40 | 4)
+#define MCU_PDC_TRIGGER_RTC_TIMER           (0x40 | 5)
+#define MCU_PDC_TRIGGER_MAC_TIMER           (0x40 | 6)
+#define MCU_PDC_TRIGGER_MOTOR_CONTROLLER    (0x40 | 7)
+#define MCU_PDC_TRIGGER_XTAL32M_READY       (0x40 | 8)
+#define MCU_PDC_TRIGGER_RFDIAG              (0x40 | 9)
+#define MCU_PDC_TRIGGER_COMBO               (0x40 | 10) /* VBUS, IO, JTAG, CMAC2SYS */
+#define MCU_PDC_TRIGGER_SNC                 (0x40 | 11)
+#define MCU_PDC_TRIGGER_SW_TRIGGER          (0x40 | 15)
+
+/* PDC master can be either of following values */
+#define MCU_PDC_MASTER_M33                  1
+#define MCU_PDC_MASTER_CMAC                 2
+#define MCU_PDC_MASTER_SNC                  3
+
+/* PDC enable bitmask can consist of following values */
+#define MCU_PDC_EN_NONE                     0x00
+#define MCU_PDC_EN_XTAL                     0x01
+#define MCU_PDC_EN_PD_TMR                   0x02
+#define MCU_PDC_EN_PD_PER                   0x04
+#define MCU_PDC_EN_PD_COM                   0x08
+
+/**
+ * Add entry to PDC lookup table
+ *
+ * This adds new entry to PDC lookup table. Unused entry index is selected
+ * automatically.
+ *
+ * @param trigger  Trigger source
+ * @param master   Master to wakeup
+ * @param en       Power domains to enable
+ *
+ * @return entry index, SYS_ENOENT if all lookup table entries are used
+ */
+int da1469x_pdc_add(uint8_t trigger, uint8_t master, uint8_t en);
+
+/**
+ * Delete entry from PDC lookup table
+ *
+ * This removed existing entry from PDC lookup table. It assumes requested
+ * entry is set.
+ *
+ * @param idx  Entry index
+ */
+void da1469x_pdc_del(int idx);
+
+/**
+ * Find entry in PDC lookup table matching given values
+ *
+ * Set either \p trigger or \p master to negative value to disable matching on
+ * that value.
+ * \p en matches at least specified power domains, more domains can be included
+ * in matched entry.
+ *
+ * @param trigger  Trigger to match
+ * @param master   Master to wakeup to match
+ * @param en       Required power domains to enable
+ *
+ * @return entry index on success, SYS_ENOENT if not found
+ */
+int da1469x_pdc_find(int trigger, int master, uint8_t en);
+
+/**
+ * Reset PDC lookup table
+ *
+ * This deletes all valid entried from LUT and acknowledges them in case some
+ * were pending.
+ */
+void da1469x_pdc_reset(void);
+
+/**
+ * Acknowledge pending PDC lookup table entry
+ *
+ * @param idx  Entry index
+ */
+static inline void
+da1469x_pdc_ack(int idx)
+{
+    PDC->PDC_ACKNOWLEDGE_REG = idx;
+}
+
+/**
+ * Set PDC lookup table entry as pending
+ *
+ * @param idx  Entry index
+ */
+static inline void
+da1469x_pdc_set(int idx)
+{
+    PDC->PDC_SET_PENDING_REG = idx;
+}
+
+/**
+ * Check if PDC lookup table entry is pending
+ *
+ * @param idx  Entry index
+ *
+ * @return true if entry is pending, false otherwise
+ */
+static inline bool
+da1469x_pdc_is_pending(int idx)
+{
+    return PDC->PDC_PENDING_REG & (1 << idx);
+}
+
+/**
+ * Acknowledge all pending entries on M33 core
+ */
+void da1469x_pdc_ack_all_m33(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __DA1469X_PDC_H_ */

--- a/smartbond/da1469x_hal/da1469x_trimv.c
+++ b/smartbond/da1469x_hal/da1469x_trimv.c
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <DA1469xAB.h>
+#include <da1469x_config.h>
+#include <da1469x_trimv.h>
+#include <da1469x_otp.h>
+
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+
+#define GROUP_ID_MAX            (MCU_TRIMV_GROUP_ID_MAX)
+
+#define CS_OFFSET               (MCU_OTPM_CS_OFFSET)
+#define CS_LENGTH               (MCU_OTPM_CS_LENGTH)
+
+#define CS_WORD_START           0xa5a5a5a5
+#define CS_WORD_END             0x00000000
+#define CS_WORD_INVALID         0xffffffff
+#define CS_WORD_TYPE_MASK       0xf0000000
+#define CS_WORD_TYPE_BOOTER     0x60000000
+#define CS_WORD_TYPE_TRIM       0x90000000
+
+struct da1469x_trimv_group {
+    uint8_t index;
+    uint8_t num_words;
+};
+
+static struct da1469x_trimv_group g_mcu_trimv_groups[GROUP_ID_MAX + 1];
+
+void
+da1469x_trimv_init_from_otp(void)
+{
+    uint32_t offset_start;
+    uint32_t offset_end;
+    uint32_t offset;
+    uint32_t ow;
+    uint8_t trimv_group;
+    uint8_t trimv_num_words;
+
+    /* Clear groups if anything was previously loaded */
+    memset(&g_mcu_trimv_groups, 0, sizeof(g_mcu_trimv_groups));
+
+    /* Start of configuration script */
+    offset_start = CS_OFFSET;
+    offset_end = CS_OFFSET + CS_LENGTH;
+    offset = offset_start;
+
+    da1469x_otp_read(offset, &ow, sizeof(ow));
+    if (ow != CS_WORD_START) {
+        return;
+    }
+
+    offset += 4;
+
+    while (offset < offset_end) {
+        da1469x_otp_read(offset, &ow, sizeof(ow));
+
+        offset += 4;
+
+        if ((ow == CS_WORD_END) || (ow == CS_WORD_INVALID)) {
+            /* End of CS or empty word */
+            break;
+        } else if ((ow & CS_WORD_TYPE_MASK) < CS_WORD_TYPE_BOOTER) {
+            /* This is a register+value configuration, skip one more word */
+            offset += 4;
+        } else if ((ow & CS_WORD_TYPE_MASK) == CS_WORD_TYPE_TRIM) {
+            trimv_num_words = (ow & 0x0000ff00) >> 8;
+            trimv_group = ow & 0x000000ff;
+
+            if (trimv_group <= GROUP_ID_MAX) {
+                /*
+                 * XXX not sure if each group can be present only once in OTP,
+                 *     but our implementation requires it for now and it works
+                 */
+                assert(g_mcu_trimv_groups[trimv_group].num_words == 0);
+
+                g_mcu_trimv_groups[trimv_group].index = (offset - offset_start) / 4;
+                g_mcu_trimv_groups[trimv_group].num_words = trimv_num_words;
+            }
+
+            offset += trimv_num_words * 4;
+        }
+    }
+}
+
+uint8_t
+da1469x_trimv_group_num_words_get(uint8_t group)
+{
+    struct da1469x_trimv_group *grp = &g_mcu_trimv_groups[group];
+
+    if (group > GROUP_ID_MAX) {
+        return 0;
+    }
+
+    return grp->num_words;
+}
+
+uint8_t
+da1469x_trimv_group_read(uint8_t group, uint32_t *buf, uint8_t num_words)
+{
+    struct da1469x_trimv_group *grp = &g_mcu_trimv_groups[group];
+    uint32_t offset;
+    int rc;
+
+    /* Silence warning if built without asserts */
+    (void)rc;
+
+    num_words = min(num_words, da1469x_trimv_group_num_words_get(group));
+
+    if (!num_words) {
+        return 0;
+    }
+
+    offset = CS_OFFSET + grp->index * 4;
+
+    rc = da1469x_otp_read(offset, buf, num_words * 4);
+    assert(rc == 0);
+
+    return num_words;
+}

--- a/smartbond/da1469x_hal/da1469x_trimv.h
+++ b/smartbond/da1469x_hal/da1469x_trimv.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __DA1469X_TRIMV_H_
+#define __DA1469X_TRIMV_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void da1469x_trimv_init_from_otp(void);
+
+uint8_t da1469x_trimv_group_num_words_get(uint8_t group);
+
+uint8_t da1469x_trimv_group_read(uint8_t group, uint32_t *buf, uint8_t length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __DA1469X_TRIMV_H_ */


### PR DESCRIPTION
This adds HAL files for some subsysems of DA1469x so drivers can reuse that code instead of accessing registers directly. These files are based on Apache Mynewt implementation.