### PR TITLE
hal: renesas: Fix assert condition in xtal32m switch

### DIFF
--- a/smartbond/da1469x_hal/da1469x_clock.c
+++ b/smartbond/da1469x_hal/da1469x_clock.c
@@ -235,7 +235,7 @@ void
 da1469x_clock_sys_xtal32m_switch(void)
 {
     if (CRG_TOP->CLK_CTRL_REG & CRG_TOP_CLK_CTRL_REG_RUNNING_AT_RC32M_Msk) {
-        assert(da1469x_clock_sys_xtal32m_switch_check_restrictions() != 0);
+        assert(da1469x_clock_sys_xtal32m_switch_check_restrictions() == 0);
 
         CRG_TOP->CLK_SWITCH2XTAL_REG = CRG_TOP_CLK_SWITCH2XTAL_REG_SWITCH2XTAL_Msk;
     } else {

--- a/smartbond/da1469x_hal/da1469x_pd.c
+++ b/smartbond/da1469x_hal/da1469x_pd.c
@@ -35,6 +35,9 @@ struct da1469x_pd_desc {
     uint8_t stat_down_bit; /* up is +1 */
 };
 
+static uint32_t trimv_words_buf[16];
+static uint32_t trimv_words_idx = 0;
+
 struct da1469x_pd_data {
     uint8_t refcnt;
     uint8_t trimv_count;
@@ -84,8 +87,10 @@ da1469x_pd_load_trimv(uint8_t pd, uint8_t group)
         return;
     }
 
-    pdd->trimv_words = calloc(pdd->trimv_count, 4);
-    if (!pdd->trimv_words) {
+    if (trimv_words_idx + pdd->trimv_count <= ARRAY_SIZE(trimv_words_buf)) {
+        pdd->trimv_words = &trimv_words_buf[trimv_words_idx];
+        trimv_words_idx += pdd->trimv_count;
+    } else {
         pdd->trimv_count = 0;
         assert(0);
         return;


### PR DESCRIPTION
- Condition was incorrect resulting in assertion failure.
- Dynamic memory allocation remove from pd ode. It was used in PRE_KERNEL_1 stage where heap is not available yet