### PR TITLE
hal: renesas: Replace the BSP clock settings with new macros.

### DIFF
--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2a1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2a1/bsp_clock_cfg.h
@@ -6,7 +6,7 @@
 */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2a1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2a1/bsp_clock_cfg.h
@@ -1,9 +1,9 @@
 /*
-* Copyright (c) 2020 - 2024 Renesas Electronics Corporation and/or its affiliates
-* Copyright (c) 2024 TOKITA Hiroshi
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
+ * Copyright (c) 2020 - 2024 Renesas Electronics Corporation and/or its affiliates
+ * Copyright (c) 2024 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
@@ -14,7 +14,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 24000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 24MHz */
@@ -27,19 +27,13 @@
 #else
 #error "Invalid HOCO frequency, only can be set to 24MHz, 32MHz, 48MHz, 64MHz"
 #endif
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                   \
-					  RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+
+#define BSP_CFG_CLOCK_SOURCE  RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
+#define BSP_CFG_ICLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 1)
+#define BSP_CFG_PCLKB_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 2)
+#define BSP_CFG_PCLKD_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 1)
+#define BSP_CFG_FCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 2)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2a1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2a1/bsp_clock_cfg.h
@@ -13,8 +13,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 
@@ -40,11 +38,6 @@
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_1)
 #define BSP_CFG_FCLK_DIV                                                                           \
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_2)
-
-#define BSP_CFG_SDADCCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(sdadcclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_SDADCCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(sdadcclk), clk_div, 0)
-
 #define BSP_CFG_CLKOUT_SOURCE                                                                      \
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
 #define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2l1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2l1/bsp_clock_cfg.h
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2020 - 2024 Renesas Electronics Corporation and/or its affiliates
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
+ * Copyright (c) 2020 - 2024 Renesas Electronics Corporation and/or its affiliates
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
@@ -13,7 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 24000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 24MHz */
@@ -27,19 +27,13 @@
 #error "Invalid HOCO frequency, only can be set to 24MHz, 32MHz, 48MHz, 64MHz"
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_CLOCK_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_1)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 2)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 1)
 
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2l1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2l1/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2l1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2l1/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
 */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_clock_cfg.h
@@ -13,7 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -25,49 +25,34 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_FCLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
-#define BSP_CFG_I3CCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_I3CCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_div, 0)
-#define BSP_CFG_CECCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cecclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CECCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cecclk), clk_div, 0)
-#define BSP_CFG_CANFDCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CANFDCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE      RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV         RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
+#define BSP_CFG_I3CCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(i3cclk)))
+#define BSP_CFG_I3CCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(i3cclk), div, 1)
+#define BSP_CFG_CECCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(cecclk)))
+#define BSP_CFG_CECCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(cecclk), div, 1)
+#define BSP_CFG_CANFDCLK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(canfdclk)))
+#define BSP_CFG_CANFDCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(canfdclk), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m1/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m1/bsp_clock_cfg.h
@@ -13,8 +13,6 @@
 #define BSP_CFG_CLOCKS_SECURE	(0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m1/bsp_clock_cfg.h
@@ -10,11 +10,10 @@
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_
 
-#define BSP_CFG_CLOCKS_SECURE	(0)
+#define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 24000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 24MHz */
@@ -28,39 +27,28 @@
 #error "Invalid HOCO frequency, only can be set to 24MHz, 32MHz, 48MHz and 64MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_2)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 2)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_2)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 1)
+#define BSP_CFG_PCLKA_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 1)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 2)
+#define BSP_CFG_PCLKC_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 1)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 1)
+#define BSP_CFG_FCLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 2)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m2/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m2/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m2/bsp_clock_cfg.h
@@ -13,7 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -25,51 +25,38 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_3)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 3)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PLL2_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL2_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), div, RA_PLL_DIV_2)
+#define BSP_CFG_PLL2_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll2)))
+#define BSP_CFG_PLL2_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll2), div, 2)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll2), okay)
-#define BSP_CFG_PLL2_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
+#define BSP_CFG_PLL2_MUL                                                                           \
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                             \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
 #else
 #define BSP_CFG_PLL2_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_FCLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m3/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m3/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m3/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m3/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m3/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m3/bsp_clock_cfg.h
