### PR TITLE
hal: renesas: bsp: Allows custom implementation of option setting memory

### DIFF
--- a/drivers/ra/README
+++ b/drivers/ra/README
@@ -50,3 +50,7 @@ Patch List:
    * Remove the static definition in FLASH HP
    Impacted files:
       drivers/ra/fsp/src/r_flash_hp/r_flash_hp.c
+
+   * Allows custom implementation of option setting memory
+   Impacted files:
+      drivers/ra/fsp/src/bsp/mcu/all/bsp_rom_registers.c

--- a/drivers/ra/fsp/src/bsp/mcu/all/bsp_rom_registers.c
+++ b/drivers/ra/fsp/src/bsp/mcu/all/bsp_rom_registers.c
@@ -71,6 +71,7 @@ BSP_DONT_REMOVE static const uint32_t g_bsp_id_codes[] BSP_PLACE_IN_SECTION (BSP
 
  #if 33U != __CORTEX_M && 85U != __CORTEX_M // NOLINT(readability-magic-numbers)
 
+ #if !defined(CONFIG_SOC_OPTION_SETTING_MEMORY)
 /** ROM registers defined here. Some have masks to make sure reserved bits are set appropriately. */
 BSP_DONT_REMOVE static const uint32_t g_bsp_rom_registers[] BSP_PLACE_IN_SECTION (BSP_SECTION_ROM_REGISTERS) =
 {
@@ -92,6 +93,7 @@ BSP_DONT_REMOVE static const uint32_t g_bsp_rom_registers[] BSP_PLACE_IN_SECTION
     (uint32_t) BSP_ROM_REG_MPU_CONTROL_SETTING
   #endif
 };
+ #endif /* !defined(CONFIG_SOC_OPTION_SETTING_MEMORY) */
 
  #elif BSP_FEATURE_FLASH_SUPPORTS_ID_CODE == 1
 


### PR DESCRIPTION
FSP does not set the option setting memory if
CONFIG_SOC_OPTION_SETTING_MEMORY is enabled.

This change is to keep it compatible with the existing RA4M1 implementation.