### PR TITLE
hal: renesas: ra: update Renesas CMSIS header file

### DIFF
--- a/drivers/ra/README
+++ b/drivers/ra/README
@@ -54,3 +54,7 @@ Patch List:
    * Allows custom implementation of option setting memory
    Impacted files:
       drivers/ra/fsp/src/bsp/mcu/all/bsp_rom_registers.c
+
+   * Move the include for cmsis_compiler.h after include for Renesas CMSIS header file
+   Impacted files:
+      drivers/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/renesas.h

--- a/drivers/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/renesas.h
+++ b/drivers/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/renesas.h
@@ -25,19 +25,6 @@
 extern "C" {
  #endif
 
-/* Workaround for LLVM. __ARM_ARCH_8_1M_MAIN__ is defined for CM85 parts. But CMSIS_5 does not support this */
- #if defined(__llvm__) && !defined(__CLANG_TIDY__) && defined(__ARM_ARCH_8_1M_MAIN__)
-  #undef __ARM_ARCH_8_1M_MAIN__
-  #define __ARM_ARCH_8M_MAIN__    1
- #endif
- #include "cmsis_compiler.h"
-
-/* Workaround for compilers that are not defining __ARM_ARCH_8_1M_MAIN__ for CM85 parts. Search CM85_WORKAROUND for related code changes */
- #if BSP_CFG_MCU_PART_SERIES == 8
-  #undef __ARM_ARCH_8M_MAIN__
-  #define __ARM_ARCH_8_1M_MAIN__    1
- #endif
-
 /** @addtogroup Configuration_of_CMSIS
  * @{
  */
@@ -113,6 +100,19 @@ extern "C" {
   #else
    #warning "Unsupported MCU"
   #endif
+ #endif
+
+/* Workaround for LLVM. __ARM_ARCH_8_1M_MAIN__ is defined for CM85 parts. But CMSIS_5 does not support this */
+ #if defined(__llvm__) && !defined(__CLANG_TIDY__) && defined(__ARM_ARCH_8_1M_MAIN__)
+  #undef __ARM_ARCH_8_1M_MAIN__
+  #define __ARM_ARCH_8M_MAIN__    1
+ #endif
+ #include "cmsis_compiler.h"
+
+/* Workaround for compilers that are not defining __ARM_ARCH_8_1M_MAIN__ for CM85 parts. Search CM85_WORKAROUND for related code changes */
+ #if BSP_CFG_MCU_PART_SERIES == 8
+  #undef __ARM_ARCH_8M_MAIN__
+  #define __ARM_ARCH_8_1M_MAIN__    1
  #endif
 
  #if   __ARM_ARCH_7EM__


### PR DESCRIPTION
Update Renesas cmsis header file to fix swap arm thread due to macros regarding FPU was not defined correctly.