@@ -13,8 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
-
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -26,50 +25,38 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_3)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 3)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PLL2_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL2_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), div, RA_PLL_DIV_2)
+#define BSP_CFG_PLL2_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll2)))
+#define BSP_CFG_PLL2_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll2), div, 2)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll2), okay)
-#define BSP_CFG_PLL2_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
+#define BSP_CFG_PLL2_MUL                                                                           \
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                             \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
 #else
 #define BSP_CFG_PLL2_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_FCLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4w1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4w1/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4w1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4w1/bsp_clock_cfg.h
@@ -10,10 +10,10 @@
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_
 
-#define BSP_CFG_CLOCKS_SECURE	(0)
+#define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 24000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 24MHz */
@@ -27,39 +27,28 @@
 #error "Invalid HOCO frequency, only can be set to 24MHz, 32MHz, 48MHz and 64MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_2)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 2)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_2)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 1)
+#define BSP_CFG_PCLKA_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 1)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 2)
+#define BSP_CFG_PCLKC_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 1)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 1)
+#define BSP_CFG_FCLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 2)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4w1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4w1/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE	(0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e1/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e1/bsp_clock_cfg.h
@@ -13,7 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -25,50 +25,38 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PLL2_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL2_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL2_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll2)))
+#define BSP_CFG_PLL2_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll2), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll2), okay)
-#define BSP_CFG_PLL2_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
+#define BSP_CFG_PLL2_MUL                                                                           \
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                             \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
 #else
 #define BSP_CFG_PLL2_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 1)
+#define BSP_CFG_PCLKA_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_FCLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e1/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_clock_cfg.h
@@ -13,8 +13,6 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_clock_cfg.h
@@ -13,8 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -26,48 +25,33 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 1)
+#define BSP_CFG_PCLKA_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_FCLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
-#define BSP_CFG_CANFDCLK_SOURCE                                                                    \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CANFDCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_div, 0)
-#define BSP_CFG_CECCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cecclk), clk_src,                               \
-					  RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CECCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cecclk), clk_div, 0)
-#define BSP_CFG_I3CCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_I3CCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE      RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV         RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
+#define BSP_CFG_CANFDCLK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(canfdclk)))
+#define BSP_CFG_CANFDCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(canfdclk), div, 1)
+#define BSP_CFG_CECCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(cecclk)))
+#define BSP_CFG_CECCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(cecclk), div, 1)
+#define BSP_CFG_I3CCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(i3cclk)))
+#define BSP_CFG_I3CCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(i3cclk), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m1/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m1/bsp_clock_cfg.h
@@ -13,8 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -26,43 +25,30 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MULv BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_OUTPUT  BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
+#define BSP_CFG_ICLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_BCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(bclk), div, 2)
+#define BSP_CFG_BCLK_OUTPUT (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2))
+#define BSP_CFG_FCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, RA_USB_CLOCK_DIV_5)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 5)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m1/bsp_clock_cfg.h
@@ -13,8 +13,6 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m2/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m2/bsp_clock_cfg.h
@@ -13,8 +13,6 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m2/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m2/bsp_clock_cfg.h
@@ -13,8 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -26,42 +25,30 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_BCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_OUTPUT  BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2)
+#define BSP_CFG_ICLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_FCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
+#define BSP_CFG_BCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(bclk), div, 2)
+#define BSP_CFG_BCLK_OUTPUT (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2))
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m3/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m3/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m3/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m3/bsp_clock_cfg.h
@@ -13,8 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -26,44 +25,32 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_2)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 2)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
+#define BSP_CFG_ICLK_DIV  RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
 
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_BCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_OUTPUT  BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2)
-#define BSP_CFG_SDCLK_OUTPUT BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), sdclk, 1)
+#define BSP_CFG_FCLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
+#define BSP_CFG_BCLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(bclk), div, 2)
+#define BSP_CFG_BCLK_OUTPUT  (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2))
+#define BSP_CFG_SDCLK_OUTPUT (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), sdclk, 1))
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m3/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m3/bsp_clock_cfg.h
@@ -13,8 +13,6 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m4/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m4/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m4/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m4/bsp_clock_cfg.h
@@ -13,8 +13,6 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m4/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m4/bsp_clock_cfg.h
@@ -13,8 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -26,57 +25,42 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PLL2_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL2_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL2_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll2)))
+#define BSP_CFG_PLL2_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll2), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll2), okay)
-#define BSP_CFG_PLL2_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
+#define BSP_CFG_PLL2_MUL                                                                           \
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                             \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
 #else
 #define BSP_CFG_PLL2_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_BCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_OUTPUT  BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2)
