### PR TITLE
hal: renesas: ra: Add part number info for RA6E2, RA4E2

### DIFF
--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_mcu_device_pn_cfg.h
@@ -7,4 +7,5 @@
 #ifndef BSP_MCU_DEVICE_PN_CFG_H_
 #define BSP_MCU_DEVICE_PN_CFG_H_
 #define BSP_PACKAGE_PINS (64)
+#define BSP_MCU_FEATURE_SET 'B'
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_mcu_device_pn_cfg.h
@@ -7,4 +7,5 @@
 #ifndef BSP_MCU_DEVICE_PN_CFG_H_
 #define BSP_MCU_DEVICE_PN_CFG_H_
 #define BSP_PACKAGE_PINS (64)
+#define BSP_MCU_FEATURE_SET 'B'
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */


### PR DESCRIPTION
Add information of BSP_MCU_FEATURE_SET for these boards as CANFD support only available on MCU Feature Set B
- ek_ra6e2
- fpb_ra6e2
- ek_ra4e2