### PR TITLE
hal: CMakeLists: Add zephyr_library() define to hal_reneas

### DIFF
--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_library()
 add_subdirectory_ifdef(CONFIG_HAS_RENESAS_RA_FSP ra)
 add_subdirectory_ifdef(CONFIG_HAS_RENESAS_RZ_FSP rz)


### PR DESCRIPTION
zephyr_library() is a CMake function used in Zephyr's build system to define and manage a Zephyr library.
This option will separate the hal_renesas with other zephyr library make it easier to add customize build option.