+#define BSP_CFG_ICLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 1)
+#define BSP_CFG_PCLKA_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_FCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
+#define BSP_CFG_BCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(bclk), div, 2)
+#define BSP_CFG_BCLK_OUTPUT (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2))
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
-#define BSP_CFG_OCTA_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_src,                       \
-					  RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_OCTA_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
+#define BSP_CFG_OCTA_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(octaspiclk)))
+#define BSP_CFG_OCTA_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(octaspiclk), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m5/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m5/bsp_clock_cfg.h
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2020 - 2024 Renesas Electronics Corporation and/or its affiliates
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
+ * Copyright (c) 2020 - 2024 Renesas Electronics Corporation and/or its affiliates
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
@@ -13,7 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -25,67 +25,48 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, and 20MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 0),                              \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll), mul, 1))
 #else
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PLL2_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL2_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL2_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll2)))
+#define BSP_CFG_PLL2_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll2), div, 1)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll2), okay)
-#define BSP_CFG_PLL2_MUL                                                                            \
-	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                            \
-			DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
+#define BSP_CFG_PLL2_MUL                                                                           \
+	BSP_CLOCKS_PLL_MUL(DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 0),                             \
+			   DT_PROP_BY_IDX(DT_NODELABEL(pll2), mul, 1))
 #else
 #define BSP_CFG_PLL2_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_1)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_OUTPUT  BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_4)
+#define BSP_CFG_ICLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 1)
+#define BSP_CFG_PCLKA_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 2)
+#define BSP_CFG_PCLKB_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 4)
+#define BSP_CFG_PCLKC_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 4)
+#define BSP_CFG_PCLKD_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 2)
+#define BSP_CFG_BCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(bclk), div, 2)
+#define BSP_CFG_BCLK_OUTPUT (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2))
+#define BSP_CFG_FCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 4)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_U60CK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(u60clk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_U60CK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(u60clk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
-#define BSP_CFG_CANFDCLK_SOURCE                                                                    \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CANFDCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_div, 0)
-#define BSP_CFG_CECCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cecclk), clk_src,                               \
-					  RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CECCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cecclk), clk_div, 0)
-#define BSP_CFG_OCTA_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_src,                           \
-					  RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_OCTA_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE      RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV         RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_U60CK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(u60clk)))
+#define BSP_CFG_U60CK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(u60clk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
+#define BSP_CFG_CANFDCLK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(canfdclk)))
+#define BSP_CFG_CANFDCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(canfdclk), div, 1)
+#define BSP_CFG_CECCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(cecclk)))
+#define BSP_CFG_CECCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(cecclk), div, 1)
+#define BSP_CFG_OCTA_SOURCE     RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(octaspiclk)))
+#define BSP_CFG_OCTA_DIV        RA_CGC_CLK_DIV(DT_NODELABEL(octaspiclk), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m5/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m5/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m5/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m5/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
 */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 
@@ -116,9 +114,6 @@
 #define BSP_CFG_SPICLK_SOURCE                                                                      \
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
 #define BSP_CFG_SPICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_div, 0)
-#define BSP_CFG_ADCCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(adcclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_ADCCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(adcclk), clk_div, 0)
 #define BSP_CFG_I3CCLK_SOURCE                                                                      \
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
 #define BSP_CFG_I3CCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_div, 0)

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_clock_cfg.h
@@ -13,7 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -29,9 +29,8 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, 20MHz, 32MHz, 48MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
@@ -41,16 +40,15 @@
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PLODIVP            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divp, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1P_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqp, 0)
-#define BSP_CFG_PLODIVQ            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divq, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1Q_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqq, 0)
-#define BSP_CFG_PLODIVR            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divr, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1R_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqr, 0)
+#define BSP_CFG_PLODIVP            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divp, 2)
+#define BSP_CFG_PLL1P_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqp, 0))
+#define BSP_CFG_PLODIVQ            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divq, 2)
+#define BSP_CFG_PLL1Q_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqq, 0))
+#define BSP_CFG_PLODIVR            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divr, 2)
+#define BSP_CFG_PLL1R_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqr, 0))
 
-#define BSP_CFG_PLL2_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL2_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL2_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll2)))
+#define BSP_CFG_PLL2_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll2), div, 1)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll2), okay)
 #define BSP_CFG_PLL2_MUL                                                                           \
