### PR TITLE
 hal: renesas: Fix CMAC trng requests 

### DIFF
--- a/smartbond/cmac/rand.h
+++ b/smartbond/cmac/rand.h
@@ -40,6 +40,12 @@ void cmac_rand_set_isr_cb(cmac_rand_isr_cb_t cb);
 
 void cmac_rand_put(uint32_t word);
 
+static inline bool
+cmac_rand_needs_data(void)
+{
+    return (cmac_rand_is_active() && !cmac_rand_is_full());
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/smartbond/cmac/shm.c
+++ b/smartbond/cmac/shm.c
@@ -22,8 +22,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/random/rand32.h>
-
 #include <DA1469xAB.h>
 #include <da1469x_pdc.h>
 #include <da1469x_trimv.h>
@@ -76,8 +74,6 @@ static int8_t g_cmac_host_pdc_sys2cmac;
 /* PDC entry for waking up M33 */
 static int8_t g_cmac_host_pdc_cmac2sys;
 
-static void cmac_host_rand_chk_fill(void);
-
 void
 cmac_cmac2sys_isr(void)
 {
@@ -92,20 +88,9 @@ cmac_cmac2sys_isr(void)
         return;
     }
 
-    cmac_host_rand_chk_fill();
-}
-
-static void
-cmac_host_rand_chk_fill(void)
-{
-    uint32_t word;
-
-    while (cmac_rand_is_active() && !cmac_rand_is_full()) {
-        word = sys_rand32_get();
-        cmac_rand_fill(&word, 1);
+    if (cmac_rand_needs_data()) {
+        cmac_rng_req();
     }
-
-    cmac_signal();
 }
 
 static void

--- a/smartbond/cmac/shm.h
+++ b/smartbond/cmac/shm.h
@@ -129,6 +129,7 @@ struct cmac_shm {
 
 extern struct cmac_shm g_cmac_shm;
 extern void cmac_read_req(void);
+extern void cmac_rng_req(void);
 
 void cmac_cmac2sys_isr(void);
 


### PR DESCRIPTION
CMAC isr will now just call cmac_rng_req() to request host to provide
TRNG data instead of doing this in isr as this could result in a
deadlock due to TRNG isr not being called while we are still waiting
in CMAC isr.