### PR TITLE
hal: renesas: ra: Rename the 'programming_enable' property for flash-hp

### DIFF
--- a/zephyr/ra/ra_cfg/fsp_cfg/r_flash_hp_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/r_flash_hp_cfg.h
@@ -11,8 +11,8 @@
          #endif
 
 #define FLASH_HP_CFG_PARAM_CHECKING_ENABLE (BSP_CFG_PARAM_CHECKING_ENABLE)
-#define FLASH_HP_CFG_CODE_FLASH_PROGRAMMING_ENABLE ((DT_PROP(DT_NODELABEL(flash0), renesas_programming_enable)))
-#define FLASH_HP_CFG_DATA_FLASH_PROGRAMMING_ENABLE ((DT_PROP(DT_NODELABEL(flash1), renesas_programming_enable)))
+#define FLASH_HP_CFG_CODE_FLASH_PROGRAMMING_ENABLE ((DT_PROP(DT_NODELABEL(flash0), programming_enable)))
+#define FLASH_HP_CFG_DATA_FLASH_PROGRAMMING_ENABLE ((DT_PROP(DT_NODELABEL(flash1), programming_enable)))
 
 #ifdef __cplusplus
          }


### PR DESCRIPTION
Modify the name `renesas,programming_enable` into `programming_enable` in `r_flash_hp_cfg.h`