@@ -60,65 +58,44 @@
 #define BSP_CFG_PLL2_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PL2ODIVP           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divp, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2P_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqp, 0)
-#define BSP_CFG_PL2ODIVQ           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divq, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2Q_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqq, 0)
-#define BSP_CFG_PL2ODIVR           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divr, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2R_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqr, 0)
+#define BSP_CFG_PL2ODIVP           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divp, 2)
+#define BSP_CFG_PLL2P_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqp, 0))
+#define BSP_CFG_PL2ODIVQ           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divq, 2)
+#define BSP_CFG_PLL2Q_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqq, 0))
+#define BSP_CFG_PL2ODIVR           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divr, 2)
+#define BSP_CFG_PLL2R_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqr, 0))
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                   \
-					  RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_CPUCLK_DIV                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cpuclk), clk_div, RA_SYS_CLOCK_DIV_1)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
+#define BSP_CFG_CPUCLK_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(cpuclk), div, 1)
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_8)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_8)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKE_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclke), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclk), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_SDCLK_OUTPUT BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), sdclk, 1)
-#define BSP_CFG_BCLK_OUTPUT  BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_8)
+#define BSP_CFG_ICLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 4)
+#define BSP_CFG_PCLKB_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 8)
+#define BSP_CFG_PCLKC_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 8)
+#define BSP_CFG_PCLKD_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 4)
+#define BSP_CFG_PCLKE_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclke), div, 2)
+#define BSP_CFG_BCLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(bclk), div, 4)
+#define BSP_CFG_SDCLK_OUTPUT (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), sdclk, 1))
+#define BSP_CFG_BCLK_OUTPUT  (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2))
+#define BSP_CFG_FCLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 8)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_U60CK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(u60clk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_U60CK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(u60clk), clk_div, 0)
-#define BSP_CFG_OCTA_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_src,                       \
-					  RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_OCTA_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_div, 0)
-#define BSP_CFG_CANFDCLK_SOURCE                                                                    \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CANFDCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
-#define BSP_CFG_SCICLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(sciclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_SCICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(sciclk), clk_div, 0)
-#define BSP_CFG_SPICLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_SPICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_div, 0)
-#define BSP_CFG_I3CCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_I3CCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_div, 0)
-#define BSP_CFG_LCDCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(lcdclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_LCDCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(lcdclk), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE      RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV         RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_U60CK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(u60clk)))
+#define BSP_CFG_U60CK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(u60clk), div, 1)
+#define BSP_CFG_OCTA_SOURCE     RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(octaspiclk)))
+#define BSP_CFG_OCTA_DIV        RA_CGC_CLK_DIV(DT_NODELABEL(octaspiclk), div, 1)
+#define BSP_CFG_CANFDCLK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(canfdclk)))
+#define BSP_CFG_CANFDCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(canfdclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
+#define BSP_CFG_SCICLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(sciclk)))
+#define BSP_CFG_SCICLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(sciclk), div, 1)
+#define BSP_CFG_SPICLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(spiclk)))
+#define BSP_CFG_SPICLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(spiclk), div, 1)
+#define BSP_CFG_I3CCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(i3cclk)))
+#define BSP_CFG_I3CCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(i3cclk), div, 1)
+#define BSP_CFG_LCDCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(lcdclk)))
+#define BSP_CFG_LCDCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(lcdclk), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m1/bsp_clock_cfg.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_
@@ -13,7 +13,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -29,9 +29,8 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, 20MHz, 32MHz, 48MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
@@ -41,16 +40,15 @@
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PLODIVP            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divp, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1P_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqp, 0)
-#define BSP_CFG_PLODIVQ            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divq, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1Q_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqq, 0)
-#define BSP_CFG_PLODIVR            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divr, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1R_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqr, 0)
+#define BSP_CFG_PLODIVP            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divp, 2)
+#define BSP_CFG_PLL1P_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqp, 0))
+#define BSP_CFG_PLODIVQ            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divq, 2)
+#define BSP_CFG_PLL1Q_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqq, 0))
+#define BSP_CFG_PLODIVR            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divr, 2)
+#define BSP_CFG_PLL1R_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqr, 0))
 
-#define BSP_CFG_PLL2_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL2_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL2_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll2)))
+#define BSP_CFG_PLL2_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll2), div, 1)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll2), okay)
 #define BSP_CFG_PLL2_MUL                                                                           \
