### PR TITLE
hal: renesas: CMakeLists: Add condition for zephyr_library() definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_HAS_RENESAS_RA_FSP OR CONFIG_HAS_RENESAS_RZ_FSP OR CONFIG_SOC_FAMILY_RENESAS_SMARTBOND)
+  zephyr_library()
+endif()
+
 add_subdirectory_ifdef(CONFIG_SOC_FAMILY_RENESAS_SMARTBOND smartbond)
 add_subdirectory(zephyr)
 add_subdirectory(drivers)

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
 add_subdirectory_ifdef(CONFIG_HAS_RENESAS_RA_FSP ra)
 add_subdirectory_ifdef(CONFIG_HAS_RENESAS_RZ_FSP rz)


### PR DESCRIPTION
Fix the warning bleeding to other vendors
`CMake Warning at /home/pdgendt/zephyrproject/zephyr/CMakeLists.txt:1011 (message):`
  `No SOURCES given to Zephyr library: ..__modules__hal__renesas__drivers`
  `Excluding target from build.`
related to #85
