### PR TITLE
hal: renesas: ra: extend support for display color correction

### DIFF
--- a/zephyr/ra/ra_cfg/fsp_cfg/r_glcdc_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/r_glcdc_cfg.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 #define GLCDC_CFG_PARAM_CHECKING_ENABLE      (BSP_CFG_PARAM_CHECKING_ENABLE)
-#define GLCDC_CFG_COLOR_CORRECTION_ENABLE    (false)
+#define GLCDC_CFG_COLOR_CORRECTION_ENABLE    (true)
 
 /* Disable DSI function handling */
 #ifdef GLCDC_CFG_USING_DSI


### PR DESCRIPTION
This PR to enable GLCDC color correction function, support for:
- display_set_brightness
- display_set_constract