@@ -60,62 +58,42 @@
 #define BSP_CFG_PLL2_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PL2ODIVP           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divp, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2P_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqp, 0)
-#define BSP_CFG_PL2ODIVQ           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divq, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2Q_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqq, 0)
-#define BSP_CFG_PL2ODIVR           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divr, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2R_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqr, 0)
+#define BSP_CFG_PL2ODIVP           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divp, 2)
+#define BSP_CFG_PLL2P_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqp, 0))
+#define BSP_CFG_PL2ODIVQ           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divq, 2)
+#define BSP_CFG_PLL2Q_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqq, 0))
+#define BSP_CFG_PL2ODIVR           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divr, 2)
+#define BSP_CFG_PLL2R_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqr, 0))
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                   \
-					  RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_CPUCLK_DIV                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cpuclk), clk_div, RA_SYS_CLOCK_DIV_1)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
+#define BSP_CFG_CPUCLK_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(cpuclk), div, 1)
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_8)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_8)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKE_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclke), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclk), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_SDCLK_OUTPUT BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), sdclk, 1)
-#define BSP_CFG_BCLK_OUTPUT  BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_8)
+#define BSP_CFG_ICLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 4)
+#define BSP_CFG_PCLKB_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 8)
+#define BSP_CFG_PCLKC_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 8)
+#define BSP_CFG_PCLKD_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 4)
+#define BSP_CFG_PCLKE_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclke), div, 2)
+#define BSP_CFG_BCLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(bclk), div, 4)
+#define BSP_CFG_SDCLK_OUTPUT (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), sdclk, 1))
+#define BSP_CFG_BCLK_OUTPUT  (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2))
+#define BSP_CFG_FCLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 8)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_U60CK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(u60clk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_U60CK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(u60clk), clk_div, 0)
-#define BSP_CFG_OCTA_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_src,                       \
-					  RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_OCTA_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_div, 0)
-#define BSP_CFG_CANFDCLK_SOURCE                                                                    \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CANFDCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
-#define BSP_CFG_SCICLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(sciclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_SCICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(sciclk), clk_div, 0)
-#define BSP_CFG_SPICLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_SPICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_div, 0)
-#define BSP_CFG_I3CCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_I3CCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE      RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV         RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_U60CK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(u60clk)))
+#define BSP_CFG_U60CK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(u60clk), div, 1)
+#define BSP_CFG_OCTA_SOURCE     RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(octaspiclk)))
+#define BSP_CFG_OCTA_DIV        RA_CGC_CLK_DIV(DT_NODELABEL(octaspiclk), div, 1)
+#define BSP_CFG_CANFDCLK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(canfdclk)))
+#define BSP_CFG_CANFDCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(canfdclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
+#define BSP_CFG_SCICLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(sciclk)))
+#define BSP_CFG_SCICLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(sciclk), div, 1)
+#define BSP_CFG_SPICLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(spiclk)))
+#define BSP_CFG_SPICLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(spiclk), div, 1)
+#define BSP_CFG_I3CCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(i3cclk)))
+#define BSP_CFG_I3CCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(i3cclk), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m1/bsp_clock_cfg.h
@@ -12,8 +12,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 
@@ -116,9 +114,6 @@
 #define BSP_CFG_SPICLK_SOURCE                                                                      \
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
 #define BSP_CFG_SPICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_div, 0)
-#define BSP_CFG_ADCCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(adcclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_ADCCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(adcclk), clk_div, 0)
 #define BSP_CFG_I3CCLK_SOURCE                                                                      \
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
 #define BSP_CFG_I3CCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_div, 0)

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_clock_cfg.h
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2020 - 2024 Renesas Electronics Corporation and/or its affiliates
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
+ * Copyright (c) 2020 - 2024 Renesas Electronics Corporation and/or its affiliates
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
@@ -12,7 +12,7 @@
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
 
-#define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
+#define BSP_CFG_XTAL_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0))
 
 #if DT_PROP(DT_NODELABEL(hoco), clock_frequency) == 16000000
 #define BSP_CFG_HOCO_FREQUENCY 0 /* HOCO 16MHz */
@@ -28,9 +28,8 @@
 #error "Invalid HOCO frequency, only can be set to 16MHz, 18MHz, 20MHz, 32MHz, 48MHz"
 #endif
 
