### PR TITLE
hal: renesas: ra: Fix flash hp when using with DCACHE

### DIFF
--- a/drivers/ra/README
+++ b/drivers/ra/README
@@ -55,6 +55,10 @@ Patch List:
    Impacted files:
       drivers/ra/fsp/inc/instances/r_flash_hp.h
 
+   * Add SCB_CleanInvalidateDCache() for flash hp when using DCACHE
+   Impacted files:
+      drivers/ra/fsp/src/r_flash_hp/r_flash_hp.c
+
    * Allows custom implementation of option setting memory
    Impacted files:
       drivers/ra/fsp/src/bsp/mcu/all/bsp_rom_registers.c

--- a/drivers/ra/fsp/src/r_flash_hp/r_flash_hp.c
+++ b/drivers/ra/fsp/src/r_flash_hp/r_flash_hp.c
@@ -2047,6 +2047,13 @@ fsp_err_t flash_hp_pe_mode_exit (void)
         err = temp_err;
     }
 
+#if defined(BSP_CFG_DCACHE_ENABLED)
+ #if (1U == BSP_CFG_DCACHE_ENABLED)
+    /* Clean and Invalidates D-Cache */
+    SCB_CleanInvalidateDCache();
+ #endif
+#endif
+
     return err;
 }
 

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_mcu_family_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_mcu_family_cfg.h
@@ -575,7 +575,7 @@
 #endif
 
 #ifndef BSP_CFG_DCACHE_ENABLED
-#define BSP_CFG_DCACHE_ENABLED (0)
+#define BSP_CFG_DCACHE_ENABLED (CONFIG_DCACHE)
 #endif
 
 /* SDRAM controller configuration */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m1/bsp_mcu_family_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m1/bsp_mcu_family_cfg.h
@@ -558,7 +558,7 @@
 #endif
 
 #ifndef BSP_CFG_DCACHE_ENABLED
-#define BSP_CFG_DCACHE_ENABLED (0)
+#define BSP_CFG_DCACHE_ENABLED (CONFIG_DCACHE)
 #endif
 
 /* SDRAM controller configuration */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_mcu_family_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_mcu_family_cfg.h
@@ -570,7 +570,7 @@
 #endif
 
 #ifndef BSP_CFG_DCACHE_ENABLED
-#define BSP_CFG_DCACHE_ENABLED (0)
+#define BSP_CFG_DCACHE_ENABLED (CONFIG_DCACHE)
 #endif
 
 /* SDRAM controller configuration */


### PR DESCRIPTION
The PR [Improve lvgl performance](https://github.com/zephyrproject-rtos/zephyr/pull/85200) aims to enable DCACHE to improve the performance of the RA8D1 and LVGL. However, when DCACHE is enabled, Flash HP cannot read or write. This PR aims to fix this issue.