### PR TITLE
hal: renesas: ra: Add the Comparator patch for the migration of FSP 5.8.0

### DIFF
--- a/drivers/ra/fsp/inc/api/r_comparator_api.h
+++ b/drivers/ra/fsp/inc/api/r_comparator_api.h
@@ -52,6 +52,7 @@ typedef enum e_comparator_mode
 /** Trigger type: rising edge, falling edge, both edges, low level. */
 typedef enum e_comparator_trigger
 {
+    COMPARATOR_TRIGGER_NO_EDGE   = 0,  ///< None edge trigger
     COMPARATOR_TRIGGER_RISING    = 1,  ///< Rising edge trigger
     COMPARATOR_TRIGGER_FALLING   = 2,  ///< Falling edge trigger
     COMPARATOR_TRIGGER_BOTH_EDGE = 3,  ///< Both edges trigger


### PR DESCRIPTION
Since the PR Migrate FSP 5.8.0 (#79) lacks the Comparator patch, this PR aims to add it.
The PR contains Comparator patch: #77