-#define BSP_CFG_PLL_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll)))
+#define BSP_CFG_PLL_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll), div, 1)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
@@ -40,16 +39,15 @@
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PLODIVP            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divp, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1P_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqp, 0)
-#define BSP_CFG_PLODIVQ            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divq, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1Q_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqq, 0)
-#define BSP_CFG_PLODIVR            BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), divr, RA_PLL_DIV_2)
-#define BSP_CFG_PLL1R_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqr, 0)
+#define BSP_CFG_PLODIVP            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divp, 2)
+#define BSP_CFG_PLL1P_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqp, 0))
+#define BSP_CFG_PLODIVQ            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divq, 2)
+#define BSP_CFG_PLL1Q_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqq, 0))
+#define BSP_CFG_PLODIVR            RA_CGC_CLK_DIV(DT_NODELABEL(pll), divr, 2)
+#define BSP_CFG_PLL1R_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll), freqr, 0))
 
-#define BSP_CFG_PLL2_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), source, RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_PLL2_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), div, RA_PLL_DIV_1)
+#define BSP_CFG_PLL2_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pll2)))
+#define BSP_CFG_PLL2_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pll2), div, 1)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay)
 #define BSP_CFG_PLL_MUL                                                                            \
@@ -59,65 +57,44 @@
 #define BSP_CFG_PLL_MUL BSP_CLOCKS_PLL_MUL(0, 0)
 #endif
 
-#define BSP_CFG_PL2ODIVP           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divp, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2P_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqp, 0)
-#define BSP_CFG_PL2ODIVQ           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divq, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2Q_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqq, 0)
-#define BSP_CFG_PL2ODIVR           BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), divr, RA_PLL_DIV_2)
-#define BSP_CFG_PLL2R_FREQUENCY_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqr, 0)
+#define BSP_CFG_PL2ODIVP           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divp, 2)
+#define BSP_CFG_PLL2P_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqp, 0))
+#define BSP_CFG_PL2ODIVQ           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divq, 2)
+#define BSP_CFG_PLL2Q_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqq, 0))
+#define BSP_CFG_PL2ODIVR           RA_CGC_CLK_DIV(DT_NODELABEL(pll2), divr, 2)
+#define BSP_CFG_PLL2R_FREQUENCY_HZ (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pll2), freqr, 0))
 
-#define BSP_CFG_CLOCK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkblock), sysclock_src,                  \
-					  RA_PLL_SOURCE_DISABLE)
-#define BSP_CFG_CPUCLK_DIV                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(cpuclk), clk_div, RA_SYS_CLOCK_DIV_1)
+#define BSP_CFG_CLOCK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(pclkblock)))
+#define BSP_CFG_CPUCLK_DIV   RA_CGC_CLK_DIV(DT_NODELABEL(cpuclk), div, 1)
 
-#define BSP_CFG_ICLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(iclk), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_PCLKA_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclka), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKB_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkb), clk_div, RA_SYS_CLOCK_DIV_8)
-#define BSP_CFG_PCLKC_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkc), clk_div, RA_SYS_CLOCK_DIV_8)
-#define BSP_CFG_PCLKD_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclkd), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_PCLKE_DIV                                                                          \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(pclke), clk_div, RA_SYS_CLOCK_DIV_2)
-#define BSP_CFG_BCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclk), clk_div, RA_SYS_CLOCK_DIV_4)
-#define BSP_CFG_SDCLK_OUTPUT BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), sdclk, 1)
-#define BSP_CFG_BCLK_OUTPUT  BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2)
-#define BSP_CFG_FCLK_DIV                                                                           \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(fclk), clk_div, RA_SYS_CLOCK_DIV_8)
+#define BSP_CFG_ICLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(iclk), div, 2)
+#define BSP_CFG_PCLKA_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclka), div, 4)
+#define BSP_CFG_PCLKB_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkb), div, 8)
+#define BSP_CFG_PCLKC_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkc), div, 8)
+#define BSP_CFG_PCLKD_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclkd), div, 4)
+#define BSP_CFG_PCLKE_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(pclke), div, 2)
+#define BSP_CFG_BCLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(bclk), div, 4)
+#define BSP_CFG_SDCLK_OUTPUT (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), sdclk, 1))
+#define BSP_CFG_BCLK_OUTPUT  (RA_CGC_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(bclkout), clk_out_div, 2))
+#define BSP_CFG_FCLK_DIV     RA_CGC_CLK_DIV(DT_NODELABEL(fclk), div, 8)
 
