### PR TITLE
hal: renesas: Update PLL clock API

### DIFF
--- a/smartbond/da1469x_hal/da1469x_clock.h
+++ b/smartbond/da1469x_hal/da1469x_clock.h
@@ -177,10 +177,14 @@ da1469x_clock_is_pll_locked(void)
     return 0 != (CRG_XTAL->PLL_SYS_STATUS_REG & CRG_XTAL_PLL_SYS_STATUS_REG_PLL_LOCK_FINE_Msk);
 }
 
-/**
- * Waits for PLL96 to lock.
- */
-void da1469x_clock_pll_wait_to_lock(void);
+static inline bool
+da1469x_clock_sys_pll_is_enabled(void)
+{
+#define IS_PLL_ENABLED_BITFIELDS \
+    (CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_EN_Msk | CRG_XTAL_PLL_SYS_CTRL1_REG_LDO_PLL_ENABLE_Msk)
+
+    return ((CRG_XTAL->PLL_SYS_CTRL1_REG & IS_PLL_ENABLED_BITFIELDS) == IS_PLL_ENABLED_BITFIELDS);
+}
 
 /**
  * Switches system clock to PLL96
@@ -188,6 +192,19 @@ void da1469x_clock_pll_wait_to_lock(void);
  * Caller shall ensure that PLL is already locked.
  */
 void da1469x_clock_sys_pll_switch(void);
+
+/**
+ * Checks if a peripheral block is clocked by the DIV1 clock path which should
+ * reflect the main system clock. This API should be used before updating
+ * the main system clock and abort if it's deemed that a peripheral might be affected.
+ * This API can also be used before disabling PLL to check if USB is active. This
+ * is because the USB is normally clocked by PLL divided by 2 in order to produce
+ * the 48MHz required for the full speed mode (12Mbps).
+ *
+ * @return true if the DIV1 clock path is used by a peripheral block and/or USB is enabled
+ *         and clocked by PLL, false otherwise.
+ */
+bool da1469x_clock_check_device_div1_clock(void);
 
 #ifdef __cplusplus
 }

--- a/smartbond/da1469x_hal/da1469x_sleep.c
+++ b/smartbond/da1469x_hal/da1469x_sleep.c
@@ -90,7 +90,6 @@ int da1469x_sleep(void)
             }
             if (sys_clock_selection == 3 << CRG_TOP_CLK_CTRL_REG_SYS_CLK_SEL_Pos) {
                 da1469x_clock_sys_pll_enable();
-                da1469x_clock_pll_wait_to_lock();
                 da1469x_clock_sys_pll_switch();
             }
         }


### PR DESCRIPTION
This commit should deal with the following topics:

1. Fix the way we wait for the PLL to lock. Entering the WFI state should be replaced by __WFE as it might happen that PLL lock ISR is fired right after evaluating the PLL lock bit which should result in stucking in the WFI state (no other interrupts should be expected at that moment to wakeup the application core).
2. Remove the PLL wait to lock API as switching to PLL requires that PLL be locked. Waiting for PLL to lock will be done silently when switching to PLL is requested.
3. Introduce an API to check if PLL is enabled and an API that should be used to check if the DIV1 clock path is used by a peripheral. The latter should also be used to check if USB is active and clocked by PLL such that disabling PLL is not allowed.