### PR TITLE
smartbond/cmac: Do not use deprecated rand32 header

### DIFF
--- a/smartbond/cmac/shm.c
+++ b/smartbond/cmac/shm.c
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <DA1469xAB.h>
 #include <da1469x_pdc.h>


### PR DESCRIPTION
Do not use deprecated random/rand32 header