-#define BSP_CFG_UCK_SOURCE                                                                         \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_UCK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(uclk), clk_div, 0)
-#define BSP_CFG_U60CK_SOURCE                                                                       \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(u60clk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_U60CK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(u60clk), clk_div, 0)
-#define BSP_CFG_OCTA_SOURCE                                                                        \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_src,                       \
-					  RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_OCTA_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(octaspiclk), clk_div, 0)
-#define BSP_CFG_CANFDCLK_SOURCE                                                                    \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CANFDCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(canfdclk), clk_div, 0)
-#define BSP_CFG_CLKOUT_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_CLKOUT_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(clkout), clk_div, 0)
-#define BSP_CFG_SCICLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(sciclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_SCICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(sciclk), clk_div, 0)
-#define BSP_CFG_SPICLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_SPICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_div, 0)
-#define BSP_CFG_I3CCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_I3CCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_div, 0)
-#define BSP_CFG_LCDCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(lcdclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_LCDCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(lcdclk), clk_div, 0)
+#define BSP_CFG_UCK_SOURCE      RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(uclk)))
+#define BSP_CFG_UCK_DIV         RA_CGC_CLK_DIV(DT_NODELABEL(uclk), div, 1)
+#define BSP_CFG_U60CK_SOURCE    RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(u60clk)))
+#define BSP_CFG_U60CK_DIV       RA_CGC_CLK_DIV(DT_NODELABEL(u60clk), div, 1)
+#define BSP_CFG_OCTA_SOURCE     RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(octaspiclk)))
+#define BSP_CFG_OCTA_DIV        RA_CGC_CLK_DIV(DT_NODELABEL(octaspiclk), div, 1)
+#define BSP_CFG_CANFDCLK_SOURCE RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(canfdclk)))
+#define BSP_CFG_CANFDCLK_DIV    RA_CGC_CLK_DIV(DT_NODELABEL(canfdclk), div, 1)
+#define BSP_CFG_CLKOUT_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(clkout)))
+#define BSP_CFG_CLKOUT_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(clkout), div, 1)
+#define BSP_CFG_SCICLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(sciclk)))
+#define BSP_CFG_SCICLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(sciclk), div, 1)
+#define BSP_CFG_SPICLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(spiclk)))
+#define BSP_CFG_SPICLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(spiclk), div, 1)
+#define BSP_CFG_I3CCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(i3cclk)))
+#define BSP_CFG_I3CCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(i3cclk), div, 1)
+#define BSP_CFG_LCDCLK_SOURCE   RA_CGC_CLK_SRC(DT_CLOCKS_CTLR(DT_NODELABEL(lcdclk)))
+#define BSP_CFG_LCDCLK_DIV      RA_CGC_CLK_DIV(DT_NODELABEL(lcdclk), div, 1)
 
 #endif /* BSP_CLOCK_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_clock_cfg.h
@@ -4,7 +4,7 @@
 * SPDX-License-Identifier: BSD-3-Clause
 */
 #include <zephyr/devicetree.h>
-#include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
 #ifndef BSP_CLOCK_CFG_H_
 #define BSP_CLOCK_CFG_H_

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_clock_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_clock_cfg.h
@@ -11,8 +11,6 @@
 
 #define BSP_CFG_CLOCKS_SECURE   (0)
 #define BSP_CFG_CLOCKS_OVERRIDE (0)
-#define BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(node_id, prop, default_value)                            \
-	(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay), (DT_PROP(node_id, prop)), (default_value)))
 
 #define BSP_CFG_XTAL_HZ BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(xtal), clock_frequency, 0)
 
@@ -115,9 +113,6 @@
 #define BSP_CFG_SPICLK_SOURCE                                                                      \
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
 #define BSP_CFG_SPICLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(spiclk), clk_div, 0)
-#define BSP_CFG_ADCCLK_SOURCE                                                                      \
-	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(adcclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
-#define BSP_CFG_ADCCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(adcclk), clk_div, 0)
 #define BSP_CFG_I3CCLK_SOURCE                                                                      \
 	BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_src, RA_CLOCK_SOURCE_DISABLE)
 #define BSP_CFG_I3CCLK_DIV BSP_CLOCK_PROP_HAS_STATUS_OKAY_OR(DT_NODELABEL(i3cclk), clk_div, 0)


### PR DESCRIPTION
    

To simplify the DeviceTree notation, we have introduced macros
that derive BSP macro definitions from DeviceTree values.
The clock settings were rewritten by it.