### PR TITLE
hal: renesas: ra: correct configuration name for r_sce follow HWM

### DIFF
--- a/drivers/ra/CMakeLists.txt
+++ b/drivers/ra/CMakeLists.txt
@@ -52,7 +52,7 @@ if(CONFIG_USE_RA_FSP_SCE)
 		fsp/src/r_sce/common
 	)
 
-	if(CONFIG_HAS_RENESAS_RA_RSIP7)
+	if(CONFIG_HAS_RENESAS_RA_RSIP_E51A)
 		zephyr_include_directories(
 			fsp/src/r_sce/crypto_procedures/src/rsip7/plainkey/public/inc
 			fsp/src/r_sce/crypto_procedures/src/rsip7/plainkey/private/inc)


### PR DESCRIPTION
change name for Renesas Security IP on RA8 from RSIP7 to RSIP-E51A follow latest HWM