### PR TITLE
[DNM] hal: renesas: ra: Use `irq_lock` for FSP_CRITICAL_SECTION

### DIFF
--- a/zephyr/ra/portable/bsp_api.h
+++ b/zephyr/ra/portable/bsp_api.h
@@ -52,7 +52,9 @@
 /* BSP MCU Specific Includes. */
  #include "bsp_register_protection.h"
  #include "bsp_irq.h"
- #include "bsp_io.h"
+ #ifdef irq_lock
+  #include "bsp_io.h"
+ #endif
  #include "bsp_group_irq.h"
  #include "bsp_clocks.h"
  #include "bsp_module_stop.h"


### PR DESCRIPTION
Use `irq_lock` for FSP_CRITICAL_SECTION

---

I think this issue needs to be considered at some point, so I'm raising it as an issue.
I haven't done any verification yet.