### PR TITLE
Add HAL for I2C driver support for RX

### DIFF
--- a/drivers/rx/CMakeLists.txt
+++ b/drivers/rx/CMakeLists.txt
@@ -91,3 +91,15 @@ if(CONFIG_USE_RX_RDP_RSPI)
 		rdp/src/r_rspi_rx/src
 		rdp/src/r_rspi_rx)
 endif()
+
+if(CONFIG_USE_RX_RDP_I2C)
+	zephyr_include_directories(
+		rdp/src/r_riic_rx
+		rdp/src/r_riic_rx/src
+		rdp/src/r_riic_rx/src/targets/${CONFIG_SOC_SERIES}
+	)
+	zephyr_library_sources(
+		rdp/src/r_riic_rx/src/r_riic_rx.c
+		rdp/src/r_riic_rx/src/targets/${CONFIG_SOC_SERIES}/r_riic_${CONFIG_SOC_SERIES}.c
+	)
+endif()

--- a/drivers/rx/README
+++ b/drivers/rx/README
@@ -52,3 +52,8 @@ Patch List:
    Impacted files:
       drivers/rx/rdp/src/r_rspi_rx/src/r_rspi_rx.c
       drivers/rx/rdp/src/r_rspi_rx/src/r_rspi_rx_private.h
+
+   * Remove the static definition in RIIC driver
+   Impacted files:
+      drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
+      drivers/rx/rdp/src/r_riic_rx/r_riic_rx_if.h

--- a/drivers/rx/README
+++ b/drivers/rx/README
@@ -6,7 +6,7 @@ Origin:
    https://www.renesas.com/us/en/software-tool/fit
 
 Status:
-   version v1.46
+   version v1.47
 
 Purpose:
    Firmware Integration Technology (FIT) for Renesas RX MCU Family.
@@ -22,7 +22,7 @@ URL:
    https://github.com/renesas/rx-driver-package
 
 Commit:
-   aa05cf00f4caade21cc6697c9f24c70d41f2a3b4
+   2fdeaa013e81e2288de4d92b8ef05a0a89edb964
 
 Maintained-by:
    Renesas Electronics Corporation

--- a/drivers/rx/README
+++ b/drivers/rx/README
@@ -57,3 +57,8 @@ Patch List:
    Impacted files:
       drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
       drivers/rx/rdp/src/r_riic_rx/r_riic_rx_if.h
+
+   * Fix the build warnings in RIIC driver
+   Impacted files:
+      drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
+      drivers/rx/rdp/src/r_riic_rx/src/targets/rx130/r_riic_rx130.c

--- a/drivers/rx/rdp/src/r_riic_rx/r_riic_rx_if.h
+++ b/drivers/rx/rdp/src/r_riic_rx/r_riic_rx_if.h
@@ -1,0 +1,273 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+ * File Name    : r_riic_rx_if.h
+ * Description  : Functions for using RIIC on RX devices. 
+ **********************************************************************************************************************/
+/***********************************************************************************************************************
+ * History : DD.MM.YYYY Version  Description
+ *         : 01.07.2013 1.00     First Release
+ *         : 30.09.2013 1.10     Change symbol of return value and status
+ *         : 08.10.2013 1.20     Modified processing for the I/O register initialization and mode transition 
+ *                                when a stop condition is detected while the slave is communicating.
+ *                               Modified processing for mode transition when an API function is called
+ *                                while the bus is busy.
+ *                               Modified processing for mode transition
+ *                                when an arbitration lost occurred and the addresses do not match.
+ *                               Modified incorrect slave transmission after the master reception.
+ *                               Modified processing for the I/O register initialization
+ *                                when generating a start condition and receiving the slave address.
+ *         : 17.07.2014 1.30     Added the parameters for the timeout detection.
+ *         : 22.09.2014 1.40     The module is updated to measure the issue that slave communication 
+ *                               is not available after an arbitration-lost occurs and the bus is locked. 
+ *                                 The issue occurs when the following four conditions are all met.
+ *                                    - RIIC FIT module rev. 1.30 or earlier is used.
+ *                                    - RX device operates as both the master and the slave 
+ *                                      in multi-master communication.
+ *                                    - An arbitration-lost is detected when communicating as the master.
+ *                                    - Communication other than master reception or slave reception is performed.
+ *         : 14.11.2014 1.50     Added RX113 support.
+ *         : 09.10.2014 1.60     Added RX71M support.
+ *         : 20.10.2014 1.70     Added RX231 support.
+ *         : 31.10.2015 1.80     Added RX130, RX230, RX23T support.
+ *         : 04.03.2016 1.90     Added RX24T support.
+ *         : 01.10.2016 2.00     Added RX65N support.
+ *         : 02.06.2017 2.10     Changed minor version to '10' for RX24U support.
+ *         : 31.08.2017 2.20     Changed minor version to '20' for RX65N-2MB and RX130-512KB support.
+ *         : 30.10.2017 2.30     Changed minor version to '30' for RX66T support.
+ *         : 03.12.2018 2.31     Changed minor version to '31' for update of xml file.
+ *         : 15.10.2018 2.40     Changed minor version to '40' for RX72T support.
+ *         : 20.05.2019 2.41     Added support for GNUC and ICCRX.
+ *                               Fixed coding style.
+ *         : 20.06.2019 2.42     Changed minor version to '42' for RX23W support. 
+ *         : 30.07.2019 2.43     Changed minor version to '43' for RX72M support.
+ *         : 10.10.2019 2.44     Changed minor version to '44' for RX13T support.
+ *         : 22.11.2019 2.45     Changed minor version to '45' for RX66N and RX72N support.
+ *         : 10.03.2020 2.46     Changed minor version to '46' for RX23E-A support.
+ *         : 30.10.2020 2.47     Changed minor version to '47' for e2studio 2020-10 support.
+ *         : 30.06.2021 2.48     Changed minor version to '48' for RX671 support.
+ *         : 31.07.2021 2.49     Changed minor version to '49' for RX140 support.
+ *         : 31.12.2021 2.50     Changed minor version to '50' for RX660 support.
+ *         : 16.12.2022 2.60     Fixed processing error of riic_bps_calc.
+ *         : 31.03.2023 2.70     Changed minor version to '70' for RX26T support.
+ *                               Fixed to comply with GSCE Coding Standards Rev.6.5.0.
+ *                               Added RX671 Demo, RX72N Demo.
+ *                               Apply a digital noise filter circuit to the riic_bps_calc function.
+ *                               Added new macros for SCL rise time and SCL fall time.
+ *         : 29.05.2023 2.80     Changed minor version to '80' for RX23E-B support.
+ *                               Fixed to comply with GSCE Coding Standards Rev.6.5.0
+ *         : 10.10.2023 2.90     Changed EEI and TEI default interrupt priority levels
+ *                                for devices with EEI and TEI assigned to group interrupts,
+ *                                to be higher than TXI and RXI priority levels in MDF file.
+ *                               Modified source code comments of RIIC_CFG_CHi_RXI_INT_PRIORITY,
+ *                                RIIC_CFG_CHi_TXI_INT_PRIORITY, RIIC_CFG_CHi_EEI_INT_PRIORITY,
+ *                                RIIC_CFG_CHi_TEI_INT_PRIORITY (i = 0 to 2) in r_riic_rx_config.h.
+ *         : 01.08.2024 2.91     Fixed issues related to EEI and TEI interrupt priority levels for RX651 in MDF file.
+ *         : 08.08.2024 3.00     Added RX260, RX261 support.
+ *         : 15.03.2025 3.01     Updated disclaimer.
+ **********************************************************************************************************************/
+/* Guards against multiple inclusion */
+#ifndef RIIC_IF_H
+    #define RIIC_IF_H
+/***********************************************************************************************************************
+ Includes   <System Includes> , "Project Includes"
+ **********************************************************************************************************************/
+/* Includes board and MCU related header files. */
+    #include "platform.h"
+/* Used for configuring the RIIC code */
+    #include "r_riic_rx_config.h"
+
+R_BSP_PRAGMA_UNPACK
+/***********************************************************************************************************************
+ Macro definitions
+ **********************************************************************************************************************/
+#if R_BSP_VERSION_MAJOR < 5
+    #error "This module must use BSP module of Rev.5.00 or higher. Please use the BSP module of Rev.5.00 or higher."
+#endif
+
+/* Version Number of API. */
+    #define RIIC_VERSION_MAJOR      (3)
+    #define RIIC_VERSION_MINOR      (01)
+
+/*----------------------------------------------------------------------------*/
+/*   Defines the argument of the R_RIIC_Control function.                     */
+/*----------------------------------------------------------------------------*/
+    #define RIIC_GEN_START_CON      ((uint8_t)(0x01))   /* Generate start condition */
+    #define RIIC_GEN_STOP_CON       ((uint8_t)(0x02))   /* Generate stop condition */
+    #define RIIC_GEN_RESTART_CON    ((uint8_t)(0x04))   /* Generate restart condition */
+    #define RIIC_GEN_SDA_HI_Z       ((uint8_t)(0x08))   /* Generate nack output */
+    #define RIIC_GEN_SCL_ONESHOT    ((uint8_t)(0x10))   /* Geenrate one-shot scl clock output */
+    #define RIIC_GEN_RESET          ((uint8_t)(0x20))   /* Reset riic module */
+
+/*----------------------------------------------------------------------------*/
+/*   Define values of channel state flag.                                     */
+/*----------------------------------------------------------------------------*/
+    #define RIIC_NO_INIT        ((riic_ch_dev_status_t)(0)) /* Uninitialized state */
+    #define RIIC_IDLE           ((riic_ch_dev_status_t)(1)) /* Successful operation */
+    #define RIIC_FINISH         ((riic_ch_dev_status_t)(2)) /* Already idle state */
+    #define RIIC_NACK           ((riic_ch_dev_status_t)(3)) /* Already idle state */
+    #define RIIC_COMMUNICATION  ((riic_ch_dev_status_t)(4)) /* Successful operation */
+    #define RIIC_AL             ((riic_ch_dev_status_t)(5)) /* Arbitration lost */
+    #define RIIC_TMO            ((riic_ch_dev_status_t)(6)) /* Time Out */
+    #define RIIC_ERROR          ((riic_ch_dev_status_t)(7)) /* error */
+
+/***********************************************************************************************************************
+ Typedef definitions
+ **********************************************************************************************************************/
+/*----------------------------------------------------------------------------*/
+/*   Define return values and values of channel state flag.                   */
+/*----------------------------------------------------------------------------*/
+typedef uint8_t riic_ch_dev_status_t;
+
+typedef enum
+{
+    RIIC_SUCCESS = 0U, /* Successful operation */
+    RIIC_ERR_LOCK_FUNC, /* Lock has already been acquired by another task. */
+    RIIC_ERR_INVALID_CHAN, /* None existent channel number */
+    RIIC_ERR_INVALID_ARG, /* Parameter error */
+    RIIC_ERR_NO_INIT, /* Uninitialized state */
+    RIIC_ERR_BUS_BUSY, /* Channel is on communication. */
+    RIIC_ERR_AL, /* Arbitration lost error */
+    RIIC_ERR_TMO, /* Time Out error */
+    RIIC_ERR_OTHER /* Other error */
+} riic_return_t;
+
+/*----------------------------------------------------------------------------*/
+/*   Define iic information structure type.                                   */
+/*----------------------------------------------------------------------------*/
+/* ---- Callback function type. ---- */
+/******************************************************************************
+ * Function Name: riic_callback
+ * Description  : .
+ * Return Value : .
+ *****************************************************************************/
+typedef void (*riic_callback) (void); /* Callback function type */
+
+/* ---- IIC Information structure type. ---- */
+typedef volatile struct
+{
+    uint8_t              rsv2; /* reserved */
+    uint8_t              rsv1; /* reserved */
+    riic_ch_dev_status_t dev_sts; /* Device status flag */
+    uint8_t              ch_no; /* Channel No. */
+    riic_callback        callbackfunc; /* Callback function */
+    uint32_t             cnt2nd; /* 2nd Data Counter */
+    uint32_t             cnt1st; /* 1st Data Counter */
+    uint8_t            * p_data2nd; /* Pointer for 2nd Data buffer */
+    uint8_t            * p_data1st; /* Pointer for 1st Data buffer */
+    uint8_t            * p_slv_adr; /* Pointer for Slave address buffer */
+} riic_info_t;
+
+/*----------------------------------------------------------------------------*/
+/*   Define riic status structure type.                                       */
+/*----------------------------------------------------------------------------*/
+typedef union
+{
+    uint32_t LONG;
+    R_BSP_ATTRIB_STRUCT_BIT_ORDER_LEFT_21
+    (
+        uint32_t rsv :12, /* reserve */
+        uint32_t AAS2 :1, /* Slave2 address detection flag */
+        uint32_t AAS1 :1, /* Slave1 address detection flag */
+        uint32_t AAS0 :1, /* Slave0 address detection flag */
+        uint32_t GCA :1, /* Generalcall address detection flag */
+        uint32_t DID :1, /* DeviceID address detection flag */
+        uint32_t HOA :1, /* Host address detection flag */
+        uint32_t MST :1, /* Master mode / Slave mode flag */
+        uint32_t TMO :1, /* Time out flag */
+        uint32_t AL :1, /* Arbitration lost detection flag */
+        uint32_t SP :1, /* Stop condition detection flag */
+        uint32_t ST :1, /* Start condition detection flag */
+        uint32_t RBUF :1, /* Receive buffer status flag */
+        uint32_t SBUF :1, /* Send buffer status flag */
+        uint32_t SCLO :1, /* SCL pin output control status */
+        uint32_t SDAO :1, /* SDA pin output control status */
+        uint32_t SCLI :1, /* SCL pin level */
+        uint32_t SDAI :1, /* SDA pin level */
+        uint32_t NACK :1, /* NACK detection flag */
+        uint32_t TRS :1, /* Send mode / Receive mode flag */
+        uint32_t BSY :1 /* Bus status flag */
+    ) BIT;
+} riic_mcu_status_t;
+
+/***********************************************************************************************************************
+ Exported global variables
+ **********************************************************************************************************************/
+/* ---- Channel status ---- */
+extern riic_ch_dev_status_t g_riic_ChStatus[];
+
+/***********************************************************************************************************************
+ Exported global functions (to be accessed by other files)
+ **********************************************************************************************************************/
+/* ---- RIIC Driver API functions ---- */
+/******************************************************************************
+ * Function Name: R_RIIC_Open
+ * Description  : .
+ * Argument     : riic_return_t
+ * Return Value : .
+ *****************************************************************************/
+riic_return_t R_RIIC_Open (riic_info_t *);
+
+/******************************************************************************
+ * Function Name: R_RIIC_MasterSend
+ * Description  : .
+ * Argument     : riic_info_t
+ * Return Value : .
+ *****************************************************************************/
+riic_return_t R_RIIC_MasterSend (riic_info_t *);
+
+/******************************************************************************
+ * Function Name: R_RIIC_MasterReceive
+ * Description  : .
+ * Argument     : riic_info_t
+ * Return Value : .
+ *****************************************************************************/
+riic_return_t R_RIIC_MasterReceive (riic_info_t *);
+
+/******************************************************************************
+ * Function Name: R_RIIC_SlaveTransfer
+ * Description  : .
+ * Argument     : riic_info_t
+ * Return Value : .
+ *****************************************************************************/
+riic_return_t R_RIIC_SlaveTransfer (riic_info_t *);
+
+/******************************************************************************
+ * Function Name: R_RIIC_GetStatus
+ * Description  : .
+ * Arguments    : riic_info_t
+ *              : riic_mcu_status_t
+ * Return Value : .
+ *****************************************************************************/
+riic_return_t R_RIIC_GetStatus (riic_info_t *, riic_mcu_status_t *);
+
+/******************************************************************************
+ * Function Name: R_RIIC_Control
+ * Description  : .
+ * Arguments    : riic_info_t
+ *              : ctrl_ptn
+ * Return Value : .
+ *****************************************************************************/
+riic_return_t R_RIIC_Control (riic_info_t *, uint8_t ctrl_ptn);
+
+/******************************************************************************
+ * Function Name: R_RIIC_Close
+ * Description  : .
+ * Argument     : riic_return_t
+ * Return Value : .
+ *****************************************************************************/
+riic_return_t R_RIIC_Close (riic_info_t *);
+
+/******************************************************************************
+ * Function Name: R_RIIC_GetVersion
+ * Description  : .
+ * Return Value : .
+ *****************************************************************************/
+uint32_t      R_RIIC_GetVersion (void);
+
+R_BSP_PRAGMA_PACKOPTION
+#endif /* RIIC_IF_H */
+

--- a/drivers/rx/rdp/src/r_riic_rx/r_riic_rx_if.h
+++ b/drivers/rx/rdp/src/r_riic_rx/r_riic_rx_if.h
@@ -268,6 +268,7 @@ riic_return_t R_RIIC_Close (riic_info_t *);
  *****************************************************************************/
 uint32_t      R_RIIC_GetVersion (void);
 
+riic_return_t riic_bps_calc (riic_info_t *, uint16_t kbps);
 R_BSP_PRAGMA_PACKOPTION
 #endif /* RIIC_IF_H */
 

--- a/drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
+++ b/drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
@@ -162,7 +162,7 @@ static void riic_reset_set (riic_info_t *);
 static void riic_all_reset (riic_info_t *);
 static void riic_clear_ir_flag (riic_info_t *);
 
-static riic_return_t riic_bps_calc (riic_info_t *, uint16_t kbps);
+riic_return_t riic_bps_calc (riic_info_t *, uint16_t kbps);
 
 /* static double riic_check_freq(void); */
 
@@ -3784,7 +3784,7 @@ static void riic_clear_ir_flag(riic_info_t * p_riic_info)
  * Return Value : RIIC_SUCCESS                   ; Successful operation, communication state
  *              : RIIC_ERR_OTHER                 ; Other error
  **********************************************************************************************************************/
-static riic_return_t riic_bps_calc(riic_info_t * p_riic_info, uint16_t kbps)
+riic_return_t riic_bps_calc(riic_info_t * p_riic_info, uint16_t kbps)
 {
     volatile uint8_t uctmp;
 

--- a/drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
+++ b/drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
@@ -1985,7 +1985,6 @@ static riic_return_t riic_after_gen_start_cond(riic_info_t * p_riic_info)
 
     /* Creates the register pointer for the specified RIIC channel. */
     volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
-    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
 
     /* IIC mode? */
     switch (riic_api_info[p_riic_info->ch_no].N_Mode)
@@ -3719,7 +3718,6 @@ static void riic_all_reset(riic_info_t * p_riic_info)
 static void riic_clear_ir_flag(riic_info_t * p_riic_info)
 {
     uint8_t internal_flag = 0x00; /* Determines whether reinitialization is necessary. */
-    volatile uint8_t uctmp = 0x00;
 
     /* Creates the register pointer for the specified RIIC channel. */
     volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);

--- a/drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
+++ b/drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx.c
@@ -1,0 +1,5052 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+ * File Name    : r_riic_rx.c
+ * Description  : Functions for using RIIC on RX devices. 
+ **********************************************************************************************************************/
+/**********************************************************************************************************************
+ * History      : DD.MM.YYYY Version  Description
+ *              : 01.07.2013 1.00     First Release
+ *              : 30.09.2013 1.10     Change symbol of return value and status
+ *              : 08.10.2013 1.20     Modified processing for the I/O register initialization and mode transition 
+ *                                     when a stop condition is detected while the slave is communicating.
+ *                                    Modified processing for mode transition when an API function is called
+ *                                     while the bus is busy.
+ *                                    Modified processing for mode transition
+ *                                     when an arbitration lost occurred and the addresses do not match.
+ *                                    Modified incorrect slave transmission after the master reception.
+ *                                    Modified processing for the I/O register initialization
+ *                                     when generating a start condition and receiving the slave address.
+ *              : 17.07.2014 1.30     Added the processes for the timeout detection.
+ *                                    Added the call back function for the timeout detection.
+ *                                    The number of channels varies depending on the MCU.
+ *                                    Therefore, process for each channel is set 
+ *                                    in the source file(r_riic_rx###.c) for each MCU folder
+ *                                    instead of this file.
+ *                                    Similarly, PORT register, ICU register, SYSTEM register also varies
+ *                                    depending on the MCU.
+ *                                    Therefore, process for port function assignment and interrupt settings
+ *                                    and module stop enable/disble is set in the source file(r_riic_rx###.c) 
+ *                                    for each MCU folder instead of this file.
+ *                                    (### is 111 or 64m)
+ *              : 22.09.2014 1.40     The module is updated to measure the issue that slave communication 
+ *                                    is not available after an arbitration-lost occurs and the bus is locked. 
+ *                                      The issue occurs when the following four conditions are all met.
+ *                                         - RIIC FIT module rev. 1.30 or earlier is used.
+ *                                         - RX device operates as both the master and the slave 
+ *                                           in multi-master communication.
+ *                                         - An arbitration-lost is detected when communicating as the master.
+ *                                         - Communication other than master reception or slave reception is performed.
+ *              : 14.11.2014 1.50     Added RX113 support.
+ *              : 09.10.2014 1.60     Added RX71M support.
+ *              : 20.10.2014 1.70     Added RX231 support.
+ *              : 31.10.2015 1.80     Added RX130, RX230, RX23T support.
+ *              : 04.03.2016 1.90     Added RX24T support.
+ *                                    Modified calculation processing for ICBRH and ICBRL registers value
+ *              : 01.10.2016 2.00     Fixed a program according to the Renesas coding rules.
+ *              : 02.06.2017 2.10     Deleted interrupt functions of RIIC3.
+ *                                    Fixed processing of the riic_bps_calc function.
+ *              : 27.04.2018 2.30     Added "for", "while" and "do while" comment.
+ *              : 15.10.2018 2.40     Added RX72T support.
+ *              : 20.05.2019 2.41     Added support for GNUC and ICCRX.
+ *                                    Fixed coding style.
+ *              : 20.06.2019 2.42     Added RX23W support.
+ *              : 30.07.2019 2.43     Added RX72M support.
+ *              : 10.10.2019 2.44     Added RX13T support.
+ *              : 22.11.2019 2.45     Added RX66N, RX72N support.
+ *                                    Modified comment of API function to Doxygen style.
+ *              : 30.06.2021 2.48     Modified "riic information" comment.
+ *                                    Modified the problem of recursive call.
+ *              : 16.12.2022 2.60     Fixed processing error of riic_bps_calc.
+ *              : 31.03.2023 2.70     Fixed to comply with GSCE Coding Standards Rev.6.5.0.
+ *                                    Apply a digital noise filter circuit to the riic_bps_calc function.
+ *                                    Added new macros for SCL rise time and SCL fall time.
+ *              : 15.03.2025 3.01     Updated disclaimer.
+ **********************************************************************************************************************/
+
+/***********************************************************************************************************************
+ Includes   <System Includes> , "Project Includes"
+ **********************************************************************************************************************/
+/* Defines for RIIC support */
+#include "r_riic_rx_if.h"
+#include "r_riic_rx_private.h"
+
+/***********************************************************************************************************************
+Exported global variables (to be accessed by other files)
+***********************************************************************************************************************/
+/*----------------------------------------------------------------------------*/
+/*   riic information                                                          */
+/*----------------------------------------------------------------------------*/
+riic_ch_dev_status_t g_riic_ChStatus[MAX_RIIC_CH_NUM]; /* Channel status */
+
+/*----------------------------------------------------------------------------*/
+/*   Callback function                                                        */
+/*----------------------------------------------------------------------------*/
+volatile riic_callback g_riic_callbackfunc_m[MAX_RIIC_CH_NUM];
+volatile riic_callback g_riic_callbackfunc_s[MAX_RIIC_CH_NUM];
+
+/***********************************************************************************************************************
+ Private global variables and functions
+ **********************************************************************************************************************/
+/*----------------------------------------------------------------------------*/
+/*   riic information                                                          */
+/*----------------------------------------------------------------------------*/
+static riic_info_t * priic_info_m[MAX_RIIC_CH_NUM]; /* IIC driver information */
+static riic_info_t * priic_info_s[MAX_RIIC_CH_NUM]; /* IIC driver information */
+
+static riic_api_event_t riic_api_event[MAX_RIIC_CH_NUM]; /* Event flag */
+static riic_api_info_t riic_api_info[MAX_RIIC_CH_NUM]; /* Internal status management */
+
+/*----------------------------------------------------------------------------*/
+/*   Main processing of RIIC Driver API functions                             */
+/*----------------------------------------------------------------------------*/
+static riic_return_t riic_open (riic_info_t *);
+static riic_return_t riic_master_send (riic_info_t *);
+static riic_return_t riic_master_receive (riic_info_t *);
+static riic_return_t riic_master_send_receive (riic_info_t *);
+static riic_return_t riic_slave_transfer (riic_info_t *);
+static void riic_getstatus (riic_info_t *, riic_mcu_status_t *);
+static riic_return_t riic_control (riic_info_t *, uint8_t ctrl_ptn);
+static void riic_close (riic_info_t *);
+static riic_return_t r_riic_advance (riic_info_t *);
+static riic_return_t riic_advance (riic_info_t *);
+
+/*----------------------------------------------------------------------------*/
+/*   Called from function table                                               */
+/*----------------------------------------------------------------------------*/
+static riic_return_t riic_func_table (riic_api_event_t, riic_info_t *);
+static riic_return_t riic_init_driver (riic_info_t *);
+static riic_return_t riic_generate_start_cond (riic_info_t *);
+static riic_return_t riic_after_gen_start_cond (riic_info_t *);
+static riic_return_t riic_after_send_slvadr (riic_info_t *);
+static riic_return_t riic_after_receive_slvadr (riic_info_t *);
+static riic_return_t riic_write_data_sending (riic_info_t *);
+static riic_return_t riic_read_data_receiving (riic_info_t *);
+static riic_return_t riic_after_dtct_stop_cond (riic_info_t *);
+static riic_return_t riic_arbitration_lost (riic_info_t *);
+static riic_return_t riic_nack (riic_info_t *);
+static riic_return_t riic_enable_slave_transfer (riic_info_t *);
+static riic_return_t riic_time_out (riic_info_t *);
+
+/*----------------------------------------------------------------------------*/
+/*   Other function                                                           */
+/*----------------------------------------------------------------------------*/
+static void riic_api_mode_event_init (riic_info_t *, riic_api_mode_t);
+static void riic_api_mode_set (riic_info_t *, riic_api_mode_t);
+static void riic_api_status_set (riic_info_t *, riic_api_status_t);
+static void riic_set_ch_status (riic_info_t *, riic_ch_dev_status_t);
+static riic_return_t riic_check_chstatus_start (riic_info_t *);
+static riic_return_t riic_check_chstatus_advance (riic_info_t *);
+static void riic_enable (riic_info_t *);
+static void riic_disable (riic_info_t *);
+static void riic_init_io_register (riic_info_t *);
+static void riic_slv_addr_match_int_enable (riic_info_t *);
+static void riic_int_enable (riic_info_t *);
+static void riic_int_disable (riic_info_t *);
+static void riic_int_icier_setting (riic_info_t *, uint8_t New_icier);
+static void riic_set_frequency (riic_info_t *);
+static bool riic_check_bus_busy (riic_info_t *);
+static void riic_start_cond_generate (riic_info_t *);
+static void riic_re_start_cond_generate (riic_info_t *);
+static void riic_stop_cond_generate (riic_info_t *);
+static void riic_set_sending_data (riic_info_t *, uint8_t *p_data);
+static uint8_t riic_get_receiving_data (riic_info_t *);
+static void riic_receive_wait_setting (riic_info_t *);
+static void riic_receive_pre_end_setting (riic_info_t *);
+static void riic_receive_end_setting (riic_info_t *);
+static void riic_reset_clear (riic_info_t *);
+static void riic_reset_set (riic_info_t *);
+static void riic_all_reset (riic_info_t *);
+static void riic_clear_ir_flag (riic_info_t *);
+
+static riic_return_t riic_bps_calc (riic_info_t *, uint16_t kbps);
+
+/* static double riic_check_freq(void); */
+
+#ifdef TN_RXA012A
+static void riic_timeout_counter_clear (uint8_t channel);
+#endif
+
+/*----------------------------------------------------------------------------*/
+/*   function table                                                           */
+/*----------------------------------------------------------------------------*/
+static const riic_mtx_t gc_riic_mtx_tbl[RIIC_STS_MAX][RIIC_EV_MAX] =
+{
+    /* Uninitialized state */
+    {
+        { RIIC_EV_INIT, riic_init_driver }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, NULL }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, NULL }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, NULL }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, NULL }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, NULL }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, NULL }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, NULL }, /* Stop Condition Generation Interrupt */
+        { RIIC_EV_INT_AL, NULL }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, NULL }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, NULL }, /* Time out Interrupt */
+    },
+
+    /* Idle state */
+    {
+        { RIIC_EV_INIT, NULL }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, riic_enable_slave_transfer }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, riic_generate_start_cond }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, NULL }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, NULL }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, NULL }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, NULL }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, NULL }, /* Stop Condition Generation Interrupt */
+        { RIIC_EV_INT_AL, NULL }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, NULL }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, NULL }, /* Time out Interrupt */
+    },
+
+    /* Idle state on enable slave transfer */
+    {
+        { RIIC_EV_INIT, NULL }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, NULL }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, riic_generate_start_cond }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, NULL }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, riic_after_receive_slvadr }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, NULL }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, riic_after_receive_slvadr }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, NULL }, /* Stop Condition Generation Interrupt */
+        { RIIC_EV_INT_AL, NULL }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, NULL }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, NULL }, /* Time out Interrupt */
+    },
+
+    /* Start condition generation completion wait state */
+    {
+        { RIIC_EV_INIT, NULL }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, NULL }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, NULL }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, riic_after_gen_start_cond }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, NULL }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, NULL }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, NULL }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, NULL }, /* Stop Condition Generation Interrupt */
+        { RIIC_EV_INT_AL, riic_arbitration_lost }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, riic_nack }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, riic_time_out }, /* Time out Interrupt */
+    },
+
+    /* Slave address [Write] transmission completion wait state */
+    {
+        { RIIC_EV_INIT, NULL }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, NULL }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, NULL }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, NULL }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, riic_after_send_slvadr }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, NULL }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, NULL }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, NULL }, /* Stop Condition Generation Interrupt */
+        { RIIC_EV_INT_AL, riic_arbitration_lost }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, riic_nack }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, riic_time_out }, /* Time out Interrupt */
+    },
+
+    /* Slave address [Read] transmission completion wait state */
+    {
+        { RIIC_EV_INIT, NULL }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, NULL }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, NULL }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, NULL }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, NULL }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, NULL }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, riic_after_send_slvadr }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, NULL }, /* Stop Condition Generation Interrupt  */
+        { RIIC_EV_INT_AL, riic_arbitration_lost }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, riic_nack }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, riic_time_out }, /* Time out Interrupt */
+    },
+
+    /* Data transmission completion wait state */
+    {
+        { RIIC_EV_INIT, NULL }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, NULL }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, NULL }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, NULL }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, NULL }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, riic_write_data_sending }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, NULL }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, NULL }, /* Stop Condition Generation Interrupt */
+        { RIIC_EV_INT_AL, riic_arbitration_lost }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, riic_nack }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, riic_time_out }, /* Time out Interrupt */
+    },
+
+    /* Data reception completion wait state */
+    {
+        { RIIC_EV_INIT, NULL }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, NULL }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, NULL }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, NULL }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, NULL }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, NULL }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, riic_read_data_receiving }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, NULL }, /* Stop Condition Generation Interrupt */
+        { RIIC_EV_INT_AL, riic_arbitration_lost }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, riic_nack }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, riic_time_out }, /* Time out Interrupt */
+    },
+
+    /* Stop condition generation completion wait state */
+    {
+        { RIIC_EV_INIT, NULL }, /* IIC Driver Initialization */
+        { RIIC_EV_EN_SLV_TRANSFER, NULL }, /* Enable Slave Transfer */
+        { RIIC_EV_GEN_START_COND, NULL }, /* Start Condition Generation */
+        { RIIC_EV_INT_START, NULL }, /* Start Condition Generation Interrupt */
+        { RIIC_EV_INT_ADD, NULL }, /* Address Sending Interrupt */
+        { RIIC_EV_INT_SEND, NULL }, /* Data Sending Interrupt */
+        { RIIC_EV_INT_RECEIVE, NULL }, /* Data Receiving Interrupt */
+        { RIIC_EV_INT_STOP, riic_after_dtct_stop_cond }, /* Stop Condition Generation Interrupt */
+        { RIIC_EV_INT_AL, NULL }, /* Arbitration-Lost Interrupt */
+        { RIIC_EV_INT_NACK, riic_nack }, /* No Acknowledge Interrupt */
+        { RIIC_EV_INT_TMO, riic_time_out }, /* Time out Interrupt */
+    },
+};
+
+/**********************************************************************************************************************
+ * Function Name: R_RIIC_Open
+ *****************************************************************************************************************/ /**
+ * @brief This function initializes the RIIC FIT module. This function must be called before calling any other API 
+ *        functions.
+ * @param[in,out] *p_riic_info
+ *             This is the pointer to the I2C communication information structure.
+ * @retval    RIIC_SUCCESS             Processing completed successfully
+ * @retval    RIIC_ERR_LOCK_FUNC       The API is locked by the other task
+ * @retval    RIIC_ERR_INVALID_CHAN    Nonexistent channel
+ * @retval    RIIC_ERR_INVALID_ARG     Invalid parameter
+ * @retval    RIIC_ERR_OTHER           The event occurred is invalid in the current state
+ * @details   Performs the initialization to start the RIIC communication. Sets the RIIC channel specified by the 
+ *            parameter. If the state of the channel is 'uninitialized (RIIC_NO_INIT)', the following processes are 
+ *            performed. \n
+ *            \li Setting the state flag.
+ *            \li Setting I/O ports.
+ *            \li Allocating I2C output ports.
+ *            \li Cancelling RIIC module-stop state.
+ *            \li Initializing variables used by the API.
+ *            \li Initializing the RIIC registers used for the RIIC communication.
+ *            \li Disabling the RIIC interrupts.
+ * @note      None
+ */
+riic_return_t R_RIIC_Open(riic_info_t * p_riic_info)
+{
+    bool chk = RIIC_FALSE;
+    riic_return_t ret;
+
+    /* ---- CHECK ARGUMENTS ---- */
+#if (1U == RIIC_CFG_PARAM_CHECKING_ENABLE)
+    if (NULL == p_riic_info)
+    {
+        return RIIC_ERR_INVALID_ARG;
+    }
+
+    /* ---- CHECK CHANNEL ---- */
+    if (false == riic_mcu_check_channel(p_riic_info->ch_no))
+    {
+        return RIIC_ERR_INVALID_CHAN;
+    }
+#endif
+
+    /*  ---- RIIC HARDWARE LOCK ---- */
+    chk = riic_mcu_hardware_lock(p_riic_info->ch_no);
+    if (RIIC_FALSE == chk)
+    {
+        /* Lock has already been acquired by another task. Needs to try again later. */
+        return RIIC_ERR_LOCK_FUNC;
+    }
+
+    /* ---- INITIALIZE RIIC INTERNAL STATUS INFORMATION ---- */
+    g_riic_ChStatus[p_riic_info->ch_no] = RIIC_NO_INIT;
+    p_riic_info->dev_sts                = RIIC_NO_INIT;
+
+    /* ---- INITIALIZE CHANNEL ---- */
+    /* Calls the API function. */
+    ret = riic_open(p_riic_info);
+
+    return ret;
+} /* End of function R_RIIC_Open() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_open
+ * Description  : sub function of R_RIIC_Open(). Initializes the I/O register for RIIC control.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_open(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+
+    /* Updates the channel status. */
+    riic_set_ch_status(p_riic_info, RIIC_IDLE);
+
+    /* Initialize API status on RAM */
+    riic_api_mode_event_init(p_riic_info, RIIC_MODE_NONE);
+
+    /* Sets the internal status. (Internal information initialization) */
+    riic_api_status_set(p_riic_info, RIIC_STS_NO_INIT);
+
+    /* Enables the IIC peripheral registers. */
+    /* Includes I/O register read operation at the end of the following function. */
+    /* RIIC HARDWARE ENABLE */
+    riic_mcu_power_on(p_riic_info->ch_no);
+
+    /* Initializes the IIC driver. */
+    ret = riic_func_table(RIIC_EV_INIT, p_riic_info);
+
+    if (RIIC_SUCCESS != ret)
+    {
+        ret = RIIC_ERR_OTHER;
+
+        /* Updates the channel status. */
+        riic_set_ch_status(p_riic_info, RIIC_NO_INIT);
+    }
+    else
+    {
+        /* Registers a callback function for supported interrupts. */
+        riic_mcu_int_init(p_riic_info->ch_no);
+
+#if (1U == RIIC_CFG_PORT_SET_PROCESSING)
+        /* Init Port Processing */
+        /* Ports open setting */
+        /* Includes I/O register read operation at the end of the following function. */
+        riic_mcu_io_open(p_riic_info->ch_no);
+
+        /* Enables RIIC multi-function pin controller. */
+        /* Includes I/O register read operation at the end of the following function. */
+        riic_mcu_mpc_enable(p_riic_info->ch_no);
+#endif
+    }
+
+    return ret;
+} /* End of function riic_open() */
+
+/**********************************************************************************************************************
+ * Function Name: R_RIIC_MasterSend
+ *****************************************************************************************************************/ /**
+ * @brief Starts master transmission. Changes the transmit pattern according to the parameters. Operates batched 
+ *        processing until stop condition generation.
+ * @param[in] *p_riic_info
+ *             This is the pointer to the I2C communication information structure. The transmit patterns can be 
+ *             selected from four patterns by the parameter setting.
+ * @retval    RIIC_SUCCESS             Processing completed successfully
+ * @retval    RIIC_ERR_INVALID_CHAN    The channel is nonexistent
+ * @retval    RIIC_ERR_INVALID_ARG     The parameter is invalid
+ * @retval    RIIC_ERR_NO_INIT         Uninitialized state
+ * @retval    RIIC_ERR_BUS_BUSY        The bus state is busy
+ * @retval    RIIC_ERR_AL              Arbitration-lost error occurred
+ * @retval    RIIC_ERR_TMO             Timeout is detected
+ * @retval    RIIC_ERR_OTHER           The event occurred is invalid in the current state
+ * @details   Starts the RIIC master transmission. The transmission is performed with the RIIC channel and transmit 
+ *            pattern specified by parameters. If the state of the channel is 'idle (RIIC_IDLE, RIIC_FINISH,  or 
+ *            RIIC_NACK)', the following processes are performed. \n
+ *            \li Setting the state flag.
+ *            \li Initializing variables used by the API.
+ *            \li Enabling the RIIC interrupts.
+ *            \li Generating a start condition.
+ * 
+ *            This function returns RIIC_SUCCESS as a return value when the processing up to the start condition 
+ *            generation ends normally. This function returns RIIC_ERR_BUS_BUSY as a return value when the following 
+ *            conditions are met to the start condition generation ends normally. (Note.1) \n
+ *            \li The internal status bit is in busy state.
+ *            \li Either SCL or SDA line is in low state. 
+ * 
+ *            The transmission processing is performed sequentially in subsequent interrupt processing after this 
+ *            function return RIIC_SUCCESS. Section "2.4 Usage of Interrupt Vector" in the application note should be 
+ *            refered for the interrupt to be used. For master transmission, the interrupt generation timing should be 
+ *            refered from "6.2.1 Master transmission" in the application note. \n
+ *            After issuing a stop condition at the end of transmission, the callback function specified by the 
+ *            argument is called. \n
+ *            The transmission completion is performed normally or not, can be confirmed by checking the device status 
+ *            flag specified by the argument or the channel status flag g_riic_ChStatus [], that is to be 
+ *            "RIIC_FINISH" for normal completion.\n
+ *            Notes:\n
+ *            1. When SCL and SDA pin is not external pull-up, this function may return RIIC_ERR_BUS_BUSY by
+ *               detecting either SCL or SDA line is as in low state.
+ * @note      Available settings for each pattern see Section 3 in the application note for details.
+ */
+riic_return_t R_RIIC_MasterSend(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+
+    /* ---- CHECK ARGUMENTS ---- */
+#if (1U == RIIC_CFG_PARAM_CHECKING_ENABLE)
+    if ((((NULL == p_riic_info) || ((0 == p_riic_info->cnt1st) && ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data1st)))
+            || ((0 == p_riic_info->cnt2nd) && ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data2nd)))
+            || (NULL == p_riic_info->callbackfunc))
+    {
+        return RIIC_ERR_INVALID_ARG;
+    }
+
+    /* ---- CHECK CHANNEL ---- */
+    if (false == riic_mcu_check_channel(p_riic_info->ch_no))
+    {
+        return RIIC_ERR_INVALID_CHAN;
+    }
+#endif
+
+    /* Calls the API function. */
+    ret = riic_master_send(p_riic_info);
+
+    return ret;
+} /* End of function R_RIIC_MasterSend() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_master_send
+ * Description  : sub function of R_RIIC_MasterSend().
+ *              : Generates the start condition. Starts the master transmission.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_NO_INIT               ; Uninitialized state
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                   ; Time out error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_master_send(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+    riic_callback callbackfunc = NULL;
+
+    /* Checks the channel status. */
+    ret = riic_check_chstatus_start(p_riic_info);
+
+    if (RIIC_SUCCESS != ret)
+    {
+        return ret;
+    }
+
+    /* Updates the channel status. */
+    riic_set_ch_status(p_riic_info, RIIC_COMMUNICATION);
+
+    /* Initialize API status on RAM */
+    riic_api_mode_event_init(p_riic_info, RIIC_MODE_M_SEND);
+
+    /* Copy p_riic_info address */
+    priic_info_m[p_riic_info->ch_no] = p_riic_info;
+
+    /* Sets the callback function. */
+    callbackfunc                              = p_riic_info->callbackfunc;
+    g_riic_callbackfunc_m[p_riic_info->ch_no] = callbackfunc;
+
+    /* Generates the start condition.  */
+    ret = riic_func_table(RIIC_EV_GEN_START_COND, p_riic_info);
+
+    if (RIIC_SUCCESS != ret)
+    {
+        /* Initialize API status on RAM */
+        riic_set_ch_status(p_riic_info, RIIC_IDLE);
+        if (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode)
+        {
+            riic_api_mode_set(p_riic_info, RIIC_MODE_NONE);
+            riic_api_mode_set(p_riic_info, RIIC_MODE_S_READY);
+        }
+        else
+        {
+            riic_api_mode_set(p_riic_info, RIIC_MODE_NONE);
+        }
+    }
+
+    return ret;
+} /* End of function riic_master_send() */
+
+/**********************************************************************************************************************
+ * Function Name: R_RIIC_MasterReceive
+ *****************************************************************************************************************/ /**
+ * @brief Starts master reception. Changes the receive pattern according to the parameters. Operates batched processing 
+ *        until stop condition generation.
+ * @param[in] *p_riic_info
+ *             This is the pointer to the I2C communication information structure. The receive pattern can be selected 
+ *             from master reception and master transmit/receive by the parameter setting. 
+ * @retval    RIIC_SUCCESS             Processing completed successfully
+ * @retval    RIIC_ERR_INVALID_CHAN    The channel is nonexistent
+ * @retval    RIIC_ERR_INVALID_ARG     The parameter is invalid
+ * @retval    RIIC_ERR_NO_INIT         Uninitialized state
+ * @retval    RIIC_ERR_BUS_BUSY        The bus state is busy
+ * @retval    RIIC_ERR_AL              Arbitration-lost error occurred
+ * @retval    RIIC_ERR_TMO             Timeout is detected
+ * @retval    RIIC_ERR_OTHER           The event occurred is invalid in the current state
+ * @details   Starts the RIIC master reception. The reception is performed with the RIIC channel and receive pattern 
+ *            specified by parameters. If the state of the channel is 'idle (RIIC_IDLE, RIIC_FINISH, or RIIC_NACK)', 
+ *            the following processes are performed. \n
+ *            \li Setting the state flag.
+ *            \li Initializing variables used by the API.
+ *            \li Enabling the RIIC interrupts.
+ *            \li Generating a start condition.
+ * 
+ *            This function returns RIIC_SUCCESS as a return value when the processing up to the start condition 
+ *            generation ends normally. This function returns RIIC_ERR_BUS_BUSY as a return value when the following 
+ *            conditions are met to the start condition generation ends normally. (Note.1) \n
+ *            \li The internal status bit is in busy state.
+ *            \li Either SCL or SDA line is in low state.
+ * 
+ *            The reception processing is performed sequentially in subsequent interrupt processing after this 
+ *            function return RIIC_SUCCESS. Section "2.4 Usage of Interrupt Vector" in the application note should be 
+ *            refered for the interrupt to be used. For master transmission, the interrupt generation timing should be 
+ *            refered from "6.2.2 Master Reception" in the application note . \n
+ *            After issuing a stop condition at the end of reception, the callback function specified by the argument 
+ *            is called. \n
+ *            The reception completion is performed normally or not, can be confirmed by checking the device status 
+ *            flag specified by the argument or the channel status flag g_riic_ChStatus [], that is to be 
+ *            "RIIC_FINISH" for normal completion.\n
+ *            Notes:\n
+ *            1. When SCL and SDA pin is not external pull-up, this function may return RIIC_ERR_BUS_BUSY by
+ *               detecting either SCL or SDA line is as in low state.
+ * @note      Available settings for each receive pattern see Section 3 in the application note for details.
+ */
+riic_return_t R_RIIC_MasterReceive(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+
+    /* ---- CHECK ARGUMENTS ---- */
+#if (1U == RIIC_CFG_PARAM_CHECKING_ENABLE)
+    /* Parameter check */
+    if ((((((NULL == p_riic_info) || (NULL == p_riic_info->p_slv_adr))
+            || ((0 != p_riic_info->cnt1st) && (NULL == p_riic_info->p_data1st))) || (NULL == p_riic_info->p_data2nd))
+            || (0 == p_riic_info->cnt2nd)) || (NULL == p_riic_info->callbackfunc))
+    {
+        return RIIC_ERR_INVALID_ARG;
+    }
+
+    /* ---- CHECK CHANNEL ---- */
+    if (false == riic_mcu_check_channel(p_riic_info->ch_no))
+    {
+        return RIIC_ERR_INVALID_CHAN;
+    }
+
+#endif
+
+    if (0 == p_riic_info->cnt1st)
+    {
+        /* Calls the API function. */
+        ret = riic_master_receive(p_riic_info);
+    }
+    else
+    {
+        /* Calls the API function. */
+        ret = riic_master_send_receive(p_riic_info);
+    }
+
+    return ret;
+} /* End of function R_RIIC_MasterReceive() */
+
+/***********************************************************************************************************************
+ * Outline      : 
+ * Function Name: riic_master_receive
+ * Description  : sub function of R_RIIC_MasterReceive(). 
+ *              : Generates the start condition. Starts the master reception.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_NO_INIT               ; Uninitialized state
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                   ; Time out error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_master_receive(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+    riic_callback callbackfunc = NULL;
+
+    /* Checks the channel status. */
+    ret = riic_check_chstatus_start(p_riic_info);
+
+    if (RIIC_SUCCESS != ret)
+    {
+        return ret;
+    }
+
+    /* Updates the channel status. */
+    riic_set_ch_status(p_riic_info, RIIC_COMMUNICATION);
+
+    /* Initialize API status on RAM */
+    riic_api_mode_event_init(p_riic_info, RIIC_MODE_M_RECEIVE);
+
+    /* Copy p_riic_info address */
+    priic_info_m[p_riic_info->ch_no] = p_riic_info;
+
+    /* Sets the callback function. */
+    callbackfunc                              = p_riic_info->callbackfunc;
+    g_riic_callbackfunc_m[p_riic_info->ch_no] = callbackfunc;
+
+    /* Generates the start condition. */
+    ret = riic_func_table(RIIC_EV_GEN_START_COND, p_riic_info);
+
+    if (RIIC_SUCCESS != ret)
+    {
+        /* Initialize API status on RAM */
+        riic_set_ch_status(p_riic_info, RIIC_IDLE);
+        if (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode)
+        {
+            riic_api_mode_set(p_riic_info, RIIC_MODE_NONE);
+            riic_api_mode_set(p_riic_info, RIIC_MODE_S_READY);
+        }
+        else
+        {
+            riic_api_mode_set(p_riic_info, RIIC_MODE_NONE);
+        }
+    }
+
+    return ret;
+} /* End of function riic_master_receive() */
+
+/***********************************************************************************************************************
+ * Outline      : 
+ * Function Name: riic_master_send_receive
+ * Description  : sub function of R_RIIC_MasterReceive().
+ *              : Generates the start condition. Starts the master reception.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_NO_INIT               ; Uninitialized state
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                   ; Time out error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_master_send_receive(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+    riic_callback callbackfunc = NULL;
+
+    /* Checks the channel status. */
+    ret = riic_check_chstatus_start(p_riic_info);
+
+    if (RIIC_SUCCESS != ret)
+    {
+        return ret;
+    }
+
+    /* Updates the channel status. */
+    riic_set_ch_status(p_riic_info, RIIC_COMMUNICATION);
+
+    /* Initialize API status on RAM */
+    riic_api_mode_event_init(p_riic_info, RIIC_MODE_M_SEND_RECEIVE);
+
+    /* Copy p_riic_info address */
+    priic_info_m[p_riic_info->ch_no] = p_riic_info;
+
+    /* Sets the callback function. */
+    callbackfunc                              = p_riic_info->callbackfunc;
+    g_riic_callbackfunc_m[p_riic_info->ch_no] = callbackfunc;
+
+    /* Generates the start condition. */
+    ret = riic_func_table(RIIC_EV_GEN_START_COND, p_riic_info);
+
+    if (RIIC_SUCCESS != ret)
+    {
+        /* Initialize API status on RAM */
+        riic_set_ch_status(p_riic_info, RIIC_IDLE);
+        if (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode)
+        {
+            riic_api_mode_set(p_riic_info, RIIC_MODE_NONE);
+            riic_api_mode_set(p_riic_info, RIIC_MODE_S_READY);
+        }
+        else
+        {
+            riic_api_mode_set(p_riic_info, RIIC_MODE_NONE);
+        }
+    }
+
+    return ret;
+} /* End of function riic_master_send_receive() */
+
+/**********************************************************************************************************************
+ * Function Name: R_RIIC_SlaveTransfer
+ *****************************************************************************************************************/ /**
+ * @brief This function performs slave transmission and reception. Changes the transmit and receive pattern according 
+ *        to the parameters.
+ * @param[in] *p_riic_info
+ *             This is the pointer to the I2C communication information structure. The operation can be selected from 
+ *             preparation for slave reception, slave transmission, or both of them by the parameter setting.
+ * @retval    RIIC_SUCCESS             Processing completed successfully
+ * @retval    RIIC_ERR_INVALID_CHAN    The channel is nonexistent
+ * @retval    RIIC_ERR_INVALID_ARG     The parameter is invalid
+ * @retval    RIIC_ERR_NO_INIT         Uninitialized state
+ * @retval    RIIC_ERR_BUS_BUSY        The bus state is busy
+ * @retval    RIIC_ERR_AL              Arbitration-lost error occurred
+ * @retval    RIIC_ERR_TMO             Timeout is detected
+ * @retval    RIIC_ERR_OTHER           The event occurred is invalid in the current state
+ * @details   Prepares for the RIIC slave transmission or slave reception. If this function is called while the master 
+ *            is communicating, an error occurs. Sets the RIIC channel specified by the parameter. If the state of the 
+ *            channel is 'idle (RIIC_IDLE, RIIC_FINISH, or RIIC_NACK)', the following processes are performed. \n
+ *            \li Setting the state flag.
+ *            \li Initializing variables used by the API.
+ *            \li Initializing the RIIC registers used for the RIIC communication.
+ *            \li Enabling the RIIC interrupts.
+ *            \li Setting the slave address and enabling the slave address match interrupt.
+ *
+ *            This function returns RIIC_SUCCESS as a return value when the setting of slave address and permission of 
+ *            slave address match interrupt are completed normally. \n
+ *            The processing of slave transmission or slave reception is performed sequentially in the subsequent 
+ *            interrupt processing. \n
+ *            Section "2.4 Usage of Interrupt Vector" in the application note should be refered for the interrupt to 
+ *            be used. \n
+ *            The interrupt generation timing of slave transmission should be refered from "6.2.4 Slave Transmission" 
+ *            in the application note. The interrupt generation timing for slave reception should be refered from 
+ *            "6.2.5 Slave reception" in the application note. \n
+ *            After detecting the stop condition of slave transmission or slave reception termination, the callback 
+ *            function specified by the argument is called. \n
+ *            The successful completion of slave reception can be checked by confirming the device status flag or 
+ *            channel status flag specified in the argument  g_riic_ChStatus [], that is to be "RIIC_FINISH". The 
+ *            successful completion of slave transmission can be checked by confirming the device status flag or 
+ *            channel status flag specified in the argument g_riic_ChStatus [], that is to be "RIIC_FINISH" or 
+ *            "RIIC_NACK". "RIIC_NACK" is set when master device transmitted NACK for notify to the slave that last 
+ *            data receive completed.
+ * @note      Available settings for each receive pattern see Section 3 in the application note for details.
+ */
+riic_return_t R_RIIC_SlaveTransfer(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+
+    /* ---- CHECK ARGUMENTS ---- */
+#if (1U == RIIC_CFG_PARAM_CHECKING_ENABLE)
+    /* Parameter check */
+    if (((NULL == p_riic_info)
+            || (((uint8_t *) FIT_NO_PTR == p_riic_info->p_data1st) && ((uint8_t *) FIT_NO_PTR == p_riic_info->p_data2nd)))
+            || (NULL == p_riic_info->callbackfunc))
+    {
+        return RIIC_ERR_INVALID_ARG;
+    }
+
+    /* ---- CHECK CHANNEL ---- */
+    if (false == riic_mcu_check_channel(p_riic_info->ch_no))
+    {
+        return RIIC_ERR_INVALID_CHAN;
+    }
+
+#endif
+
+    /* Calls the API function. */
+    ret = riic_slave_transfer(p_riic_info);
+
+    return ret;
+} /* End of function R_RIIC_SlaveTransfer() */
+
+/***********************************************************************************************************************
+ * Outline      : 
+ * Function Name: riic_slave_transfer
+ * Description  : sub function of R_RIIC_SlaveTransfer.
+ *              : Generates the start condition. Starts the slave reception and the slave transmission.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_NO_INIT               ; Uninitialized state
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                   ; Time out error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_slave_transfer(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+    riic_callback callbackfunc = NULL;
+
+    /* Checks the channel status. */
+    ret = riic_check_chstatus_start(p_riic_info);
+
+    if (RIIC_SUCCESS != ret)
+    {
+        return ret;
+    }
+
+    if (RIIC_MODE_S_READY != riic_api_info[p_riic_info->ch_no].N_Mode)
+    {
+        /* Updates the channel status. */
+        riic_set_ch_status(p_riic_info, RIIC_IDLE);
+
+        /* Initialize API status on RAM */
+        riic_api_mode_event_init(p_riic_info, RIIC_MODE_S_READY);
+
+        /* Generates the start condition. */
+        ret = riic_func_table(RIIC_EV_EN_SLV_TRANSFER, p_riic_info);
+    }
+
+    /* Copy p_riic_info address */
+    priic_info_s[p_riic_info->ch_no] = p_riic_info;
+
+    /* Sets the callback function. */
+    callbackfunc                              = p_riic_info->callbackfunc;
+    g_riic_callbackfunc_s[p_riic_info->ch_no] = callbackfunc;
+
+    /* ---- Enables IIC bus interrupt enable register. ---- */
+    if (((uint8_t *) FIT_NO_PTR != p_riic_info->p_data1st) && ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data2nd))
+    {
+        /* Enables slave send and slave receive */
+        riic_int_icier_setting(p_riic_info, RIIC_ICIER_TX_RX);
+    }
+    else if (((uint8_t *) FIT_NO_PTR != p_riic_info->p_data1st) && ((uint8_t *) FIT_NO_PTR == p_riic_info->p_data2nd))
+    {
+        /* Enable slave send */
+        riic_int_icier_setting(p_riic_info, RIIC_ICIER_TX);
+    }
+    else if (((uint8_t *) FIT_NO_PTR == p_riic_info->p_data1st) && ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data2nd))
+    {
+        /* Enable slave receive */
+        riic_int_icier_setting(p_riic_info, RIIC_ICIER_RX);
+    }
+    else
+    {
+        /* Do Nothing */
+    }
+
+    return ret;
+} /* End of function riic_slave_transfer() */
+
+/**********************************************************************************************************************
+ * Function Name: R_RIIC_GetStatus
+ *****************************************************************************************************************/ /**
+ * @brief Returns the state of this module.
+ * @param[in] *p_riic_info
+ *             This is the pointer to the I2C communication information structure.
+ * @param[in] *p_riic_status
+ *             This contains the variable to store the RIIC state.
+ * @retval    RIIC_SUCCESS             Processing completed successfully
+ * @retval    RIIC_ERR_INVALID_CHAN    The channel is nonexistent
+ * @retval    RIIC_ERR_INVALID_ARG     The parameter is invalid
+ * @details   Returns the state of this module. \n
+ *            By reading the register, pin level, variable, or others, obtains the state of the RIIC channel which 
+ *            specified by the parameter, and returns the obtained state as 32-bit structure. \n
+ *            When this function is called, the RIIC arbitration-lost flag and NACK flag are cleared to 0. If the 
+ *            device state is "RIIC_ AL", the value is updated to "RIIC_FINISH". \n
+ * @note      The state flag allocation see Section 3 in the application note for details.
+ */
+riic_return_t R_RIIC_GetStatus(riic_info_t *p_riic_info, riic_mcu_status_t *p_riic_status)
+{
+    /* ---- CHECK ARGUMENTS ---- */
+#if (1U == RIIC_CFG_PARAM_CHECKING_ENABLE)
+
+    if ((NULL == p_riic_info) || (NULL == p_riic_status))
+    {
+        return RIIC_ERR_INVALID_ARG;
+    }
+
+    /* ---- CHECK CHANNEL ---- */
+    if (false == riic_mcu_check_channel(p_riic_info->ch_no))
+    {
+        return RIIC_ERR_INVALID_CHAN;
+    }
+
+#endif
+
+    /* Calls the API function. */
+    riic_getstatus(p_riic_info, p_riic_status);
+
+    return RIIC_SUCCESS;
+} /* End of function R_RIIC_GetStatus() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_getstatus
+ * Description  : sub function of R_RIIC_GetStatus.
+ *                Returns the state of this module.
+ *                Obtains the state of the RIIC channel, which specified by the parameter, by reading the register,
+ *                variable, or others, and returns the obtained state as 32-bit structure.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ *                riic_mcu_status_t * p_riic_status ; The address to store the I2C state flag.
+ * Return Value : none
+ **********************************************************************************************************************/
+static void riic_getstatus(riic_info_t *p_riic_info, riic_mcu_status_t *p_riic_status)
+{
+    volatile uint8_t uctmp = 0x00;
+    volatile riic_mcu_status_t sts_flag;
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picsr1_reg = RIIC_ICSR1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+
+    sts_flag.LONG = 0x00000000;
+
+    /* ---- Check Bus state ---- */
+    if (RIIC_ICCR2_BBSY_SET == ((*piccr2_reg) & RIIC_ICCR2_BBSY))
+    {
+        sts_flag.BIT.BSY = 1U;
+    }
+    else
+    {
+        sts_flag.BIT.BSY = 0U;
+    }
+
+    /* ---- Check Mode ---- */
+    if (RIIC_ICCR2_TRS_SET == ((*piccr2_reg) & RIIC_ICCR2_TRS))
+    {
+        /* Send */
+        sts_flag.BIT.TRS = 1U;
+    }
+    else
+    {
+        /* Receive */
+        sts_flag.BIT.TRS = 0U;
+    }
+
+    /* ---- Check Event detection ---- */
+    if (RIIC_ICSR2_NACKF_SET == ((*picsr2_reg) & RIIC_ICSR2_NACKF))
+    {
+        /* NACK translation detected*/
+        sts_flag.BIT.NACK = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.NACK = 0U;
+    }
+
+    /* ---- Check Send buffer status ---- */
+    if (RIIC_ICSR2_TDRE_SET == ((*picsr2_reg) & RIIC_ICSR2_TDRE))
+    {
+        /* Send buffer empty */
+        sts_flag.BIT.SBUF = 1U;
+    }
+    else
+    {
+        /* Send buffer not empty */
+        sts_flag.BIT.SBUF = 0U;
+    }
+
+    /* ---- Check Receive buffer status ---- */
+    if (RIIC_ICSR2_RDRF_SET == ((*picsr2_reg) & RIIC_ICSR2_RDRF))
+    {
+        /* Receive buffer not empty */
+        sts_flag.BIT.RBUF = 1U;
+    }
+    else
+    {
+        /* Receive buffer empty */
+        sts_flag.BIT.RBUF = 0U;
+    }
+
+    /* ---- Check SDA pin level ---- */
+    if (RIIC_ICCR1_SDAI_SET == ((*piccr1_reg) & RIIC_ICCR1_SDAI))
+    {
+        /* SDA pin is High level */
+        sts_flag.BIT.SDAI = 1U;
+    }
+    else
+    {
+        /* SDA pin is Low level */
+        sts_flag.BIT.SDAI = 0U;
+    }
+
+    /* ---- Check SCL pin level ---- */
+    if (RIIC_ICCR1_SCLI_SET == ((*piccr1_reg) & RIIC_ICCR1_SCLI))
+    {
+        /* SCL pin is High level */
+        sts_flag.BIT.SCLI = 1U;
+    }
+    else
+    {
+        /* SCL pin is Low level */
+        sts_flag.BIT.SCLI = 0U;
+    }
+
+    /* ---- Check SDA output control status ---- */
+    if (RIIC_ICCR1_SDAO_SET == ((*piccr1_reg) & RIIC_ICCR1_SDAO))
+    {
+        /* SDA pin is Open */
+        sts_flag.BIT.SDAO = 1U;
+    }
+    else
+    {
+        /* SDA pin is Low hold */
+        sts_flag.BIT.SDAO = 0U;
+    }
+
+    /* ---- Check SCL output control status ---- */
+    if (RIIC_ICCR1_SCLO_SET == ((*piccr1_reg) & RIIC_ICCR1_SCLO))
+    {
+        /* SCL pin is Open */
+        sts_flag.BIT.SCLO = 1U;
+    }
+    else
+    {
+        /* SCL pin is Low hold */
+        sts_flag.BIT.SCLO = 0U;
+    }
+
+    /* ---- Check Event detection ---- */
+    if (RIIC_ICSR2_START_SET == ((*picsr2_reg) & RIIC_ICSR2_START))
+    {
+        /* Start condition detected*/
+        sts_flag.BIT.ST = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.ST = 0U;
+    }
+
+    /* ---- Check Event detection ---- */
+    if (RIIC_ICSR2_STOP_SET == ((*picsr2_reg) & RIIC_ICSR2_STOP))
+    {
+        /* Stop condition detected*/
+        sts_flag.BIT.SP = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.SP = 0U;
+    }
+
+    /* ---- Check Event detection ---- */
+    if (RIIC_ICSR2_AL_SET == ((*picsr2_reg) & RIIC_ICSR2_AL))
+    {
+        /* Arbitration lost detected*/
+        sts_flag.BIT.AL = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.AL = 0U;
+    }
+
+    /* ---- Check Event detection ---- */
+    if (RIIC_ICSR2_TMOF_SET == ((*picsr2_reg) & RIIC_ICSR2_TMOF))
+    {
+        /* Time out detected*/
+        sts_flag.BIT.TMO = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.TMO = 0U;
+    }
+
+    /* ---- Check Master/Slave Mode ---- */
+    if (RIIC_ICCR2_MST_SET == ((*piccr2_reg) & RIIC_ICCR2_MST))
+    {
+        /* Master Mode */
+        sts_flag.BIT.MST = 1U;
+    }
+    else
+    {
+        /* Slave Mode */
+        sts_flag.BIT.MST = 0U;
+    }
+
+    /* ---- Check Host Address detection ---- */
+    if (RIIC_ICSR1_HOA_SET == ((*picsr1_reg) & RIIC_ICSR1_HOA))
+    {
+        /* Host Address detected */
+        sts_flag.BIT.HOA = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.HOA = 0U;
+    }
+
+    /* ---- Check Device ID Address detection ---- */
+    if (RIIC_ICSR1_DID_SET == ((*picsr1_reg) & RIIC_ICSR1_DID))
+    {
+        /* Device ID Address detected */
+        sts_flag.BIT.DID = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.DID = 0U;
+    }
+
+    /* ---- Check Generalcall Address detection ---- */
+    if (RIIC_ICSR1_GCA_SET == ((*picsr1_reg) & RIIC_ICSR1_GCA))
+    {
+        /* Generalcall Address detected */
+        sts_flag.BIT.GCA = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.GCA = 0U;
+    }
+
+    /* ---- Check Slave0 Address detection ---- */
+    if (RIIC_ICSR1_AAS0_SET == ((*picsr1_reg) & RIIC_ICSR1_AAS0))
+    {
+        /* Slave0 Address detected */
+        sts_flag.BIT.AAS0 = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.AAS0 = 0U;
+    }
+
+    /* ---- Check Slave1 Address detection ---- */
+    if (RIIC_ICSR1_AAS1_SET == ((*picsr1_reg) & RIIC_ICSR1_AAS1))
+    {
+        /* Slave1 Address detected */
+        sts_flag.BIT.AAS1 = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.AAS1 = 0U;
+    }
+
+    /* ---- Check Slave2 Address detection ---- */
+    if (RIIC_ICSR1_AAS2_SET == ((*picsr1_reg) & RIIC_ICSR1_AAS2))
+    {
+        /* Slave2 Address detected */
+        sts_flag.BIT.AAS2 = 1U;
+    }
+    else
+    {
+        /* Not detected */
+        sts_flag.BIT.AAS2 = 0U;
+    }
+
+    /* ---- Set the state ---- */
+    *p_riic_status = sts_flag;
+
+    /* ---- clear flag ---- */
+    (*picsr2_reg) &= RIIC_ICSR2_AL_CLR;
+    (*picsr2_reg) &= RIIC_ICSR2_NACKF_CLR;
+    uctmp          = *picsr2_reg;
+
+    if (RIIC_AL == g_riic_ChStatus[p_riic_info->ch_no])
+    {
+        /* Initialize the channel status. */
+        riic_set_ch_status(p_riic_info, RIIC_FINISH);
+    }
+} /* End of function riic_getstatus() */
+
+/**********************************************************************************************************************
+ * Function Name: R_RIIC_Control
+ *****************************************************************************************************************/ /**
+ * @brief This function outputs conditions, Hi-Z from the SDA, and one-shot of the SCL clock. Also it resets the 
+ *        settings of this module. This function is mainly used when a communication error occurs.
+ * @param[in] *p_riic_info
+ *             This is the pointer to the I2C communication information structure.
+ * @param[in] ctrl_ptn
+ *             Specifies the output pattern. See Section 3 in the application note for details.
+ * @retval    RIIC_SUCCESS             Processing completed successfully
+ * @retval    RIIC_ERR_INVALID_CHAN    Nonexistent channel
+ * @retval    RIIC_ERR_INVALID_ARG     Invalid parameter
+ * @retval    RIIC_ERR_BUS_BUSY        Bus is busy
+ * @retval    RIIC_ERR_AL              Arbitration-lost error occurred
+ * @retval    RIIC_ERR_OTHER           The event occurred is invalid in the current state
+ * @details   Outputs control signals of the RIIC. Outputs conditions specified by the argument, Hi-Z from the SDA pin, 
+ *            and one-shot of the SCL clock. Also resets the RIIC module settings.
+ * @note      One-shot output of the SCL clock. \n
+ *            In master mode, if the clock signals from the master and slave devices go out of synchronization due to 
+ *            noise or other factors, the slave device may hold the SDA line low (bus hang up). Then the SDA line can 
+ *            be released from being held low by outputting one clock of the SCL at a time. \n
+ *            In this module, one clock of the SCL can be output by setting the output pattern "RIIC_GEN_SCL_ONESHOT" 
+ *            (one-shot output of the SCL clock) and calling R_RIIC_Control().
+ */
+riic_return_t R_RIIC_Control(riic_info_t * p_riic_info, uint8_t ctrl_ptn)
+{
+    riic_return_t ret;
+
+    /* ---- CHECK ARGUMENTS ---- */
+#if (1U == RIIC_CFG_PARAM_CHECKING_ENABLE)
+
+    if ((NULL == p_riic_info) || (0 == ctrl_ptn))
+    {
+        return RIIC_ERR_INVALID_ARG;
+    }
+
+    /* ---- CHECK CHANNEL ---- */
+    if (false == riic_mcu_check_channel(p_riic_info->ch_no))
+    {
+        return RIIC_ERR_INVALID_CHAN;
+    }
+
+#endif
+
+    /* Calls the API function. */
+    ret = riic_control(p_riic_info, ctrl_ptn);
+
+    return ret;
+} /* End of function R_RIIC_Control() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_control
+ * Description  : sub function of R_RIIC_Control.
+ *                This function is mainly used when a communication error occurs.
+ *                Outputs control signals of the simple I2C mode.
+ *                Outputs conditions specified by the argument, NACK,
+ *                and one-shot of the SSCL clock. Also resets the simple I2C mode settings.
+ * Arguments    : r_iic_info_t * p_riic_info     ; IIC Information
+ *                uint8_t cntl_ptn               ; Output Pattern
+ *                 [Options]
+ *                  RIIC_GEN_START_CON
+ *                  RIIC_GEN_STOP_CON
+ *                  RIIC_GEN_RESTART_CON 
+ *                  RIIC_GEN_SDA_HI_Z
+ *                  RIIC_GEN_SCL_ONESHOT
+ *                  RIIC_GEN_RESET
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_INVALID_ARG           ; Parameter error
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_control(riic_info_t * p_riic_info, uint8_t ctrl_ptn)
+{
+    volatile riic_return_t ret = RIIC_SUCCESS;
+    volatile uint8_t uctmp = 0x00;
+    volatile uint32_t cnt = 0x00000000;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+
+    /* Disable all RIIC interrupt */
+    riic_int_disable(p_riic_info);
+
+    /* ==== Release reset(IICRST) of RIIC ==== */
+    riic_reset_clear(p_riic_info);
+
+    if (RIIC_ICCR1_ICE_SET != ((*piccr1_reg) & RIIC_ICCR1_ICE)) /* Check ICCR1.ICE = 0 */
+    {
+        /* Set ICE bit to enable RIIC modeule */
+        (*piccr1_reg) |= RIIC_ICCR1_ICE_SET;
+    }
+
+    if ((0 != (uint8_t) (((RIIC_GEN_START_CON | RIIC_GEN_RESTART_CON) | RIIC_GEN_STOP_CON) & ctrl_ptn))
+            && (0 == (uint8_t) (((RIIC_GEN_SDA_HI_Z | RIIC_GEN_SCL_ONESHOT) | RIIC_GEN_RESET) & ctrl_ptn)))
+    {
+        /* ==== Check request output pattern ==== */
+        /* ---- Generate the start condition ---- */
+        if (RIIC_GEN_START_CON == (ctrl_ptn & RIIC_GEN_START_CON))
+        {
+            /* Checks bus busy. */
+            if (RIIC_ICCR2_BBSY_SET == ((*piccr2_reg) & RIIC_ICCR2_BBSY))
+            {
+                /* When BBSY bit is "1"(Bus busy) */
+                ret = RIIC_ERR_BUS_BUSY;
+                return ret;
+            }
+
+            /* Generates the start condition. */
+            riic_start_cond_generate(p_riic_info);
+
+            /* Wait the request generation has been completed */
+            cnt = RIIC_CFG_BUS_CHECK_COUNTER;
+            /* WAIT_LOOP */
+            while (RIIC_ICSR2_START_SET != ((*picsr2_reg) & RIIC_ICSR2_START))
+            {
+                /* Check Arbitration */
+                if (RIIC_ICSR2_AL_SET == ((*picsr2_reg) & RIIC_ICSR2_AL))
+                {
+                    /* When AL bit is "1" */
+                    ret = RIIC_ERR_AL;
+                    return ret;
+                }
+
+                /* Check Reply */
+                if (0x00000000 < cnt)
+                {
+                    cnt--;
+                }
+                else
+                {
+                    /* When Non Reply */
+                    ret = RIIC_ERR_BUS_BUSY;
+                    return ret;
+                }
+            }
+
+            /* Clear START detect bit */
+            (*picsr2_reg) &= RIIC_ICSR2_START_CLR;
+        }
+
+        /* ---- Generate the restart condition ---- */
+        if (RIIC_GEN_RESTART_CON == (ctrl_ptn & RIIC_GEN_RESTART_CON))
+        {
+            /* Checks bus busy. */
+            if (RIIC_ICCR2_BBSY_SET != ((*piccr2_reg) & RIIC_ICCR2_BBSY))
+            {
+                /* When BBSY bit is "0"(Not Bus busy) */
+                ret = RIIC_ERR_OTHER;
+                return ret;
+            }
+
+            /* Generates the restart condition. */
+            riic_re_start_cond_generate(p_riic_info);
+
+            /* Wait the request generation has been completed*/
+            cnt = RIIC_CFG_BUS_CHECK_COUNTER;
+            /* WAIT_LOOP */
+            while (RIIC_ICSR2_START_SET != ((*picsr2_reg) & RIIC_ICSR2_START))
+            {
+                /* Check Arbitration */
+                if (RIIC_ICSR2_AL_SET == ((*picsr2_reg) & RIIC_ICSR2_AL))
+                {
+                    /* When AL bit is "1" */
+                    ret = RIIC_ERR_AL;
+                    return ret;
+                }
+
+                /* Check Reply */
+                if (0x00000000 < cnt)
+                {
+                    cnt--;
+                }
+                else
+                {
+                    /* When Non Reply */
+                    ret = RIIC_ERR_BUS_BUSY;
+                    return ret;
+                }
+            }
+
+            /* Clear START detect bit */
+            (*picsr2_reg) &= RIIC_ICSR2_START_CLR;
+        }
+
+        /* ---- Generate the stop condition ---- */
+        if (RIIC_GEN_STOP_CON == (ctrl_ptn & RIIC_GEN_STOP_CON))
+        {
+            /* Checks bus busy. */
+            if (RIIC_ICCR2_BBSY_SET != ((*piccr2_reg) & RIIC_ICCR2_BBSY))
+            {
+                /* When BBSY bit is "0"(Not Bus busy) */
+                ret = RIIC_ERR_OTHER;
+                return ret;
+            }
+
+            /* Generates the stop condition. */
+            riic_stop_cond_generate(p_riic_info);
+
+            /* Wait the request generation has been completed*/
+            cnt = RIIC_CFG_BUS_CHECK_COUNTER;
+            /* WAIT_LOOP */
+            while (RIIC_ICSR2_STOP_SET != ((*picsr2_reg) & RIIC_ICSR2_STOP))
+            {
+                /* Check Arbitration */
+                if (RIIC_ICSR2_AL_SET == ((*picsr2_reg) & RIIC_ICSR2_AL))
+                {
+                    /* When AL bit is "1" */
+                    ret = RIIC_ERR_AL;
+                    return ret;
+                }
+
+                /* Check Reply */
+                if (0x00000000 < cnt)
+                {
+                    cnt--;
+                }
+                else
+                {
+                    /* When Non Reply */
+                    ret = RIIC_ERR_BUS_BUSY;
+                    return ret;
+                }
+            }
+
+            /* Clear STOP detect bit */
+            (*picsr2_reg) &= RIIC_ICSR2_STOP_CLR;
+        }
+    }
+    else if ((0x00 != (uint8_t) ((RIIC_GEN_SDA_HI_Z | RIIC_GEN_SCL_ONESHOT) & ctrl_ptn))
+            && (0x00 == (uint8_t) ((((RIIC_GEN_START_CON | RIIC_GEN_RESTART_CON) | RIIC_GEN_STOP_CON) |
+            RIIC_GEN_RESET) & ctrl_ptn)))
+    {
+        /* ---- Select SDA pin in a high-impedance state ---- */
+        if (RIIC_GEN_SDA_HI_Z == (ctrl_ptn & RIIC_GEN_SDA_HI_Z))
+        {
+            /* Changes the SDA pin in a high-impedance state. */
+            /* Sets for ICCR1.SDAO bit. */
+            *piccr1_reg = (uint8_t) (((*piccr1_reg) | RIIC_ICCR1_SDAO_SET) & RIIC_ICCR1_SOWP_CLR);
+        }
+
+        /* ---- Generate OneShot of SSCL clock ---- */
+        if (RIIC_GEN_SCL_ONESHOT == (ctrl_ptn & RIIC_GEN_SCL_ONESHOT))
+        {
+            /* Output SCL oneshot */
+            (*piccr1_reg) |= RIIC_ICCR1_CLO_SET;
+
+            /* Wait output scl oneshot has been completed */
+            cnt = RIIC_CFG_BUS_CHECK_COUNTER;
+            /* WAIT_LOOP */
+            while (RIIC_ICCR1_CLO_SET == ((*piccr1_reg) & RIIC_ICCR1_CLO_SET))
+            {
+                /* Check Reply */
+                if (0x00000000 < cnt)
+                {
+                    cnt--;
+                }
+                else
+                {
+                    /* Set SCLO bit is "1"(Hi-z). */
+                    *piccr1_reg = (uint8_t) (((*piccr1_reg) | RIIC_ICCR1_SCLO_SET) & RIIC_ICCR1_SOWP_CLR);
+
+                    /* When Non Reply */
+                    ret = RIIC_ERR_BUS_BUSY;
+                    return ret;
+                }
+            }
+        }
+    }
+    else if ((0x00 != (uint8_t) ((RIIC_GEN_RESET) & ctrl_ptn))
+            && (0x00 == (uint8_t) (((((RIIC_GEN_START_CON | RIIC_GEN_RESTART_CON) | RIIC_GEN_STOP_CON) |
+            RIIC_GEN_SDA_HI_Z) | RIIC_GEN_SCL_ONESHOT) & ctrl_ptn)))
+    {
+        /* ---- Generate Reset ---- */
+        /* Updates the channel status. */
+        riic_set_ch_status(p_riic_info, RIIC_IDLE);
+
+        /* Initialize API status on RAM */
+        riic_api_mode_event_init(p_riic_info, RIIC_MODE_NONE);
+
+        /* Initializes the IIC registers. */
+        /* Sets the internal status. */
+        /* Enables the interrupt. */
+        /* Clears the RIIC reset or internal reset. */
+        riic_enable(p_riic_info);
+    }
+    else
+    {
+        /* parameter error */
+        ret = RIIC_ERR_INVALID_ARG;
+    }
+    uctmp = *piccr1_reg;
+
+    riic_clear_ir_flag(p_riic_info); /* Clear IR flag for RXI and TXI */
+
+    return ret;
+} /* End of function riic_control() */
+
+/**********************************************************************************************************************
+ * Function Name: R_RIIC_Close
+ *****************************************************************************************************************/ /**
+ * @brief This function completes the RIIC communication and releases the RIIC used.
+ * @param[in] *p_riic_info
+ *             This is the pointer to the I2C communication information structure.
+ * @retval    RIIC_SUCCESS           Processing completed successfully
+ * @retval    RIIC_ERR_INVALID_CHAN  The channel is nonexistent
+ * @retval    RIIC_ERR_INVALID_ARG   Invalid parameter
+ * @details   Configures the settings to complete the RIIC communication. Disables the RIIC channel specified by the 
+ *            parameter. The following processes are performed in this function. \n
+ *            \li Entering the RIIC module-stop state.
+ *            \li Releasing I2C output ports.
+ *            \li Disabling the RIIC interrupt.
+ * 
+ *            To restart the communication, call the R_RIIC_Open() function (initialization function). If the 
+ *            communication is forcibly terminated, that communication is not guaranteed. \n
+ * @note      None
+ */
+riic_return_t R_RIIC_Close(riic_info_t * p_riic_info)
+{
+    /* ---- CHECK ARGUMENTS ---- */
+#if (1U == RIIC_CFG_PARAM_CHECKING_ENABLE)
+    if (NULL == p_riic_info)
+    {
+        return RIIC_ERR_INVALID_ARG;
+    }
+
+    /* ---- CHECK CHANNEL ---- */
+    if (false == riic_mcu_check_channel(p_riic_info->ch_no))
+    {
+        return RIIC_ERR_INVALID_CHAN;
+    }
+
+#endif
+
+    /* ---- Hardware Unlock ---- */
+    riic_mcu_hardware_unlock(p_riic_info->ch_no);
+
+    /* Calls the API function. */
+    riic_close(p_riic_info);
+
+    return RIIC_SUCCESS;
+} /* End of function R_RIIC_Close() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_close
+ * Description  : sub function of R_RIIC_Close. 
+ *                Resets the RIIC driver.
+ *              : The processing performs internal reset by setting to ICCR1.IICRST bit.
+ *              : Forcibly, stops the IIC communication.
+ *              : After called the processing, channel status becomes "RIIC_NO_INIT".
+ *              : When starts the communication again, please call an initialization processing.
+ * Arguments    : riic_info_t * p_riic_info      ;   IIC Information
+ * Return Value : none
+ **********************************************************************************************************************/
+static void riic_close(riic_info_t * p_riic_info)
+{
+    /* Updates the channel status. */
+    riic_set_ch_status(p_riic_info, RIIC_NO_INIT);
+
+    /* Disables IIC. */
+    riic_disable(p_riic_info);
+
+#if (1U == RIIC_CFG_PORT_SET_PROCESSING)
+    /* Disables RIIC multi-function pin controller after setting SCL and SDA to Hi-z by Reset. */
+    /* Includes I/O register read operation at the end of the following function. */
+    riic_mcu_mpc_disable(p_riic_info->ch_no);
+#endif
+
+    riic_mcu_power_off(p_riic_info->ch_no);
+} /* End of function riic_close() */
+
+/**********************************************************************************************************************
+ * Function Name: R_RIIC_GetVersion
+ *****************************************************************************************************************/ /**
+ * @brief Returns the current version of this module.
+ * @return    Version number
+ * @details   This function will return the version of the currently installed RIIC FIT module. The version number is 
+ *            encoded where the top 2 bytes are the major version number and the bottom 2 bytes are the minor version 
+ *            number. For example, Version 4.25 would be returned as 0x00040019.
+ * @note      None
+ */
+uint32_t R_RIIC_GetVersion(void)
+{
+    uint32_t const version = (RIIC_VERSION_MAJOR << 16) | RIIC_VERSION_MINOR;
+
+    return version;
+} /* End of function R_RIIC_GetVersion() */
+
+/***********************************************************************************************************************
+ * Function Name: r_riic_advance
+ * Description  : Advances the IIC communication.
+ *              : The return value shows the communication result. Refer to the return value.
+ * Arguments    : riic_info_t * p_riic_info     ;   IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_INVALID_ARG           ; Parameter error
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                   ; Time out error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t r_riic_advance(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+
+    /* Parameter check */
+    if (NULL == p_riic_info)
+    {
+        ret = RIIC_ERR_INVALID_ARG;
+    }
+    else
+    {
+        /* Calls the API function. */
+        ret = riic_advance(p_riic_info);
+    }
+
+    return ret;
+} /* End of function r_riic_advance() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_advance
+ * Description  : sub function of r_riic_advance.
+ *                Advances the IIC communication.
+ *              : The return value shows the communication result. Refer to the return value.
+ * Arguments    : riic_info_t * p_riic_info     ;   IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy
+ *              : RIIC_ERR_NO_INIT               ; Uninitialized state
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                   ; Time out error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_advance(riic_info_t * p_riic_info)
+{
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picier_reg = RIIC_ICIER_ADR(p_riic_info->ch_no);
+    riic_return_t ret;
+
+    /* Checks the channel status. */
+    ret = riic_check_chstatus_advance(p_riic_info);
+    if (RIIC_SUCCESS != ret)
+    {
+        return ret;
+    }
+
+    /* Event happened? */
+    if (RIIC_EV_INIT != riic_api_event[p_riic_info->ch_no])
+    {
+        /* IIC communication processing */
+        ret = riic_func_table(riic_api_event[p_riic_info->ch_no], p_riic_info);
+
+        /* return value? */
+        switch (ret)
+        {
+            case RIIC_SUCCESS :
+                if (RIIC_STS_TMO == riic_api_info[p_riic_info->ch_no].N_status)
+                {
+                    /* Checks the callback function. */
+                    if ((((((RIIC_MODE_M_SEND == riic_api_info[p_riic_info->ch_no].N_Mode)
+                            || (RIIC_MODE_M_SEND == riic_api_info[p_riic_info->ch_no].B_Mode))
+                            || (RIIC_MODE_M_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+                            || (RIIC_MODE_M_RECEIVE == riic_api_info[p_riic_info->ch_no].B_Mode))
+                            || (RIIC_MODE_M_SEND_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+                            || (RIIC_MODE_M_SEND_RECEIVE == riic_api_info[p_riic_info->ch_no].B_Mode))
+                    {
+                        riic_set_ch_status(priic_info_m[p_riic_info->ch_no], RIIC_TMO);
+                        if (NULL != g_riic_callbackfunc_m[p_riic_info->ch_no])
+                        {
+                            g_riic_callbackfunc_m[p_riic_info->ch_no]();
+                        }
+                    }
+
+                    if ((RIIC_MODE_S_SEND == riic_api_info[p_riic_info->ch_no].N_Mode)
+                            || (RIIC_MODE_S_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+                    {
+                        riic_set_ch_status(priic_info_s[p_riic_info->ch_no], RIIC_TMO);
+                        if (NULL != g_riic_callbackfunc_s[p_riic_info->ch_no])
+                        {
+                            g_riic_callbackfunc_s[p_riic_info->ch_no]();
+                        }
+                    }
+                }
+
+                else if (((RIIC_STS_SP_COND_WAIT != riic_api_info[p_riic_info->ch_no].N_status)
+                        || (0x00 != ((*picsr2_reg) & RIIC_ICSR2_STOP))) || (0x00 != ((*picier_reg) & RIIC_ICIER_SP)))
+                {
+                    /* Advances communication. (Not finished) */
+                    /* Do Nothing */
+                }
+                else
+                {
+                    /* Finished communication.(after detect stop condition) */
+                    /* Updates the channel status. */
+                    if (RIIC_ICSR2_AL == ((*picsr2_reg) & RIIC_ICSR2_AL))
+                    {
+                        if (((RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].N_Mode)
+                                || (RIIC_MODE_S_SEND == riic_api_info[p_riic_info->ch_no].N_Mode))
+                                || (RIIC_MODE_S_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+                        {
+                            riic_set_ch_status(priic_info_s[p_riic_info->ch_no], RIIC_FINISH);
+                        }
+
+                        riic_set_ch_status(priic_info_m[p_riic_info->ch_no], RIIC_AL);
+                    }
+                    else if (RIIC_ICSR2_NACKF == ((*picsr2_reg) & RIIC_ICSR2_NACKF))
+                    {
+                        riic_set_ch_status(p_riic_info, RIIC_NACK);
+                    }
+                    else
+                    {
+                        riic_set_ch_status(p_riic_info, RIIC_FINISH);
+                    }
+
+                    /* Checks the callback function. */
+                    if ((((((RIIC_MODE_M_SEND == riic_api_info[p_riic_info->ch_no].N_Mode)
+                            || (RIIC_MODE_M_SEND == riic_api_info[p_riic_info->ch_no].B_Mode))
+                            || (RIIC_MODE_M_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+                            || (RIIC_MODE_M_RECEIVE == riic_api_info[p_riic_info->ch_no].B_Mode))
+                            || (RIIC_MODE_M_SEND_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+                            || (RIIC_MODE_M_SEND_RECEIVE == riic_api_info[p_riic_info->ch_no].B_Mode))
+                    {
+                        if (NULL != g_riic_callbackfunc_m[p_riic_info->ch_no])
+                        {
+                            g_riic_callbackfunc_m[p_riic_info->ch_no]();
+                        }
+                    }
+
+                    if ((RIIC_MODE_S_SEND == riic_api_info[p_riic_info->ch_no].N_Mode)
+                            || (RIIC_MODE_S_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+                    {
+                        if (NULL != g_riic_callbackfunc_s[p_riic_info->ch_no])
+                        {
+                            g_riic_callbackfunc_s[p_riic_info->ch_no]();
+                        }
+                    }
+
+                    /* Return to the last mode */
+                    if ((RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].N_Mode)
+                            || (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode))
+                    {
+                        /* Initialize API status on RAM */
+                        riic_api_mode_set(p_riic_info, RIIC_MODE_NONE);
+                        riic_api_mode_set(p_riic_info, RIIC_MODE_S_READY);
+                        riic_api_status_set(p_riic_info, RIIC_STS_IDLE_EN_SLV);
+
+                        /* ---- Enables IIC bus interrupt enable register. ---- */
+                        if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                        {
+                            /* Enables slave send and slave receive */
+                            riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_TX_RX);
+                        }
+                        else if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                && ((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                        {
+                            /* Enable slave send */
+                            riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_TX);
+                        }
+                        else if (((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                        {
+                            /* Enable slave receive */
+                            riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_RX);
+                        }
+                        else
+                        {
+                            /* Do Nothing */
+                        }
+                    }
+                    else
+                    {
+                        /* Initialize API status on RAM */
+                        riic_api_mode_set(p_riic_info, RIIC_MODE_NONE);
+                        riic_api_status_set(p_riic_info, RIIC_STS_IDLE);
+
+                        /* Initializes ICIER register. */
+                        *picier_reg = RIIC_ICIER_INIT;
+                        /* WAIT_LOOP */
+                        while (RIIC_ICIER_INIT != (*picier_reg))
+                        {
+                            /* Do Nothing */
+                        }
+                    }
+                }
+                break;
+
+            default :
+
+                /* Updates the channel status. */
+                riic_set_ch_status(p_riic_info, RIIC_ERROR);
+                break;
+        }
+    }
+
+    /* Event nothing. */
+    else
+    {
+        ret = RIIC_ERR_OTHER;
+    }
+
+    return ret;
+} /* End of function riic_advance() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_func_table
+ * Description  : IIC Protocol Execution Processing.
+ *                Executes the function which set in "pfunc".
+ * Arguments    : riic_api_event_t event    ; Event
+ *              : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : Refer to the each calling function.
+ **********************************************************************************************************************/
+static riic_return_t riic_func_table(riic_api_event_t event, riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+    riic_return_t (*pFunc) (riic_info_t *);
+    riic_api_status_t n_status;
+
+    /* Acquires a now state. */
+    n_status = riic_api_info[p_riic_info->ch_no].N_status;
+
+    /* Checks the parameter. */
+    if ((RIIC_STS_MAX > n_status) && (RIIC_EV_MAX > event))
+    {
+        /* Checks the appointed function. */
+        if (NULL != gc_riic_mtx_tbl[n_status][event].proc)
+        {
+            /* Sets the function. */
+            pFunc = gc_riic_mtx_tbl[n_status][event].proc;
+
+            /* Event flag initialization. */
+            riic_api_event[p_riic_info->ch_no] = RIIC_EV_INIT;
+
+            /* Calls the status transition function. */
+            ret = (*pFunc)(p_riic_info);
+        }
+        else
+        {
+            /* Appointed function error */
+            ret = RIIC_ERR_OTHER;
+        }
+    }
+    else
+    {
+        /* Appointed function error */
+        ret = RIIC_ERR_OTHER;
+    }
+
+    return ret;
+} /* End of function riic_func_table() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_init_driver
+ * Description  : Initialize IIC Driver Processing.
+ *                Initializes the IIC registers.
+ *              : Sets the internal status.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, idle state
+ **********************************************************************************************************************/
+static riic_return_t riic_init_driver(riic_info_t * p_riic_info)
+{
+    /* Initializes the IIC registers. */
+    /* Sets the internal status. */
+    /* Enables the interrupt. */
+    /* Clears the RIIC reset or internal reset. */
+    riic_enable(p_riic_info);
+
+    return RIIC_SUCCESS;
+} /* End of function riic_init_driver() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_generate_start_cond
+ * Description  : Generate Start Condition Processing.
+ *                Checks bus busy. Sets the internal status. Generates the start condition.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, communication state
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy error
+ **********************************************************************************************************************/
+static riic_return_t riic_generate_start_cond(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+    bool boolret;
+    volatile uint8_t uctmp;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picier_reg = RIIC_ICIER_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+
+    /* Checks bus busy. */
+    boolret = riic_check_bus_busy(p_riic_info);
+    if (RIIC_FALSE == boolret)
+    {
+        ret = RIIC_ERR_BUS_BUSY; /* Bus busy */
+    }
+    else
+    {
+        /* Clears each status flag. */
+        (*picsr2_reg) &= RIIC_ICSR2_STOP_CLR;
+        /* WAIT_LOOP */
+        while (0x00 != (((*picsr2_reg) & RIIC_ICSR2_START) || ((*picsr2_reg) & RIIC_ICSR2_STOP)))
+        {
+            /* Do Nothing */
+        }
+
+        /* Sets the internal status. */
+        riic_api_status_set(p_riic_info, RIIC_STS_ST_COND_WAIT);
+
+        /* Clears ALIE bit. */
+        (*picier_reg) &= (~RIIC_ICIER_AL);
+        uctmp          = *picier_reg; /* Reads ICIER. */
+
+        /* Enables IIC bus interrupt enable register. */
+        if (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode)
+        {
+            if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+            {
+                /* Enables slave send and slave receive */
+                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_ST_NAK_AL | RIIC_ICIER_TX_RX);
+            }
+            else if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data2nd))
+            {
+                /* Enable slave send */
+                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_ST_NAK_AL | RIIC_ICIER_TX);
+            }
+            else if (((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+            {
+                /* Enable slave receive */
+                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_ST_NAK_AL | RIIC_ICIER_RX);
+            }
+            else
+            {
+                /* Do Nothing */
+            }
+        }
+        else
+        {
+            riic_int_icier_setting(p_riic_info, RIIC_ICIER_ST_NAK_AL);
+        }
+
+        /* Generates the start condition. */
+        riic_start_cond_generate(p_riic_info);
+
+        ret = RIIC_SUCCESS;
+    }
+
+    return ret;
+} /* End of function riic_generate_start_cond() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_after_gen_start_cond
+ * Description  : After Start Condition Generation Processing.
+ *                Performs one of the following processing according to the state.
+ *                Transmits the slave address for writing.
+ *                Transmits the slave address for reading.
+ *                Generates the stop condition.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, communication state
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_after_gen_start_cond(riic_info_t * p_riic_info)
+{
+    riic_return_t ret = RIIC_SUCCESS;
+    uint8_t buf_send_data;
+    volatile uint32_t cnt;
+    bool scl_low_chk;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+
+    /* IIC mode? */
+    switch (riic_api_info[p_riic_info->ch_no].N_Mode)
+    {
+        case RIIC_MODE_M_SEND :
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Checks the previous status. */
+            switch (riic_api_info[p_riic_info->ch_no].B_status)
+            {
+                /* The previous status is idle. */
+                case RIIC_STS_IDLE :
+                case RIIC_STS_IDLE_EN_SLV :
+
+                    /* Is the slave address pointer set? */
+                    if ((uint8_t *) FIT_NO_PTR == p_riic_info->p_slv_adr) /* Pattern 4 of Master Write */
+                    {
+                        /* Sets the internal status. */
+                        riic_api_status_set(p_riic_info, RIIC_STS_SP_COND_WAIT);
+
+                        /* Enables the IIC bus interrupt. */
+                        if (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode)
+                        {
+                            if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                    && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                            {
+                                /* Enables slave send and slave receive */
+                                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_SP_NAK_AL |
+                                RIIC_ICIER_TX_RX);
+                            }
+                            else if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                    && ((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                            {
+                                /* Enable slave send */
+                                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_SP_NAK_AL |
+                                RIIC_ICIER_TX);
+                            }
+                            else if (((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                    && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                            {
+                                /* Enable slave receive */
+                                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_SP_NAK_AL |
+                                RIIC_ICIER_RX);
+                            }
+                            else
+                            {
+                                /* Do Nothing */
+                            }
+                        }
+                        else
+                        {
+                            riic_int_icier_setting(p_riic_info, RIIC_ICIER_SP_NAK_AL);
+                        }
+
+                        /* check SCL line */
+                        scl_low_chk = false;
+                        /* WAIT_LOOP */
+                        for (cnt = RIIC_CFG_SCL_CHECK_COUNTER; (false == scl_low_chk) && (cnt > 0x00000000); cnt--)
+                        {
+                            if (RIIC_ICCR1_SCLI_SET != ((*piccr1_reg) & RIIC_ICCR1_SCLI)) /* SCL low ? */
+                            {
+                                scl_low_chk = true;
+                            }
+                        }
+
+                        if (false == scl_low_chk) /* time out ? */
+                        {
+                            return RIIC_ERR_OTHER;
+                        }
+
+                        /* Generates the stop condition. */
+                        riic_stop_cond_generate(p_riic_info);
+                    }
+                    else
+                    {
+                        /* Sets a write code. */
+                        buf_send_data  = (uint8_t) ((*(p_riic_info->p_slv_adr)) << 1U);
+                        buf_send_data &= W_CODE;
+
+                        /* Sets the internal status. */
+                        riic_api_status_set(p_riic_info, RIIC_STS_SEND_SLVADR_W_WAIT);
+
+                        /* Enables the IIC bus interrupt. */
+                        /* Transmit data empty interrupt request is enabled. */
+                        if (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode)
+                        {
+                            if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                    && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                            {
+                                /* Enables slave send and slave receive */
+                                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_TEND_NAK_AL |
+                                RIIC_ICIER_TX_RX);
+                            }
+                            else if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                    && ((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                            {
+                                /* Enable slave send */
+                                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_TEND_NAK_AL |
+                                RIIC_ICIER_TX);
+                            }
+                            else if (((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data1st)
+                                    && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                            {
+                                /* Enable slave receive */
+                                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_TEND_NAK_AL |
+                                RIIC_ICIER_RX);
+                            }
+                            else
+                            {
+                                /* Do Nothing */
+                            }
+                        }
+                        else
+                        {
+                            riic_int_icier_setting(p_riic_info, RIIC_ICIER_TEND_NAK_AL);
+                        }
+
+                        /* Transmits the slave address. */
+                        riic_set_sending_data(p_riic_info, &buf_send_data);
+                    }
+                    break;
+
+                    /* Previous status is data transfer completion waiting status. */
+                case RIIC_STS_SEND_DATA_WAIT :
+
+                    /* Sets a read code. */
+                    buf_send_data  = (uint8_t) ((*(p_riic_info->p_slv_adr)) << 1U);
+                    buf_send_data |= R_CODE;
+
+                    /* Sets the internal status. */
+                    riic_api_status_set(p_riic_info, RIIC_STS_SEND_SLVADR_R_WAIT);
+
+                    /* Enables the IIC bus interrupt. */
+                    riic_int_icier_setting(p_riic_info, RIIC_ICIER_RX_NAK_AL);
+
+                    /* Transmits the slave address. */
+                    riic_set_sending_data(p_riic_info, &buf_send_data);
+
+                    break;
+
+                default :
+
+                    /* None status. */
+                    ret = RIIC_ERR_OTHER;
+                    break;
+            }
+        break;
+
+        case RIIC_MODE_M_RECEIVE :
+
+            /* Sets a read code. */
+            buf_send_data  = (uint8_t) ((*(p_riic_info->p_slv_adr)) << 1U);
+            buf_send_data |= R_CODE;
+
+            /* Sets the internal status. */
+            riic_api_status_set(p_riic_info, RIIC_STS_SEND_SLVADR_R_WAIT);
+
+            /* Enables the IIC bus interrupt. */
+            if (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode)
+            {
+                if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                        && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                {
+                    /* Enables slave send and slave receive */
+                    riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_RX_NAK_AL |
+                    RIIC_ICIER_TX_RX);
+                }
+                else if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                        && ((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                {
+                    /* Enable slave send */
+                    riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_RX_NAK_AL | RIIC_ICIER_TX);
+                }
+                else if (((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data1st)
+                        && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+                {
+                    /* Enable slave receive */
+                    riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_RX_NAK_AL | RIIC_ICIER_RX);
+                }
+                else
+                {
+                    /* Do Nothing */
+                }
+            }
+            else
+            {
+                riic_int_icier_setting(p_riic_info, RIIC_ICIER_RX_NAK_AL);
+            }
+
+            /* Transmits the slave address. */
+            riic_set_sending_data(p_riic_info, &buf_send_data);
+
+            break;
+
+        default :
+            ret = RIIC_ERR_OTHER;
+            break;
+    }
+    return ret;
+} /* End of function riic_after_gen_start_cond() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_after_send_slvadr
+ * Description  : After Slave Address Transmission Processing.
+ *                Performs one of the following processing according to the state.
+ *                Transmits a data. Generates the stop condition. Receives a data.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, communication state
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_after_send_slvadr(riic_info_t * p_riic_info)
+{
+    riic_return_t ret = RIIC_SUCCESS;
+    volatile uint8_t uctmp = 0x00;
+
+    /* IIC mode? */
+    switch (riic_api_info[p_riic_info->ch_no].N_Mode)
+    {
+        case RIIC_MODE_M_SEND :
+
+            /* --- Pattern 1 of Master Write --- */
+            if (((uint8_t *) FIT_NO_PTR != (uint8_t *) p_riic_info->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR != (uint8_t *) p_riic_info->p_data2nd))
+            {
+                /* Sets the internal status. */
+                riic_api_status_set(p_riic_info, RIIC_STS_SEND_DATA_WAIT);
+
+                /* Enables the IIC bus interrupt. */
+                riic_int_icier_setting(p_riic_info, RIIC_ICIER_TEND_NAK_AL);
+
+                /* 1st data counter = 0?  */
+                if (0x00000000 != p_riic_info->cnt1st)
+                {
+                    /* Transmits a 1st data. */
+                    riic_set_sending_data(p_riic_info, p_riic_info->p_data1st);
+
+                    /* Decreases the 1st data counter. */
+                    p_riic_info->cnt1st--;
+
+                    /* Increases the 1st data buffer pointer. */
+                    p_riic_info->p_data1st++;
+                }
+                else
+                {
+                    ret = RIIC_ERR_OTHER;
+                }
+            }
+
+            /* --- Pattern 2 of Master Write --- */
+            else if (((uint8_t *) FIT_NO_PTR == p_riic_info->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data2nd))
+            {
+                /* Sets the internal status. */
+                riic_api_status_set(p_riic_info, RIIC_STS_SEND_DATA_WAIT);
+
+                /* Enables the IIC bus interrupt. */
+                riic_int_icier_setting(p_riic_info, RIIC_ICIER_TEND_NAK_AL);
+
+                /* 2nd data counter = 0?  */
+                if (0x00000000 != p_riic_info->cnt2nd)
+                {
+                    /* Transmits a 2nd data. */
+                    riic_set_sending_data(p_riic_info, p_riic_info->p_data2nd);
+
+                    /* Decreases the 2nd data counter. */
+                    p_riic_info->cnt2nd--;
+
+                    /* Increases the 2nd data buffer pointer. */
+                    p_riic_info->p_data2nd++;
+                }
+                else
+                {
+                    ret = RIIC_ERR_OTHER;
+                }
+            }
+
+            /* --- Pattern 3 of Master Write --- */
+            else if (((uint8_t *) FIT_NO_PTR == p_riic_info->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR == p_riic_info->p_data2nd))
+            {
+                /* Sets the internal status. */
+                riic_api_status_set(p_riic_info, RIIC_STS_SP_COND_WAIT);
+
+                /* Enables the IIC bus interrupt. */
+                riic_int_icier_setting(p_riic_info, RIIC_ICIER_SP_NAK_AL);
+
+                /* Generates the stop condition. */
+                riic_stop_cond_generate(p_riic_info);
+            }
+            else
+            {
+                ret = RIIC_ERR_OTHER;
+            }
+
+            break;
+
+        case RIIC_MODE_M_RECEIVE :
+
+            /* Sets the internal status. */
+            riic_api_status_set(p_riic_info, RIIC_STS_RECEIVE_DATA_WAIT);
+
+            /* Enables the IIC bus interrupt. */
+            riic_int_icier_setting(p_riic_info, RIIC_ICIER_RX_NAK_AL);
+
+            if (2U >= p_riic_info->cnt2nd)
+            {
+                /* The period between the ninth clock cycle and the first clock cycle is held low. */
+                riic_receive_wait_setting(p_riic_info);
+            }
+
+            if (0x00000001 >= p_riic_info->cnt2nd)
+            {
+                /* Processing before receiving the "last byte - 1byte" in RX. */
+                riic_receive_pre_end_setting(p_riic_info);
+            }
+
+            /* Performs dummy read. */
+            uctmp = riic_get_receiving_data(p_riic_info);
+
+            break;
+
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Now status? */
+            switch (riic_api_info[p_riic_info->ch_no].N_status)
+            {
+                case RIIC_STS_SEND_SLVADR_W_WAIT :
+
+                    /* Sets the internal status. */
+                    riic_api_status_set(p_riic_info, RIIC_STS_SEND_DATA_WAIT);
+
+                    /* Enables the IIC bus interrupt. */
+                    riic_int_icier_setting(p_riic_info, RIIC_ICIER_TEND_NAK_AL);
+
+                    /* Transmits a 1st data. */
+                    riic_set_sending_data(p_riic_info, p_riic_info->p_data1st);
+
+                    /* Decreases the 1st data counter. */
+                    p_riic_info->cnt1st--;
+
+                    /* Increases the 1st Data buffer pointer. */
+                    p_riic_info->p_data1st++;
+
+                    break;
+
+                case RIIC_STS_SEND_SLVADR_R_WAIT :
+
+                    /* Sets the internal status. */
+                    riic_api_status_set(p_riic_info, RIIC_STS_RECEIVE_DATA_WAIT);
+
+                    /* Enables the IIC bus interrupt. */
+                    riic_int_icier_setting(p_riic_info, RIIC_ICIER_RX_NAK_AL);
+
+                    if (2U >= p_riic_info->cnt2nd)
+                    {
+                        /* The period between the ninth clock cycle and the first clock cycle is held low. */
+                        riic_receive_wait_setting(p_riic_info);
+                    }
+
+                    if (0x00000001 >= p_riic_info->cnt2nd)
+                    {
+                        /* Processing before receiving the "last byte - 1byte" in RX. */
+                        riic_receive_pre_end_setting(p_riic_info);
+                    }
+
+                    /* Performs dummy read. */
+                    uctmp = riic_get_receiving_data(p_riic_info);
+
+                    break;
+
+                default :
+                    ret = RIIC_ERR_OTHER;
+                    break;
+            }
+        break;
+
+        default :
+            ret = RIIC_ERR_OTHER;
+            break;
+
+    }
+
+    return ret;
+} /* End of function riic_after_send_slvadr() */
+
+/***********************************************************************************************************************
+ * Outline      : 
+ * Function Name: riic_after_receive_slvadr
+ * Description  : After Slave Address Receive Processing
+ *                Performs one of the following processing according to the state.
+ *                Transmits a data. Generates the stop condition. Receives a data.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, communication state
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_after_receive_slvadr(riic_info_t * p_riic_info)
+{
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t         uctmp      = 0x00;
+    uint8_t blank_data[1] =
+    { BLANK };
+
+    /* Clears each status flag. */
+    (*picsr2_reg) &= RIIC_ICSR2_STOP_CLR;
+    /* WAIT_LOOP */
+    while (0x00 != ((*picsr2_reg) & RIIC_ICSR2_STOP))
+    {
+        /* Do Nothing */
+    }
+
+    /* ---- Enables IIC bus interrupt enable register. ---- */
+    if (((uint8_t *) FIT_NO_PTR != p_riic_info->p_data1st) && ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data2nd))
+    {
+        /* Enables slave send and slave receive */
+        riic_int_icier_setting(p_riic_info, RIIC_ICIER_TX_RX_SP_NAK);
+    }
+    else if (((uint8_t *) FIT_NO_PTR != p_riic_info->p_data1st) && ((uint8_t *) FIT_NO_PTR == p_riic_info->p_data2nd))
+    {
+        /* Enable slave send */
+        riic_int_icier_setting(p_riic_info, RIIC_ICIER_TX_SP_NAK);
+    }
+    else if (((uint8_t *) FIT_NO_PTR == p_riic_info->p_data1st) && ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data2nd))
+    {
+        /* Enable slave receive */
+        riic_int_icier_setting(p_riic_info, RIIC_ICIER_RX_SP);
+    }
+    else
+    {
+        /* Do Nothing */
+    }
+
+    /* Slave receive mode? */
+    if (0x00 == ((*piccr2_reg) & RIIC_ICCR2_TRS))
+    {
+        /* Sets the internal status. */
+        riic_api_status_set(p_riic_info, RIIC_STS_RECEIVE_DATA_WAIT);
+
+        if (0x00000002 >= p_riic_info->cnt2nd)
+        {
+            /* The period between the ninth clock cycle and the first clock cycle is held low. */
+            riic_receive_wait_setting(p_riic_info);
+        }
+
+        if (0x00000001 >= p_riic_info->cnt2nd)
+        {
+            /* Processing before receiving the "last byte - 1byte" in RX. */
+            riic_receive_pre_end_setting(p_riic_info);
+        }
+
+        /* Performs dummy read. */
+        uctmp = riic_get_receiving_data(p_riic_info);
+    }
+
+    /* Slave send mode */
+    else
+    {
+        /* Sets the internal status. */
+        riic_api_status_set(p_riic_info, RIIC_STS_SEND_DATA_WAIT);
+
+        /* 1st data counter = 0?  */
+        if (0x00000000 != p_riic_info->cnt1st)
+        {
+            if ((uint8_t *) FIT_NO_PTR == p_riic_info->p_data1st)
+            {
+                /* Internal error */
+                return RIIC_ERR_OTHER;
+            }
+
+            /* Transmits a 1st data. */
+            riic_set_sending_data(p_riic_info, p_riic_info->p_data1st);
+
+            /* Decreases the 1st data counter. */
+            p_riic_info->cnt1st--;
+
+            /* Increases the 1st data buffer pointer. */
+            p_riic_info->p_data1st++;
+        }
+        else
+        {
+            /* Transmits a "FFh" data. */
+            riic_set_sending_data(p_riic_info, blank_data);
+        }
+
+    }
+
+    return RIIC_SUCCESS;
+
+} /* End of function riic_after_receive_slvadr() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_write_data_sending
+ * Description  : After Transmitting Data Processing.
+ *                Performs one of the following processing  according to the state.
+ *                Transmits a data. Generates stop condition. Generates restart condition.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, communication state
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_write_data_sending(riic_info_t * p_riic_info)
+{
+    riic_return_t ret = RIIC_SUCCESS;
+    uint8_t blank_data[1] =
+    { BLANK };
+
+    /* IIC mode? */
+    switch (riic_api_info[p_riic_info->ch_no].N_Mode)
+    {
+        case RIIC_MODE_M_SEND :
+
+            /* Is 1st data pointer set? */
+            if ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data1st)
+            {
+                /* 1st data counter = 0?  */
+                if (0x00000000 != p_riic_info->cnt1st) /* Pattern 1 of Master Write */
+                {
+                    /* Transmits a 1st data. */
+                    riic_set_sending_data(p_riic_info, p_riic_info->p_data1st);
+
+                    /* Decreases the 1st data counter. */
+                    p_riic_info->cnt1st--;
+
+                    /* Increases the 1st data buffer pointer. */
+                    p_riic_info->p_data1st++;
+
+                    break;
+                }
+            }
+
+            /* Is 2nd data pointer set? */
+            if ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data2nd)
+            {
+                /* 2nd data counter = 0? */
+                if (0x00000000 != p_riic_info->cnt2nd) /* Pattern 2 of Master Write */
+                {
+                    /* Transmits a 2nd data. */
+                    riic_set_sending_data(p_riic_info, p_riic_info->p_data2nd);
+
+                    /* Decreases the 2nd data counter. */
+                    p_riic_info->cnt2nd--;
+
+                    /* Increases the 2nd data buffer pointer. */
+                    p_riic_info->p_data2nd++;
+
+                    break;
+                }
+            }
+
+            /* Sets the internal status. */
+            riic_api_status_set(p_riic_info, RIIC_STS_SP_COND_WAIT);
+
+            /* Enables the IIC bus interrupt. */
+            riic_int_icier_setting(p_riic_info, RIIC_ICIER_SP_NAK_AL);
+
+            /* Generates the stop condition. */
+            riic_stop_cond_generate(p_riic_info);
+
+            break;
+
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Is 1st data pointer set? */
+            if (0x00000000 != p_riic_info->cnt1st)
+            {
+                /* Transmits a 1st data. */
+                riic_set_sending_data(p_riic_info, p_riic_info->p_data1st);
+
+                /* Decreases the 1st data counter. */
+                p_riic_info->cnt1st--;
+
+                /* Increases the 1st data buffer pointer. */
+                p_riic_info->p_data1st++;
+
+                break;
+            }
+
+            /* Sets the internal status. */
+            riic_api_status_set(p_riic_info, RIIC_STS_ST_COND_WAIT);
+
+            /* Enables the IIC bus interrupt. */
+            riic_int_icier_setting(p_riic_info, RIIC_ICIER_ST_NAK_AL);
+
+            /* Restarts the condition generation */
+            riic_re_start_cond_generate(p_riic_info);
+
+            break;
+
+        case RIIC_MODE_S_SEND :
+
+            /* Is 1st data pointer set? */
+            if ((uint8_t *) FIT_NO_PTR != p_riic_info->p_data1st)
+            {
+                /* 1st data counter = 0?  */
+                if (0x00000000 != p_riic_info->cnt1st)
+                {
+                    /* Transmits a 1st data. */
+                    riic_set_sending_data(p_riic_info, p_riic_info->p_data1st);
+
+                    /* Decreases the 1st data counter. */
+                    p_riic_info->cnt1st--;
+
+                    /* Increases the 1st data buffer pointer. */
+                    p_riic_info->p_data1st++;
+                }
+                else
+                {
+                    /* Transmits a "FFh" data. */
+                    riic_set_sending_data(p_riic_info, blank_data);
+                }
+            }
+            else
+            {
+                /* Transmits a "FFh" data. */
+                riic_set_sending_data(p_riic_info, blank_data);
+            }
+
+            break;
+
+        default :
+            ret = RIIC_ERR_OTHER;
+            break;
+    }
+
+    return ret;
+} /* End of function riic_write_data_sending() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_read_data_receiving
+ * Description  : After Receiving Data Processing.
+ *                Performs one of the following processing  according to the state.
+ *                Receives a data. Generates stop condition.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, communication state
+ **********************************************************************************************************************/
+static riic_return_t riic_read_data_receiving(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    if (0x00000003 >= p_riic_info->cnt2nd)
+    {
+        /* The period between the ninth clock cycle and the first clock cycle is held low. */
+        riic_receive_wait_setting(p_riic_info);
+    }
+
+    if (0x00000002 >= p_riic_info->cnt2nd)
+    {
+        /* Processing before receiving the "last byte - 1byte" in RX. */
+        riic_receive_pre_end_setting(p_riic_info);
+    }
+
+    if (0x00000001 >= p_riic_info->cnt2nd)
+    {
+        if (RIIC_MODE_S_RECEIVE != riic_api_info[p_riic_info->ch_no].N_Mode)
+        {
+            /* Sets the internal status. */
+            riic_api_status_set(p_riic_info, RIIC_STS_SP_COND_WAIT);
+
+            /* Enables the IIC bus interrupt. */
+            riic_int_icier_setting(p_riic_info, RIIC_ICIER_SP_NAK_AL);
+
+            /* Generates the stop condition. */
+            riic_stop_cond_generate(p_riic_info);
+        }
+
+        if (0x00000000 != p_riic_info->cnt2nd)
+        {
+            /* Stores the received data. */
+            *p_riic_info->p_data2nd = riic_get_receiving_data(p_riic_info);
+            p_riic_info->cnt2nd--; /* Decreases the receiving data counter. */
+            p_riic_info->p_data2nd++; /* Increases the receiving data buffer pointer. */
+        }
+        else
+        {
+            /* Performs dummy read. */
+            uctmp = riic_get_receiving_data(p_riic_info);
+        }
+
+        /* Reception end setting */
+        riic_receive_end_setting(p_riic_info);
+    }
+    else
+    {
+        /* Stores the received data. */
+        *p_riic_info->p_data2nd = riic_get_receiving_data(p_riic_info);
+        p_riic_info->cnt2nd--; /* Decreases the receiving data counter. */
+        p_riic_info->p_data2nd++; /* Increases the receiving data buffer pointer. */
+    }
+
+    return RIIC_SUCCESS;
+} /* End of function riic_read_data_receiving() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_after_dtct_stop_cond
+ * Description  : After Generating Stop Condition Processing.
+ *                Checks bus busy.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, finished communication and idle state
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy error
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                  ; Time out error
+ **********************************************************************************************************************/
+static riic_return_t riic_after_dtct_stop_cond(riic_info_t * p_riic_info)
+{
+    riic_return_t ret = RIIC_SUCCESS;
+    bool boolret = RIIC_FALSE;
+    volatile uint8_t * const picser_reg = RIIC_ICSER_ADR(p_riic_info->ch_no);
+
+    /* Waits from "bus busy" to "bus ready". */
+    boolret = riic_check_bus_busy(p_riic_info);
+    if (RIIC_FALSE == boolret)
+    {
+        ret = RIIC_ERR_BUS_BUSY;
+    }
+    else
+    {
+        if (RIIC_TMO == g_riic_ChStatus[p_riic_info->ch_no])
+        {
+            ret = RIIC_ERR_TMO;
+        }
+
+        if (RIIC_AL == g_riic_ChStatus[p_riic_info->ch_no])
+        {
+            ret = RIIC_ERR_AL;
+        }
+    }
+
+    if ((RIIC_MODE_S_SEND == riic_api_info[p_riic_info->ch_no].N_Mode)
+            || (RIIC_MODE_S_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+    {
+        /* Disable slave address1 */
+        (*picser_reg) &= RIIC_ICSER_SAR_DASABLE;
+    }
+
+    return ret;
+} /* End of function riic_after_dtct_stop_cond() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_arbitration_lost
+ * Description  : Arbitration Lost Error Processing. 
+ *                Returns RIIC_ERR_AL.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                    ; Arbitration lost error
+ **********************************************************************************************************************/
+static riic_return_t riic_arbitration_lost(riic_info_t * p_riic_info)
+{
+    /* Checks the internal mode. */
+    /* slave transfer not enable in now */
+    if (((RIIC_MODE_M_SEND == riic_api_info[p_riic_info->ch_no].N_Mode)
+            || (RIIC_MODE_M_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+            || (RIIC_MODE_M_SEND_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+    {
+        /* slave transfer not enable in now and before */
+        if ((((RIIC_MODE_M_SEND == riic_api_info[p_riic_info->ch_no].B_Mode)
+                || (RIIC_MODE_M_RECEIVE == riic_api_info[p_riic_info->ch_no].B_Mode))
+                || (RIIC_MODE_M_SEND_RECEIVE == riic_api_info[p_riic_info->ch_no].B_Mode))
+                || (RIIC_MODE_NONE == riic_api_info[p_riic_info->ch_no].B_Mode))
+        {
+            /* Sets the internal status. */
+            riic_api_status_set(p_riic_info, RIIC_STS_SP_COND_WAIT);
+
+            /* Enables the IIC bus interrupt. */
+            riic_int_icier_setting(p_riic_info, RIIC_ICIER_SP);
+
+        }
+        else if (RIIC_MODE_S_READY == riic_api_info[p_riic_info->ch_no].B_Mode)
+        {
+            /* Initialize API status on RAM */
+            riic_api_mode_event_init(priic_info_s[p_riic_info->ch_no], RIIC_MODE_S_READY);
+
+            /* Sets the internal status. */
+            riic_api_status_set(priic_info_s[p_riic_info->ch_no], RIIC_STS_AL);
+
+            /* ---- Enables IIC bus interrupt enable register. ---- */
+            if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+            {
+                /* Enables slave send and slave receive */
+                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_TX_RX_SP_NAK);
+            }
+            else if (((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data2nd))
+            {
+                /* Enable slave send */
+                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_TX_SP_NAK);
+            }
+            else if (((uint8_t *) FIT_NO_PTR == priic_info_s[p_riic_info->ch_no]->p_data1st)
+                    && ((uint8_t *) FIT_NO_PTR != priic_info_s[p_riic_info->ch_no]->p_data2nd))
+            {
+                /* Enable slave receive */
+                riic_int_icier_setting(priic_info_s[p_riic_info->ch_no], RIIC_ICIER_RX_SP);
+            }
+            else
+            {
+                /* Do Nothing */
+            }
+        }
+        else
+        {
+            /* Do Nothing */
+        }
+    }
+
+    /* slave transfer enable in now */
+    else if ((RIIC_MODE_S_SEND == riic_api_info[p_riic_info->ch_no].N_Mode)
+            || (RIIC_MODE_S_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+    {
+        /* Do Nothing */
+    }
+    else
+    {
+        /* Do Nothing */
+    }
+
+    return RIIC_SUCCESS;
+} /* End of function riic_arbitration_lost() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_time_out
+ * Description  : Time Out Error Processing.
+ *                Generates the time out error and returns RIIC_TMO.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Arbitration lost error
+ **********************************************************************************************************************/
+static riic_return_t riic_time_out(riic_info_t * p_riic_info)
+{
+    /* Sets the internal status. */
+    riic_api_status_set(p_riic_info, RIIC_STS_TMO);
+
+    return RIIC_SUCCESS;
+} /* End of function riic_time_out() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_nack
+ * Description  : Nack Error Processing.
+ *                Generates the stop condition and returns RIIC_NACK.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ **********************************************************************************************************************/
+static riic_return_t riic_nack(riic_info_t * p_riic_info)
+{
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t         uctmp      = 0x00;
+
+    /* Sets the internal status. */
+    riic_api_status_set(p_riic_info, RIIC_STS_SP_COND_WAIT);
+
+    if (RIIC_ICCR2_MST_SET == ((*piccr2_reg) & RIIC_ICCR2_MST))
+    {
+        /* Enables the IIC bus interrupt. */
+        riic_int_icier_setting(p_riic_info, RIIC_ICIER_SP_AL);
+
+        /* Generates the stop condition. */
+        riic_stop_cond_generate(p_riic_info);
+    }
+    else
+    {
+        /* Enables the IIC bus interrupt. */
+        riic_int_icier_setting(p_riic_info, RIIC_ICIER_SP);
+    }
+
+    /* Checks the internal mode. */
+    if ((((RIIC_MODE_M_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode)
+            || (RIIC_MODE_M_SEND_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+            || (RIIC_MODE_S_SEND == riic_api_info[p_riic_info->ch_no].N_Mode))
+            || (RIIC_MODE_S_RECEIVE == riic_api_info[p_riic_info->ch_no].N_Mode))
+    {
+        /* Dummy Read */
+        /* Refer to the RX User's Manual. */
+        uctmp = riic_get_receiving_data(p_riic_info);
+    }
+
+    return RIIC_SUCCESS;
+} /* End of function riic_nack() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_enable_slave_transfer
+ * Description  : Enable IIC Slave Transfer Processing.
+ *                Enable the slave address match interrupt. Sets the internal status.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, idle state on enable slave transfer
+ **********************************************************************************************************************/
+static riic_return_t riic_enable_slave_transfer(riic_info_t * p_riic_info)
+{
+    /* Setting the IIC registers. */
+    /* Includes I/O register read operation at the end of the following function. */
+    riic_slv_addr_match_int_enable(p_riic_info);
+
+    /* Sets the internal status. */
+    riic_api_status_set(p_riic_info, RIIC_STS_IDLE_EN_SLV);
+
+    return RIIC_SUCCESS;
+} /* End of function riic_enable_slave_transfer() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_api_mode_event_init
+ * Description  : Initializes RAM.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ *              : riic_api_mode_t new_mode  ; New mode
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_api_mode_event_init(riic_info_t * p_riic_info, riic_api_mode_t new_mode)
+{
+    uint8_t ch_no = p_riic_info->ch_no;
+    
+    /* Clears the event flag. */
+    riic_api_event[ch_no] = RIIC_EV_INIT;
+
+    /* Sets the previous mode. */
+    riic_api_info[ch_no].B_Mode = riic_api_info[ch_no].N_Mode;
+
+    /* Sets the mode to RIIC_MODE_NONE. */
+    riic_api_info[ch_no].N_Mode = new_mode;
+} /* End of function riic_api_mode_event_init() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_api_mode_set
+ * Description  : Update Internal Status Processing.
+ *                Updates the now status and the previous status.
+ * Arguments    : riic_info_t * p_riic_info          ; IIC Information
+ *              : riic_api_mode_t new_status    ; New status
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_api_mode_set(riic_info_t * p_riic_info, riic_api_mode_t new_mode)
+{
+    uint8_t ch_no = p_riic_info->ch_no;
+    
+    /* Sets the previous status. */
+    riic_api_info[ch_no].B_Mode = riic_api_info[ch_no].N_Mode;
+
+    /* Sets the now status. */
+    riic_api_info[ch_no].N_Mode = new_mode;
+} /* End of function riic_api_mode_set() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_api_status_set
+ * Description  : Update Internal Status Processing.
+ *                Updates the now status and the previous status.
+ * Arguments    : riic_info_t * p_riic_info          ; IIC Information
+ *              : riic_api_status_t new_status  ; New status
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_api_status_set(riic_info_t * p_riic_info, riic_api_status_t new_status)
+{
+    uint8_t ch_no = p_riic_info->ch_no;
+    
+    /* Sets the previous status. */
+    riic_api_info[ch_no].B_status = riic_api_info[ch_no].N_status;
+
+    /* Sets the now status. */
+    riic_api_info[ch_no].N_status = new_status;
+} /* End of function riic_api_status_set() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_set_ch_status
+ * Description  : Updates the channel status.
+ * Arguments    : riic_info_t * p_riic_info          ; IIC Information
+ *              : riic_ch_dev_status_t status               ; channel status, device status
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_set_ch_status(riic_info_t * p_riic_info, riic_ch_dev_status_t status)
+{
+    /* Sets the channel status. */
+    g_riic_ChStatus[p_riic_info->ch_no] = status;
+
+    /* Sets the device status. */
+    p_riic_info->dev_sts = status;
+} /* End of function riic_set_ch_status() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_check_chstatus_start
+ * Description  : Check Channel Status Processing (at Start Function).
+ *                When calls the starting function, checks the channel status.
+ * Arguments    : riic_info_t * p_riic_info          ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_NO_INIT               ; Uninitialized state
+ *              : RIIC_ERR_BUS_BUSY              ; Bus busy
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                   ; Time out error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_check_chstatus_start(riic_info_t * p_riic_info)
+{
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+    riic_return_t ret;
+
+    /* Checks the channel status. */
+    switch (g_riic_ChStatus[p_riic_info->ch_no])
+    {
+        case RIIC_NO_INIT :
+
+            /* It is necessary to reinitialize. */
+            /* Sets the return value to uninitialized state. */
+            ret = RIIC_ERR_NO_INIT;
+            break;
+
+        case RIIC_IDLE :
+        case RIIC_FINISH :
+        case RIIC_NACK :
+
+            /* Checks the device status. */
+            if ((((RIIC_NO_INIT == p_riic_info->dev_sts) || (RIIC_IDLE == p_riic_info->dev_sts))
+                    || (RIIC_FINISH == p_riic_info->dev_sts)) || (RIIC_NACK == p_riic_info->dev_sts))
+            {
+                /* Sets the return value to success state. */
+                ret = RIIC_SUCCESS;
+            }
+            else if (RIIC_COMMUNICATION == p_riic_info->dev_sts)
+            {
+                /* Another device performed a driver reset processing
+                 when this device is in idle state or communicating state. */
+                /* It is necessary to reinitialize. */
+                /* Sets the return value to bus busy state. */
+                ret = RIIC_ERR_BUS_BUSY;
+            }
+            else if (RIIC_TMO == p_riic_info->dev_sts)
+            {
+                /* The device is in error state. */
+                /* Sets the return value to time out error state. */
+                ret = RIIC_ERR_TMO;
+            }
+            else if (RIIC_AL == p_riic_info->dev_sts)
+            {
+                /* The device is in error state. */
+                /* Sets the return value to error state. */
+                ret = RIIC_ERR_AL;
+            }
+            else
+            {
+                ret = RIIC_ERR_OTHER;
+            }
+            break;
+
+        case RIIC_COMMUNICATION :
+
+            /* The device or another device is on communication. */
+            /* Sets the return value to communication state. */
+            ret = RIIC_ERR_BUS_BUSY;
+            break;
+
+        case RIIC_TMO :
+
+            /* The channel is in error state. */
+            /* Sets the return value to time out error state. */
+            ret = RIIC_ERR_TMO;
+            break;
+
+        case RIIC_AL :
+
+            /* The channel is in error state. */
+            /* Sets the return value to error state. */
+            ret = RIIC_ERR_AL;
+            break;
+
+        default :
+            ret = RIIC_ERR_OTHER;
+            break;
+    }
+
+    if (RIIC_MSK_BBSY == ((*piccr2_reg) & RIIC_MSK_BBSY))
+    {
+        ret = RIIC_ERR_BUS_BUSY;
+    }
+
+    return ret;
+} /* End of function riic_check_chstatus_start() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_check_chstatus_advance
+ * Description  : Check Channel Status Processing (at Advance Function).
+ *                When calls the advance function, checks channel status.
+ * Arguments    : riic_info_t * p_riic_info          ; IIC Information
+ * Return Value : RIIC_SUCCESS                   ; Successful operation
+ *              : RIIC_ERR_NO_INIT               ; Uninitialized state
+ *              : RIIC_ERR_AL                    ; Arbitration lost error
+ *              : RIIC_ERR_TMO                   ; Time out error
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_check_chstatus_advance(riic_info_t * p_riic_info)
+{
+    riic_return_t ret;
+
+    /* Checks the channel status. */
+    switch (g_riic_ChStatus[p_riic_info->ch_no])
+    {
+        case RIIC_NO_INIT :
+
+            /* It is necessary to reinitialize. */
+            /* Sets the return value to uninitialized state. */
+            ret = RIIC_ERR_NO_INIT;
+            break;
+
+        case RIIC_IDLE :
+        case RIIC_FINISH :
+        case RIIC_NACK :
+
+            /* Sets the return value to error state. */
+            ret = RIIC_ERR_OTHER;
+            break;
+
+        case RIIC_COMMUNICATION :
+
+            /* Checks the device status. */
+            if ((((RIIC_NO_INIT == p_riic_info->dev_sts) || (RIIC_IDLE == p_riic_info->dev_sts))
+                    || (RIIC_FINISH == p_riic_info->dev_sts)) || (RIIC_NACK == p_riic_info->dev_sts))
+            {
+                /* Sets the return value to idle state. */
+                ret = RIIC_ERR_OTHER;
+            }
+            else if (RIIC_COMMUNICATION == p_riic_info->dev_sts)
+            {
+                /* The device or another device is on communication. */
+                /* Sets the return value to communication state. */
+                ret = RIIC_SUCCESS;
+            }
+            else if (RIIC_TMO == p_riic_info->dev_sts)
+            {
+                /* The device is in error state. */
+                /* Sets the return value to time out error state. */
+                ret = RIIC_ERR_TMO;
+            }
+            else if (RIIC_AL == p_riic_info->dev_sts)
+            {
+                /* The device is in error state. */
+                /* Sets the return value to error state. */
+                ret = RIIC_ERR_AL;
+            }
+            else
+            {
+                ret = RIIC_ERR_OTHER;
+            }
+            break;
+
+        case RIIC_TMO :
+
+            /* The channel is in time out error state. */
+            /* Sets the return value to time out error state. */
+            ret = RIIC_ERR_TMO;
+            break;
+
+        case RIIC_AL :
+
+            /* The channel is in error state. */
+            /* Sets the return value to error state. */
+            ret = RIIC_ERR_AL;
+            break;
+
+        default :
+            ret = RIIC_ERR_OTHER;
+            break;
+    }
+
+    return ret;
+
+} /* End of function riic_check_chstatus_advance() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_enable
+ * Description  : Enables IIC bus interrupt enable register.
+ *              : Enables interrupt.
+ *              : Enables IIC.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_enable(riic_info_t * p_riic_info)
+{
+    /* Initializes the IIC registers. */
+    /* Includes I/O register read operation at the end of the following function. */
+    riic_init_io_register(p_riic_info);
+
+    /* Clears the interrupt request register. */
+    riic_clear_ir_flag(p_riic_info);
+
+    /* Sets the internal status. */
+    riic_api_status_set(p_riic_info, RIIC_STS_IDLE);
+
+    /* Enables the interrupt. */
+    riic_int_enable(p_riic_info);
+
+    /* Clears the RIIC reset or internal reset. */
+    riic_reset_clear(p_riic_info);
+} /* End of function riic_enable() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_disable
+ * Description  : Disables IIC.
+ *              : Disables interrupt.
+ *              : Initializes IIC bus interrupt enable register.
+ *              : Sets internal status.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_disable(riic_info_t * p_riic_info)
+{
+    /* Disables IIC. */
+    /* Sets SCLn and SDAn to non-driven state. */
+    /* Resets all RIIC registers and the internal status. (RIIC reset) */
+    riic_all_reset(p_riic_info);
+
+    /* Sets the internal mode. */
+    riic_api_mode_event_init(p_riic_info, RIIC_MODE_NONE);
+
+    /* Sets the internal status. */
+    riic_api_status_set(p_riic_info, RIIC_STS_NO_INIT);
+
+    /* Disables the interrupt. */
+    riic_int_disable(p_riic_info);
+
+    /* Clears the RIIC reset or internal reset. */
+    riic_reset_clear(p_riic_info);
+} /* End of function riic_disable() */
+
+/***********************************************************************************************************************
+ * Outline      : Initialize IIC Driver Processing
+ * Function Name: riic_init_io_register
+ * Description  : Initializes RIIC register.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_init_io_register(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psarl0_reg = RIIC_SARL0_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psaru0_reg = RIIC_SARU0_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psarl1_reg = RIIC_SARL1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psaru1_reg = RIIC_SARU1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psarl2_reg = RIIC_SARL2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psaru2_reg = RIIC_SARU2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picser_reg = RIIC_ICSER_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picmr2_reg = RIIC_ICMR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picmr3_reg = RIIC_ICMR3_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picfer_reg = RIIC_ICFER_ADR(p_riic_info->ch_no);
+
+    /* Sets SCLn and SDAn to non-driven state. */
+    /* Resets all RIIC registers and the internal status. (RIIC reset) */
+    riic_all_reset(p_riic_info);
+
+    /* Resets ICMR.BC, ICSR1, ICSR2, ICDRS registers and the internal status. (Internal reset) */
+    (*piccr1_reg) |= RIIC_ICCR1_ICE_SET; /* Sets ICCR1.ICE bit to 1. */
+
+    /* Sets slave address format and slave address. */
+    *psarl0_reg = RIIC_SARL0_INIT; /* Sets SARLy and SARUy.(y=0,1,2) */
+    *psaru0_reg = RIIC_SARU0_INIT; /* Sets SARLy and SARUy.(y=0,1,2) */
+    *psarl1_reg = RIIC_SARL1_INIT; /* Sets SARLy and SARUy.(y=0,1,2) */
+    *psaru1_reg = RIIC_SARU1_INIT; /* Sets SARLy and SARUy.(y=0,1,2) */
+    *psarl2_reg = RIIC_SARL2_INIT; /* Sets SARLy and SARUy.(y=0,1,2) */
+    *psaru2_reg = RIIC_SARU2_INIT; /* Sets SARLy and SARUy.(y=0,1,2) */
+    *picser_reg = RIIC_ICSER_INIT; /* Sets ICSER register. */
+
+    uctmp = *picser_reg; /* Reads ICSER. */
+
+    /* Initializes ICMR3 registers. */
+    *picmr3_reg = g_riic_icmr3_init[p_riic_info->ch_no];
+
+    /* Initializes ICFER register. */
+    *picfer_reg = g_riic_icfer_init[p_riic_info->ch_no];
+    uctmp = *picfer_reg; /* Reads ICFER. */
+
+    /* Sets a transfer clock. */
+    /* Includes I/O register read operation at the end of the following function. */
+    riic_set_frequency(p_riic_info); /* Sets ICMR1.CKS[2:0] bit, ICBRL and ICBRH registers. */
+
+    /* Initializes ICMR2 registers. */
+    *picmr2_reg = g_riic_icmr2_init[p_riic_info->ch_no];
+
+    /* Disable interrupts each target MCU.  */
+    riic_mcu_int_disable(p_riic_info->ch_no);
+
+#ifdef TN_RXA012A
+    riic_timeout_counter_clear(p_riic_info->ch_no);
+#endif
+
+} /* End of function riic_init_io_register() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_slv_addr_match_int_enable
+ * Description  : Enable Slave Address Match Interrupt Processing.
+ *                Enables slave address match interrupt.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_slv_addr_match_int_enable(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const psarl0_reg = RIIC_SARL0_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psaru0_reg = RIIC_SARU0_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psarl1_reg = RIIC_SARL1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psaru1_reg = RIIC_SARU1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psarl2_reg = RIIC_SARL2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const psaru2_reg = RIIC_SARU2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picser_reg = RIIC_ICSER_ADR(p_riic_info->ch_no);
+
+    /* internal reset */
+    riic_reset_set(p_riic_info);
+
+    /* Enables slave address match interrupt. */
+    if (1U == g_riic_slv_ad0_format[p_riic_info->ch_no])
+    {
+        /* 7bit address format setting */
+        *psarl0_reg    = g_riic_slv_ad0_val[p_riic_info->ch_no] << 1;
+        *psaru0_reg    = 0x00;
+        (*picser_reg) |= RIIC_ICSER_SAR0E_SET;
+    }
+    else if (2U == g_riic_slv_ad0_format[p_riic_info->ch_no])
+    {
+        /* 10bit address format setting */
+        *psarl0_reg = (uint8_t) (g_riic_slv_ad0_val[p_riic_info->ch_no] & RIIC_SARL_MASK);
+        *psaru0_reg = (uint8_t) (((g_riic_slv_ad0_val[p_riic_info->ch_no] & RIIC_SARU_MASK) >> 7) |
+        RIIC_SARU_10BIT_FORMAT_SET);
+        (*picser_reg) |= RIIC_ICSER_SAR0E_SET;
+    }
+    else
+    {
+        /* Disable slave address0 */
+        (*picser_reg) &= RIIC_ICSER_SAR0E_CLR;
+    }
+
+    if (1U == g_riic_slv_ad1_format[p_riic_info->ch_no])
+    {
+        /* 7bit address format setting */
+        *psarl1_reg    = (uint8_t) (g_riic_slv_ad1_val[p_riic_info->ch_no] << 1);
+        *psaru1_reg    = 0x00;
+        (*picser_reg) |= RIIC_ICSER_SAR1E_SET;
+    }
+    else if (2U == g_riic_slv_ad1_format[p_riic_info->ch_no])
+    {
+        /* 10bit address format setting */
+        *psarl1_reg = (uint8_t) (g_riic_slv_ad1_val[p_riic_info->ch_no] & RIIC_SARL_MASK);
+        *psaru1_reg = (uint8_t) (((g_riic_slv_ad1_val[p_riic_info->ch_no] & RIIC_SARU_MASK) >> 7) |
+        RIIC_SARU_10BIT_FORMAT_SET);
+        (*picser_reg) |= RIIC_ICSER_SAR1E_SET;
+    }
+    else
+    {
+        /* Disable slave address1 */
+        (*picser_reg) &= RIIC_ICSER_SAR1E_CLR;
+    }
+
+    if (1U == g_riic_slv_ad2_format[p_riic_info->ch_no])
+    {
+        /* 7bit address format setting */
+        *psarl2_reg    = (uint8_t) (g_riic_slv_ad2_val[p_riic_info->ch_no] << 1);
+        *psaru2_reg    = 0x00;
+        (*picser_reg) |= RIIC_ICSER_SAR2E_SET;
+    }
+    else if (2 == g_riic_slv_ad2_format[p_riic_info->ch_no])
+    {
+        /* 10bit address format setting */
+        *psarl2_reg = (uint8_t) (g_riic_slv_ad2_val[p_riic_info->ch_no] & RIIC_SARL_MASK);
+        *psaru2_reg = (uint8_t) (((g_riic_slv_ad2_val[p_riic_info->ch_no] & RIIC_SARU_MASK) >> 7) |
+        RIIC_SARU_10BIT_FORMAT_SET);
+        (*picser_reg) |= RIIC_ICSER_SAR2E_SET;
+    }
+    else
+    {
+        /* Disable slave address2 */
+        (*picser_reg) &= RIIC_ICSER_SAR2E_CLR;
+    }
+
+    if (1U == g_riic_gca_enable[p_riic_info->ch_no])
+    {
+        /* General call address setting */
+        (*picser_reg) |= RIIC_ICSER_GCAE_SET;
+    }
+    else
+    {
+        /* Disable General call address */
+        (*picser_reg) &= RIIC_ICSER_GCAE_CLR;
+    }
+    uctmp = *picser_reg; /* Reads ICSER. */
+
+    /* Clears internal reset. */
+    riic_reset_clear(p_riic_info);
+} /* End of function riic_slv_addr_match_int_enable() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_int_enable
+ * Description  : Enable Interrupt Processing.
+ *                Clears interrupt request register. Enables interrupt.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_int_enable(riic_info_t * p_riic_info)
+{
+    /* Clears the interrupt request register. */
+    riic_clear_ir_flag(p_riic_info);
+
+    /* Enable interrupts each target MCU.  */
+    riic_mcu_int_enable(p_riic_info->ch_no);
+} /* End of function riic_int_enable() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_int_disable
+ * Description  : Disable Interrupt Processing.
+ *                Disables interrupt. Sets interrupt source priority. Clears interrupt request register.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_int_disable(riic_info_t * p_riic_info)
+{
+    /* Disable interrupts each target MCU.  */
+    riic_mcu_int_disable(p_riic_info->ch_no);
+
+    /* Clears the interrupt request register. */
+    /* Includes I/O register read operation at the end of the following function. */
+    riic_clear_ir_flag(p_riic_info);
+} /* End of function riic_int_disable() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_int_icier_setting
+ * Description  : Set ICIER Register Processing.
+ *                Sets an interrupt condition of RIIC.
+ * Arguments    : riic_info_t *  p_riic_info     ; IIC Information
+ : uint8_t        New_icier       ; New ICIER value
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_int_icier_setting(riic_info_t * p_riic_info, uint8_t New_icier)
+{
+    /* Setting TMOIE bit of interrupt enable register. */
+    riic_mcu_int_icier_setting(p_riic_info->ch_no, New_icier);
+
+} /* End of function riic_int_icier_setting() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_set_frequency
+ * Description  : Set IIC Frequency Processing. Sets ICMR1, ICBRL and ICBRH registers.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_set_frequency(riic_info_t * p_riic_info)
+{
+    riic_bps_calc(p_riic_info, g_riic_bps[p_riic_info->ch_no]); /* Set BPS */
+} /* End of function riic_set_frequency() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_check_bus_busy
+ * Description  : Check Bus Busy Processing.
+ *                When the bits of the RIIC registers are the following set values, the bus is released.
+ *              :   ICCR2.BBSY = 0 ; The I2C bus is released (bus free state).
+ *              :   ICCR1.SCLI = 1 ; SCLn pin input is at a high level.
+ *              :   ICCR1.SDAI = 1 ; SDAn pin input is at a high level.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : RIIC_TRUE                      ; Bus ready
+ *              : RIIC_FALSE                     ; Bus busy
+ **********************************************************************************************************************/
+static bool riic_check_bus_busy(riic_info_t * p_riic_info)
+{
+    volatile uint32_t cnt = 0x00000000;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+
+    /* Checks bus busy. */
+    /* WAIT_LOOP */
+    for (cnt = RIIC_CFG_BUS_CHECK_COUNTER; cnt > 0x00000000; cnt--)
+    {
+        /* Bus busy? */
+        if ((RIIC_MSK_BBSY != ((*piccr2_reg) & RIIC_MSK_BBSY)) && /* ICCR2.BBSY = 0 */
+        (RIIC_MSK_SCLSDA == ((*piccr1_reg) & RIIC_MSK_SCLSDA))) /* ICCR1.SCLI = 1, ICCR1.SDAI = 1 */
+        {
+            return RIIC_TRUE; /* Bus ready */
+        }
+    }
+    return RIIC_FALSE; /* Bus busy */
+} /* End of function riic_check_bus_busy() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_start_cond_generate
+ * Description  : Generate Start Condition Processing.
+ *                Sets ICCR2.ST bit.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_start_cond_generate(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+
+    /* Clears start condition detection flag. */
+    if (0x00 != (((*picsr2_reg) & RIIC_ICSR2_START_SET) >> 2U))
+    {
+        (*picsr2_reg) &= RIIC_ICSR2_START_CLR;
+    }
+
+    /* Generates a start condition. */
+    (*piccr2_reg) |= RIIC_ICCR2_ST; /* Sets ICCR2.ST bit. */
+    uctmp          = *piccr2_reg; /* Reads ICCR2. */
+} /* End of function riic_start_cond_generate() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_re_start_cond_generate
+ * Description  : Generate Restart Condition Processing.
+ *                Sets ICCR2.RS bit.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_re_start_cond_generate(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+
+    /* Clears start condition detection flag. */
+    if (0x00 != (((*picsr2_reg) & RIIC_ICSR2_START_SET) >> 2U))
+    {
+        (*picsr2_reg) &= RIIC_ICSR2_START_CLR;
+    }
+
+    /* Generates a restart condition. */
+    (*piccr2_reg) |= RIIC_ICCR2_RS; /* Sets ICCR2.RS bit. */
+    uctmp          = *piccr2_reg; /* Reads ICCR2. */
+} /* End of function riic_re_start_cond_generate() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_stop_cond_generate
+ * Description  : Generate Stop Condition Processing.
+ *                Clears ICSR2.STOP bit and sets ICCR2.SP bit.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_stop_cond_generate(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picsr2_reg = RIIC_ICSR2_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const piccr2_reg = RIIC_ICCR2_ADR(p_riic_info->ch_no);
+
+    /* Clears stop condition detection flag. */
+    if (0x00 != (((*picsr2_reg) & RIIC_ICSR2_STOP_SET) >> 3U))
+    {
+        (*picsr2_reg) &= RIIC_ICSR2_STOP_CLR;
+    }
+
+    /* Generates a stop condition. */
+    (*piccr2_reg) |= RIIC_ICCR2_SP; /* Sets ICCR2.SP bit. */
+    uctmp          = *piccr2_reg; /* Reads ICCR2. */
+} /* End of function riic_stop_cond_generate() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_set_sending_data
+ * Description  : Transmit Data Processing.
+ *                Sets transmission data to ICDRT register.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ *              : uint8_t *p_data                ; Transmitted data buffer pointer
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_set_sending_data(riic_info_t * p_riic_info, uint8_t *p_data)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picdrt_reg = RIIC_ICDRT_ADR(p_riic_info->ch_no);
+
+    /* Clears TXI interrupt request register. */
+    /* For the measure to keep the IR flag for the TXI interrupt from stocking twice,               */
+    /* when the IR flag is 1 before writing data to the data buffer in the TXI interrupt handling,  */
+    /* the IR flag is cleared before transmission.                                                  */
+    /* This issue happens, for example, when the following three all occur.                         */
+    /*  - An AL occurred during MasterSend.                                                         */
+    /*  - In the communication with an AL occurred, the RX device is specified with SlaveSend       */
+    /*    by the communication target Master.                                                       */
+    /*  - The TXI interrupt handling is in wait state after receiving the address due to            */
+    /*    another interrupt execution, etc.                                                         */
+    riic_mcu_clear_ir_txi(p_riic_info->ch_no);
+
+    /* Sets the transmitting data. */
+    *picdrt_reg = *p_data; /* Writes data to RIIC in order to transmit. */
+    uctmp       = *picdrt_reg; /* Reads ICDRT. */
+} /* End of function riic_set_sending_data() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_get_receiving_data
+ * Description  : Receive Data Prpcessing.
+ *                Stores received data from ICDRR register.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : Returns received data.
+ **********************************************************************************************************************/
+static uint8_t riic_get_receiving_data(riic_info_t * p_riic_info)
+{
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picdrr_reg = RIIC_ICDRR_ADR(p_riic_info->ch_no);
+
+    /* Stores the received data. */
+    return *picdrr_reg;
+} /* End of function riic_get_receiving_data() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_receive_wait_setting
+ * Description  : Receive "last byte - 2bytes" Setting Proccesing.
+ *                Sets ICMR3.WAIT bit.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_receive_wait_setting(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picmr3_reg = RIIC_ICMR3_ADR(p_riic_info->ch_no);
+
+    /* Sets ICMR3.WAIT bit. */
+    (*picmr3_reg) |= RIIC_ICMR3_WAIT_SET;
+    uctmp          = *picmr3_reg; /* Reads ICMR3. */
+} /* End of function riic_receive_wait_setting() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_receive_pre_end_setting
+ * Description  : Receive "last byte - 1byte" Setting Proccesing.
+ *                Sets ICMR3.RDRFS bit and ACKBT bit.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_receive_pre_end_setting(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picmr3_reg = RIIC_ICMR3_ADR(p_riic_info->ch_no);
+
+    /* Sets ICMR3.RDRFS bit.*/
+    (*picmr3_reg) |= RIIC_ICMR3_RDRFS_SET;
+
+    /* Sets ICMR3.ACKBT bit. */
+    (*picmr3_reg) |= RIIC_ICMR3_ACKWP_SET; /* Modification of the ACKBT bit is enabled.                */
+    (*picmr3_reg) |= RIIC_ICMR3_ACKBT_SET; /* A 1 is sent as the acknowledge bit (NACK transmission).  */
+    (*picmr3_reg) &= RIIC_ICMR3_ACKWP_CLR; /* Modification of the ACKBT bit is disabled.               */
+    uctmp          = *picmr3_reg; /* Reads ICMR3.                                             */
+} /* End of function riic_receive_pre_end_setting() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_receive_end_setting
+ * Description  : Receive End Setting Processing.
+ *                Sets ICMR3.ACKBT bit and clears ICMR3.WAIT bit.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_receive_end_setting(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const picmr3_reg = RIIC_ICMR3_ADR(p_riic_info->ch_no);
+
+    /* Sets ICMR3.ACKBT bit. */
+    (*picmr3_reg) |= RIIC_ICMR3_ACKWP_SET; /* Modification of the ACKBT bit is enabled. */
+    (*picmr3_reg) |= RIIC_ICMR3_ACKBT_SET;
+    (*picmr3_reg) &= RIIC_ICMR3_ACKWP_CLR; /* Modification of the ACKBT bit is disabled. */
+
+    /* Clears ICMR3.WAIT bit. */
+    (*picmr3_reg) &= RIIC_ICMR3_WAIT_CLR;
+    uctmp          = *picmr3_reg; /* Reads ICMR3. */
+} /* End of function riic_receive_end_setting() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_reset_clear
+ * Description  : Enable IIC Function Processing.
+ *                Enables RIIC communication and enables RIIC multi-function pin controller.
+ * Arguments    : riic_info_t * p_riic_info     ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_reset_clear(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+
+    /* Enables RIIC. */
+    (*piccr1_reg) &= RIIC_ICCR1_ENABLE; /* Clears ICCR1.IICRST bit. */
+    uctmp          = *piccr1_reg; /* Reads ICCR1. */
+} /* End of function riic_reset_clear() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_reset_set
+ * Description  : Disable IIC Function Processing.
+ *                Disables RIIC communication and disables RIIC multi-function pin controller.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_reset_set(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+
+    /* Resets RIIC registers. */
+    (*piccr1_reg) |= RIIC_ICCR1_RIIC_RESET; /* Sets ICCR1.IICRST bit. */
+    uctmp          = *piccr1_reg; /* Reads ICCR1. */
+} /* End of function riic_reset_set() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_all_reset
+ * Description  : All reset IIC Function Processing.
+ *                Resets all registers and internal states of the RIIC.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_all_reset(riic_info_t * p_riic_info)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+
+    /* Resets RIIC registers. */
+    (*piccr1_reg) &= RIIC_ICCR1_ICE_CLR; /* Clears ICCR1.ICE bit to 0. */
+    (*piccr1_reg) |= RIIC_ICCR1_RIIC_RESET; /* Sets ICCR1.IICRST bit to 1. */
+
+    uctmp = *piccr1_reg; /* Reads ICCR1. */
+} /* End of function riic_all_reset() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_clear_ir_flag
+ * Description  : Clears Interrupt Request Flag Processing.
+ *                Clears interrupt request register.
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Information
+ * Return Value : None
+ **********************************************************************************************************************/
+static void riic_clear_ir_flag(riic_info_t * p_riic_info)
+{
+    uint8_t internal_flag = 0x00; /* Determines whether reinitialization is necessary. */
+    volatile uint8_t uctmp = 0x00;
+
+    /* Creates the register pointer for the specified RIIC channel. */
+    volatile uint8_t * const piccr1_reg = RIIC_ICCR1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picier_reg = RIIC_ICIER_ADR(p_riic_info->ch_no);
+
+    /* Checks IR flag. */
+    /* If IR flag is set, clears IR flag. */
+    if ((RIIC_IR_SET == riic_mcu_check_ir_txi(p_riic_info->ch_no))
+            || (RIIC_IR_SET == riic_mcu_check_ir_rxi(p_riic_info->ch_no)))
+    {
+        /* Checks ICCR1.ICE bit. */
+        if (RIIC_ICCR1_ICE_SET == ((*piccr1_reg) & RIIC_ICCR1_ICE)) /* ICCR1.ICE = 1 */
+        {
+            /* Sets return value. */
+            internal_flag = 0x01;
+
+            /* Clears ICCR1.ICE bit and sets ICCR1.IICRST bit. */
+            (*piccr1_reg) |= RIIC_ICCR1_RIIC_RESET;
+            /* WAIT_LOOP */
+            while (RIIC_ICCR1_RIIC_RESET != ((*piccr1_reg) & RIIC_ICCR1_RIIC_RESET))
+            {
+                /* Do Nothing */
+            }
+            (*piccr1_reg) &= RIIC_ICCR1_ICE_CLR;
+            /* WAIT_LOOP */
+            while (RIIC_ICCR1_NOT_DRIVEN != ((*piccr1_reg) & RIIC_ICCR1_ICE))
+            {
+                /* Do Nothing */
+            }
+        }
+
+        /* Initializes ICIER register. */
+        *picier_reg = RIIC_ICIER_INIT;
+        /* WAIT_LOOP */
+        while (RIIC_ICIER_INIT != (*picier_reg))
+        {
+            /* Do Nothing */
+        }
+
+        riic_mcu_clear_ir_rxi(p_riic_info->ch_no); /* Clears RXI interrupt request register. */
+        riic_mcu_clear_ir_txi(p_riic_info->ch_no); /* Clears TXI interrupt request register. */
+
+        /* Checks the need of the reinitialization. */
+        if (0x01 == internal_flag)
+        {
+            internal_flag = 0x00;
+
+            /* Reinitializes RIIC register because cleared ICCR1.ICE bit. */
+            /* Includes I/O register read operation at the end of the following function. */
+            riic_init_io_register(p_riic_info);
+        }
+    }
+} /* End of function riic_clear_ir_flag() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_bps_calc
+ * Description  : Calculation for ICBRH and ICBRL registers value
+ *              :  and CKS bits value from setting bps of the argument.
+ *              :
+ * Arguments    : riic_info_t * p_riic_info      ; IIC Informationu
+ *              : uint16_t kbps                  ; bit rate(kHz)
+ * Return Value : RIIC_SUCCESS                   ; Successful operation, communication state
+ *              : RIIC_ERR_OTHER                 ; Other error
+ **********************************************************************************************************************/
+static riic_return_t riic_bps_calc(riic_info_t * p_riic_info, uint16_t kbps)
+{
+    volatile uint8_t uctmp;
+
+    volatile uint8_t * const picmr1_reg = RIIC_ICMR1_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picmr3_reg = RIIC_ICMR3_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picbrl_reg = RIIC_ICBRL_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picbrh_reg = RIIC_ICBRH_ADR(p_riic_info->ch_no);
+    volatile uint8_t * const picfer_reg = RIIC_ICFER_ADR(p_riic_info->ch_no);
+    
+    uint8_t uctmp_tmp;
+
+    const uint8_t d_cks[RIIC_MAX_DIV] =
+    { 1, 2, 4, 8, 16, 32, 64, 128 }; /* divider array of RIIC clock  */
+    double pclk_val;
+
+    volatile double bps = (double) (kbps * 1000);
+    volatile double L_time; /* H Width period */
+    volatile double H_time; /* L Width period */
+    
+    double bps_tmp;
+
+    volatile double calc_val; /* Using for calculation buffer */
+    
+    double calc_val_tmp;
+
+    double scl_up_time;
+    double scl_down_time;
+
+    volatile uint8_t cnt;
+    uint8_t          nf_replace;
+
+    pclk_val = riic_mcu_check_freq(); /* Store pclk frequency */
+
+    /* Set Rise up time and down time */
+    if (kbps > RIIC_FAST_SPPED_MAX)
+    {
+        /* When bps more than 400Kbps[Fast mode plus] */
+        scl_up_time   = RIIC_CFG_SCL1M_UP_TIME;
+        scl_down_time = RIIC_CFG_SCL1M_DOWN_TIME;
+    }
+    else if (kbps > RIIC_STAD_SPPED_MAX)
+    {
+        /* When bps more than 100Kbps[Fast mode] */
+        scl_up_time   = RIIC_CFG_SCL400K_UP_TIME;
+        scl_down_time = RIIC_CFG_SCL400K_DOWN_TIME;
+    }
+    else
+    {
+        /* When bps less than 100Kbps[Standard mode] */
+        scl_up_time   = RIIC_CFG_SCL100K_UP_TIME;
+        scl_down_time = RIIC_CFG_SCL100K_DOWN_TIME;
+    }
+
+    /* Calculation for ICBRH and ICBRL registers value */
+
+    /* Calculation L width time */
+    L_time = (1 / (2 * bps)); /* Harf period of frequency */
+    H_time = L_time;
+
+    /* Check I2C mode of Speed */
+    if (kbps > RIIC_FAST_SPPED_MAX)
+    {
+        /* 400kbps over */
+        /* Check L width */
+        if (L_time <= (0.5E-6 + scl_down_time))
+        {
+            /* Wnen L width less than 0.5us */
+            /* Subtract Rise up and down time for SCL from H/L width */
+            L_time  = 0.5E-6;
+            bps_tmp = bps;
+            H_time  = (((1 / bps_tmp) - L_time) - scl_up_time) - scl_down_time;
+        }
+        else
+        {
+            /* Subtract Rise up and down time for SCL from H/L width */
+            L_time -= scl_down_time;
+            H_time -= scl_up_time;
+        }
+    }
+    else if (kbps > RIIC_STAD_SPPED_MAX)
+    {
+        /* 100kbps over */
+        /* Check L width */
+        if (L_time <= (1.3E-6 + scl_down_time))
+        {
+            /* Wnen L width less than 1.3us */
+            /* Subtract Rise up and down time for SCL from H/L width */
+            L_time  = 1.3E-6;
+            bps_tmp = bps;
+            H_time  = (((1 / bps_tmp) - L_time) - scl_up_time) - scl_down_time;
+        }
+        else
+        {
+            /* Subtract Rise up and down time for SCL from H/L width */
+            L_time -= scl_down_time;
+            H_time -= scl_up_time;
+        }
+    }
+    else
+    {
+        /* less than 100kbps */
+/* Since the L width is calculated based on the half period of frequency above, it is always larger than 4.7 us
+   at 100 kbps or less. Comment out the following branch processing.
+         * Check L width *
+        if (L_time < 4.7E-6)
+        {
+            * Wnen L width less than 4.7us *
+            * Subtract Rise up and down time for SCL from H/L width *
+            L_time = 4.7E-6;
+            H_time = (((1 / bps) - L_time) - scl_up_time) - scl_down_time;
+        }
+        else
+        {
+ */
+        /* Subtract Rise up and down time for SCL from H/L width */
+        L_time -= scl_down_time;
+        H_time -= scl_up_time;
+
+/*      }*/
+    }
+
+    /*************** Calculation ICBRL value ***********************/
+    /* Calculating until calc_val is less than 32 */
+    /* WAIT_LOOP */
+    for (calc_val = 0xFF, cnt = 0; RIIC_ICBR_MAX < calc_val; cnt++)
+    {
+        calc_val = L_time; /* Set L width time */
+
+        /* Check the range of divider of CKS */
+        if (cnt >= RIIC_MAX_DIV)
+        {
+            /* Cannot set bps */
+            return RIIC_ERR_OTHER;
+        }
+
+        calc_val_tmp = calc_val;
+        calc_val     = (calc_val_tmp / (d_cks[cnt] / pclk_val));/* Calculattion ICBRL value */
+        calc_val     = calc_val + 0.5; /* round off */
+    }
+
+    /* store ICMR1 value to avoid CKS bit. */
+    uctmp     = (uint8_t) ((uint8_t) (*picmr1_reg) & (((~BIT4) & (~BIT5)) & (~BIT6)));
+    uctmp_tmp = uctmp;
+
+    *picmr1_reg = (uint8_t) ((uctmp_tmp) | ((cnt - 1) << 4)); /* Set ICMR1.CKS bits.*/
+
+    /* Apply noise filter stage  */
+    nf_replace = ((*picmr3_reg) & (0x03)) + 1;
+
+    /* Check if digital noise filter circuit is used */
+    if (((*picfer_reg) & BIT5) == BIT5)
+    {
+        if ((0 < nf_replace) && (((nf_replace + 1) * 2) > calc_val))
+        {
+            calc_val = (nf_replace + 1) * 2;
+        }
+
+        /* Set value to ICBRL register */
+        *picbrl_reg = (uint8_t) ((((uint8_t) (calc_val - 1 - nf_replace) | BIT7) | BIT6) | BIT5);
+    }
+    else
+    {
+        /* Set value to ICBRL register */
+        *picbrl_reg = (uint8_t) ((((uint8_t) (calc_val - 1) | BIT7) | BIT6) | BIT5);
+    }
+
+    /*************** Calculation ICBRH value ***********************/
+    calc_val     = H_time; /* Set H width */
+    calc_val_tmp = calc_val;
+    calc_val     = (calc_val_tmp / (d_cks[cnt - 1] / pclk_val)); /* Calculattion ICBRH value */
+    calc_val     = (uint8_t) (calc_val + 0.5); /* round off */
+
+    /* If the calculated value is less than 1, it rounded up to 1. */
+    if (1 > calc_val)
+    {
+        calc_val = 1;
+    }
+
+    /* Check if digital noise filter circuit is used */
+    if (((*picfer_reg) & BIT5) == BIT5)
+    {
+        if ((0 < nf_replace) && (((nf_replace + 1) * 2) > calc_val))
+        {
+            calc_val = (nf_replace + 1) * 2;
+        }
+
+        /* Set value to ICBRH register */
+        *picbrh_reg = (uint8_t) ((((uint8_t) (calc_val - 1 - nf_replace) | BIT7) | BIT6) | BIT5);
+    }
+    else
+    {
+        /* Set value to ICBRH register */
+        *picbrh_reg = (uint8_t) ((((uint8_t) (calc_val - 1) | BIT7) | BIT6) | BIT5);
+    }
+    uctmp = *picbrh_reg; /* dummy read */
+
+    return RIIC_SUCCESS;
+
+} /* End of function riic_bps_calc() */
+
+#if (RIIC_CFG_CH0_INCLUDED == 1U)
+/***********************************************************************************************************************
+ * Function Name: riic0_eei_sub
+ * Description  : Interrupt EEI handler for channel 0.
+ *                Types of interrupt requests transfer error or event generation.
+ *                The event generations are arbitration-lost, NACK detection, timeout detection, 
+ *                start condition detection, and stop condition detection.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic0_eei_sub(void)
+{
+    riic_info_t * p_riic_info;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(0);
+    #endif
+
+    /* Checks Time Out. */
+    if ((0U != RIIC0.ICSR2.BIT.TMOF) && (0U != RIIC0.ICIER.BIT.TMOIE))
+    {
+        /* all interrupt disable */
+        RIIC0.ICIER.BIT.TMOIE = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC0.ICIER.BIT.TMOIE)
+        {
+            /* Do Nothing */
+        }
+        riic_api_event[0] = RIIC_EV_INT_TMO;
+    }
+
+    /* Checks Arbitration Lost. */
+    if ((0U != RIIC0.ICSR2.BIT.AL) && (0U != RIIC0.ICIER.BIT.ALIE))
+    {
+        RIIC0.ICIER.BIT.ALIE = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC0.ICIER.BIT.ALIE)
+        {
+            /* Do Nothing */
+        }
+        riic_api_event[0] = RIIC_EV_INT_AL;
+        if (RIIC_MODE_S_READY == riic_api_info[0].B_Mode)
+        {
+            riic_set_ch_status(priic_info_s[0], RIIC_COMMUNICATION);
+        }
+    }
+
+    /* Checks stop condition detection. */
+    if ((0U != RIIC0.ICSR2.BIT.STOP) && (0U != RIIC0.ICIER.BIT.SPIE))
+    {
+        if (((RIIC_MODE_S_READY == riic_api_info[0].N_Mode) || (RIIC_MODE_S_SEND == riic_api_info[0].N_Mode))
+                || (RIIC_MODE_S_RECEIVE == riic_api_info[0].N_Mode))
+        {
+            /* Sets the internal status. */
+            riic_api_status_set(priic_info_s[0], RIIC_STS_SP_COND_WAIT);
+        }
+
+        /* Prohibits STOP interrupt. */
+        RIIC0.ICIER.BIT.SPIE = 0U;
+
+        RIIC0.ICMR3.BIT.RDRFS = 0U; /* Refer to the technical update. */
+        RIIC0.ICMR3.BIT.ACKWP = 1U; /* Refer to the technical update. */
+        RIIC0.ICMR3.BIT.ACKBT = 0U; /* Refer to the technical update. */
+        RIIC0.ICMR3.BIT.ACKWP = 0U; /* Refer to the technical update. */
+        /* WAIT_LOOP */
+        while ((0U != RIIC0.ICMR3.BIT.RDRFS) || (0U != RIIC0.ICMR3.BIT.ACKBT))
+        {
+            /* Do Nothing */
+        }
+
+        /* Clears each status flag. */
+        RIIC0.ICSR2.BIT.STOP = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC0.ICSR2.BIT.STOP)
+        {
+            /* Do Nothing */
+        }
+
+        /* Sets event flag. */
+        riic_api_event[0] = RIIC_EV_INT_STOP;
+    }
+
+    /* Checks NACK reception. */
+    if ((0U != RIIC0.ICSR2.BIT.NACKF) && (0U != RIIC0.ICIER.BIT.NAKIE))
+    {
+        /* Prohibits NACK interrupt to generate stop condition. */
+        RIIC0.ICIER.BIT.NAKIE = 0U;
+
+        /* Prohibits these interrupt. */
+        /* After NACK interrupt, these interrupts will occur when they do not stop the following interrupts. */
+        RIIC0.ICIER.BIT.TEIE = 0U;
+        RIIC0.ICIER.BIT.TIE  = 0U;
+        RIIC0.ICIER.BIT.RIE  = 0U;
+        /* WAIT_LOOP */
+        while (((0U != RIIC0.ICIER.BIT.TEIE) || (0U != RIIC0.ICIER.BIT.TIE)) || (0U != RIIC0.ICIER.BIT.RIE))
+        {
+            /* Do Nothing */
+        }
+
+        if (0U == RIIC0.ICCR2.BIT.TRS)
+        {
+            riic_mcu_clear_ir_rxi(0);
+        }
+
+        /* Sets event flag. */
+        riic_api_event[0] = RIIC_EV_INT_NACK;
+    }
+
+    /* Checks start condition detection. */
+    if ((0U != RIIC0.ICSR2.BIT.START) && (0U != RIIC0.ICIER.BIT.STIE))
+    {
+        /* Disable start condition detection interrupt. */
+        /* Clears status flag. */
+        RIIC0.ICIER.BIT.STIE  = 0U;
+        RIIC0.ICSR2.BIT.START = 0U;
+        /* WAIT_LOOP */
+        while ((0U != RIIC0.ICSR2.BIT.START) || (0U != RIIC0.ICIER.BIT.STIE))
+        {
+            /* Do Nothing */
+        }
+
+        /* Sets event flag. */
+        riic_api_event[0] = RIIC_EV_INT_START;
+    }
+
+    switch (riic_api_info[0].N_Mode)
+    {
+        case RIIC_MODE_M_SEND :
+        case RIIC_MODE_M_RECEIVE :
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Master mode data */
+            p_riic_info = priic_info_m[0];
+            break;
+
+        case RIIC_MODE_S_READY :
+        case RIIC_MODE_S_SEND :
+        case RIIC_MODE_S_RECEIVE :
+
+            /* Slave mode data */
+            p_riic_info = priic_info_s[0];
+            break;
+
+        default :
+
+            /* Internal error */
+            return;
+            break;
+    }
+
+    r_riic_advance(p_riic_info); /* Calls advance function */
+} /* End of function riic0_eei_sub() */
+
+/***********************************************************************************************************************
+ * Function Name: riic0_txi_sub
+ * Description  : Interrupt TXI handler for channel 0.
+ *                Types of interrupt requests transmission data empty.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic0_txi_sub(void)
+{
+    uint8_t tmp;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(0);
+    #endif
+
+    /* TXI processing is performed only when the following conditions are all met.                 */
+    /*  - The address part of data has been received and the received address matches the RX's     */
+    /*    own address.                                                                             */
+    /*  - The RX device is in slave mode.                                                          */
+    /*  - The RX device is in transmission mode (the R/W bit received is 'R' (slave transmission)) */
+    tmp = RIIC0.ICCR2.BYTE;
+    if ((RIIC_ICCR2_MST_SET != (tmp & RIIC_ICCR2_MST)) && (RIIC_ICCR2_TRS_SET == (tmp & RIIC_ICCR2_TRS)))
+    {
+        /* Processing when the addresses match (slave send specified) */
+
+        /* Determines whether the state is arbitration-lost detected.                           */
+        /* When an arbitration-lost is detected, the riic_after_receive_slvadr function is not  */
+        /* executed. Thus the internal status needs to be changed to "RIIC_STS_SEND_DATA_WAIT". */
+        if (RIIC_STS_AL == riic_api_info[0].N_status)
+        {
+            /* Processing when an arbitration-lost is detected. */
+            /* Sets the internal status. */
+            riic_api_status_set(priic_info_s[0], RIIC_STS_SEND_DATA_WAIT);
+        }
+
+        /* Determines if the slave transmission is the first slave transmission.             */
+        /* N_mode is updated from "RIIC_MODE_S_READY" to "RIIC_MODE_S_SEND" on the first TXI */
+        /* interrupt after the slave transmission is determined.                             */
+        if (RIIC_MODE_S_READY == riic_api_info[0].N_Mode)
+        {
+            /* Processing for the first slave transmission */
+            /* Sets the internal mode. */
+            riic_api_info[0].N_Mode = RIIC_MODE_S_SEND; /* Set slave transmission mode. */
+        }
+
+        /* Sets event. */
+        switch (riic_api_info[0].N_status)
+        {
+            case RIIC_STS_IDLE_EN_SLV :
+
+                /* Updates the channel status. */
+                riic_set_ch_status(priic_info_s[0], RIIC_COMMUNICATION);
+
+                /* Sets interrupted address sending. */
+                riic_api_event[0] = RIIC_EV_INT_ADD;
+
+                break;
+
+            case RIIC_STS_SEND_DATA_WAIT :
+
+                /* Sets interrupted data sending. */
+                riic_api_event[0] = RIIC_EV_INT_SEND;
+
+                break;
+
+            default :
+
+                /* Does nothing. */
+                break;
+
+        }
+
+        r_riic_advance(priic_info_s[0]); /* Calls advance function */
+
+    }
+} /* End of function riic0_txi_sub() */
+
+/***********************************************************************************************************************
+ * Function Name: riic0_rxi_sub
+ * Description  : Interrupt RXI handler for channel 0.
+ *                Types of interrupt requests reception end.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic0_rxi_sub(void)
+{
+    riic_info_t * p_riic_info;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(0);
+    #endif
+
+    if (RIIC_STS_AL == riic_api_info[0].N_status)
+    {
+        /* Sets the internal status. */
+        riic_api_status_set(priic_info_s[0], RIIC_STS_IDLE_EN_SLV);
+    }
+
+    if (RIIC_MODE_S_READY == riic_api_info[0].N_Mode)
+    {
+        /* Sets the internal mode. */
+        riic_api_info[0].N_Mode = RIIC_MODE_S_RECEIVE;
+    }
+
+    if ((RIIC_STS_IDLE_EN_SLV == riic_api_info[0].N_status))
+    {
+        /* Updates the channel status. */
+        riic_set_ch_status(priic_info_s[0], RIIC_COMMUNICATION);
+    }
+
+    switch (riic_api_info[0].N_Mode)
+    {
+        case RIIC_MODE_M_RECEIVE :
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Master mode data */
+            p_riic_info = priic_info_m[0];
+            break;
+
+        case RIIC_MODE_S_RECEIVE :
+
+            /* Slave mode data */
+            p_riic_info = priic_info_s[0];
+            break;
+
+        default :
+
+            /* Internal error */
+            return;
+            break;
+    }
+
+    /* Sets interrupted data receiving. */
+    riic_api_event[0] = RIIC_EV_INT_RECEIVE;
+
+    r_riic_advance(p_riic_info); /* Calls advance function */
+} /* End of function riic0_rxi_sub() */
+
+/***********************************************************************************************************************
+ * Function Name: riic0_tei_sub
+ * Description  : Interrupt TEI handler for channel 0.
+ *                Types of interrupt requests transmission end.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic0_tei_sub(void)
+{
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(0);
+    #endif
+
+    /* Clears ICSR2.TEND. */
+    RIIC0.ICSR2.BIT.TEND = 0U;
+    /* WAIT_LOOP */
+    while (0U != RIIC0.ICSR2.BIT.TEND)
+    {
+        /* Do Nothing */
+    }
+
+    /* Sets event. */
+    switch (riic_api_info[0].N_status)
+    {
+        case RIIC_STS_SEND_SLVADR_W_WAIT :
+        case RIIC_STS_SEND_SLVADR_R_WAIT :
+
+            /* Sets interrupted address sending. */
+            riic_api_event[0] = RIIC_EV_INT_ADD;
+
+            break;
+
+        case RIIC_STS_SEND_DATA_WAIT :
+
+            /* Sets interrupted data sending. */
+            riic_api_event[0] = RIIC_EV_INT_SEND;
+
+            break;
+
+        default :
+
+            /* Does nothing. */
+            break;
+
+    }
+
+    r_riic_advance(priic_info_m[0]); /* Calls advance function */
+} /* End of function riic0_tei_sub() */
+#endif
+
+#if (RIIC_CFG_CH1_INCLUDED == 1U)
+/***********************************************************************************************************************
+ * Function Name: riic1_eei_sub
+ * Description  : Interrupt EEI handler for channel 1.
+ *                Types of interrupt requests transfer error or event generation.
+ *                The event generations are arbitration-lost, NACK detection, timeout detection, 
+ *                start condition detection, and stop condition detection.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic1_eei_sub (void)
+{
+    riic_info_t * p_riic_info;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(1);
+    #endif
+
+    /* Checks Time Out. */
+    if ((0U != RIIC1.ICSR2.BIT.TMOF) && (0U != RIIC1.ICIER.BIT.TMOIE))
+    {
+        /* all interrupt disable */
+        RIIC1.ICIER.BIT.TMOIE = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC1.ICIER.BIT.TMOIE)
+        {
+            /* Do Nothing */
+        }
+        riic_api_event[1] = RIIC_EV_INT_TMO;
+    }
+
+    /* Checks Arbitration Lost. */
+    if ((0U != RIIC1.ICSR2.BIT.AL) && (0U != RIIC1.ICIER.BIT.ALIE))
+    {
+        RIIC1.ICIER.BIT.ALIE = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC1.ICIER.BIT.ALIE)
+        {
+            /* Do Nothing */
+        }
+        riic_api_event[1] = RIIC_EV_INT_AL;
+        if (RIIC_MODE_S_READY == riic_api_info[1].B_Mode)
+        {
+            riic_set_ch_status(priic_info_s[1], RIIC_COMMUNICATION);
+        }
+    }
+
+    /* Checks stop condition detection. */
+    if ((0U != RIIC1.ICSR2.BIT.STOP) && (0U != RIIC1.ICIER.BIT.SPIE))
+    {
+        if (((RIIC_MODE_S_READY == riic_api_info[1].N_Mode) || (RIIC_MODE_S_SEND == riic_api_info[1].N_Mode))
+                || (RIIC_MODE_S_RECEIVE == riic_api_info[1].N_Mode))
+        {
+            /* Sets the internal status. */
+            riic_api_status_set(priic_info_s[1], RIIC_STS_SP_COND_WAIT);
+        }
+
+        /* Prohibits STOP interrupt. */
+        RIIC1.ICIER.BIT.SPIE = 0U;
+
+        RIIC1.ICMR3.BIT.RDRFS = 0U; /* Refer to the technical update. */
+        RIIC1.ICMR3.BIT.ACKWP = 1U; /* Refer to the technical update. */
+        RIIC1.ICMR3.BIT.ACKBT = 0U; /* Refer to the technical update. */
+        RIIC1.ICMR3.BIT.ACKWP = 0U; /* Refer to the technical update. */
+        /* WAIT_LOOP */
+        while ((0U != RIIC1.ICMR3.BIT.RDRFS) || (0U != RIIC1.ICMR3.BIT.ACKBT))
+        {
+            /* Do Nothing */
+        }
+
+        /* Clears each status flag. */
+        RIIC1.ICSR2.BIT.STOP = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC1.ICSR2.BIT.STOP)
+        {
+            /* Do Nothing */
+        }
+
+        /* Sets event flag. */
+        riic_api_event[1] = RIIC_EV_INT_STOP;
+    }
+
+    /* Checks NACK reception. */
+    if ((0U != RIIC1.ICSR2.BIT.NACKF) && (0U != RIIC1.ICIER.BIT.NAKIE))
+    {
+        /* Prohibits NACK interrupt to generate stop condition. */
+        RIIC1.ICIER.BIT.NAKIE = 0U;
+
+        /* Prohibits these interrupt. */
+        /* After NACK interrupt, these interrupts will occur when they do not stop the following interrupts. */
+        RIIC1.ICIER.BIT.TEIE = 0U;
+        RIIC1.ICIER.BIT.TIE = 0U;
+        RIIC1.ICIER.BIT.RIE = 0U;
+        /* WAIT_LOOP */
+        while (((0U != RIIC1.ICIER.BIT.TEIE) || (0U != RIIC1.ICIER.BIT.TIE)) || (0U != RIIC1.ICIER.BIT.RIE) )
+        {
+            /* Do Nothing */
+        }
+
+        if (0U == RIIC1.ICCR2.BIT.TRS)
+        {
+            riic_mcu_clear_ir_rxi(1);
+        }
+
+        /* Sets event flag. */
+        riic_api_event[1] = RIIC_EV_INT_NACK;
+    }
+
+    /* Checks start condition detection. */
+    if ((0U != RIIC1.ICSR2.BIT.START) && (0U != RIIC1.ICIER.BIT.STIE))
+    {
+        /* Disable start condition detection interrupt. */
+        /* Clears status flag. */
+        RIIC1.ICIER.BIT.STIE = 0U;
+        RIIC1.ICSR2.BIT.START = 0U;
+        /* WAIT_LOOP */
+        while ((0U != RIIC1.ICSR2.BIT.START) || (0U != RIIC1.ICIER.BIT.STIE))
+        {
+            /* Do Nothing */
+        }
+
+        /* Sets event flag. */
+        riic_api_event[1] = RIIC_EV_INT_START;
+    }
+
+    switch (riic_api_info[1].N_Mode)
+    {
+        case RIIC_MODE_M_SEND :
+        case RIIC_MODE_M_RECEIVE :
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Master mode data */
+            p_riic_info = priic_info_m[1];
+        break;
+
+        case RIIC_MODE_S_READY :
+        case RIIC_MODE_S_SEND :
+        case RIIC_MODE_S_RECEIVE :
+
+            /* Slave mode data */
+            p_riic_info = priic_info_s[1];
+        break;
+
+        default :
+
+            /* Internal error */
+            return;
+        break;
+    }
+
+    r_riic_advance(p_riic_info); /* Calls advance function */
+} /* End of function riic1_eei_sub() */
+
+/***********************************************************************************************************************
+ * Function Name: riic1_txi_sub
+ * Description  : Interrupt TXI handler for channel 1.
+ *                Types of interrupt requests transmission data empty. Does not use.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic1_txi_sub (void)
+{
+    uint8_t tmp;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(1);
+    #endif
+
+    /* TXI processing is performed only when the following conditions are all met.                 */
+    /*  - The address part of data has been received and the received address matches the RX's     */
+    /*    own address.                                                                             */
+    /*  - The RX device is in slave mode.                                                          */
+    /*  - The RX device is in transmission mode (the R/W bit received is 'R' (slave transmission)) */
+    tmp = RIIC1.ICCR2.BYTE;
+    if ((RIIC_ICCR2_MST_SET != (tmp & RIIC_ICCR2_MST)) && (RIIC_ICCR2_TRS_SET == (tmp & RIIC_ICCR2_TRS)))
+    {
+        /* Processing when the addresses match (slave send specified) */
+
+        /* Determines whether the state is arbitration-lost detected.                           */
+        /* When an arbitration-lost is detected, the riic_after_receive_slvadr function is not  */
+        /* executed. Thus the internal status needs to be changed to "RIIC_STS_SEND_DATA_WAIT". */
+        if (RIIC_STS_AL == riic_api_info[1].N_status)
+        {
+            /* Processing when an arbitration-lost is detected. */
+            /* Sets the internal status. */
+            riic_api_status_set(priic_info_s[1], RIIC_STS_SEND_DATA_WAIT);
+        }
+
+        /* Determines if the slave transmission is the first slave transmission.             */
+        /* N_mode is updated from "RIIC_MODE_S_READY" to "RIIC_MODE_S_SEND" on the first TXI */
+        /* interrupt after the slave transmission is determined.                             */
+        if (RIIC_MODE_S_READY == riic_api_info[1].N_Mode)
+        {
+            /* Processing for the first slave transmission */
+            /* Sets the internal mode. */
+            riic_api_info[1].N_Mode = RIIC_MODE_S_SEND; /* Set slave transmission mode. */
+        }
+
+        /* Sets event. */
+        switch (riic_api_info[1].N_status)
+        {
+            case RIIC_STS_IDLE_EN_SLV :
+
+                /* Updates the channel status. */
+                riic_set_ch_status(priic_info_s[1], RIIC_COMMUNICATION);
+
+                /* Sets interrupted address sending. */
+                riic_api_event[1] = RIIC_EV_INT_ADD;
+
+            break;
+
+            case RIIC_STS_SEND_DATA_WAIT :
+
+                /* Sets interrupted data sending. */
+                riic_api_event[1] = RIIC_EV_INT_SEND;
+
+            break;
+
+            default :
+
+                /* Does nothing. */
+            break;
+
+        }
+
+        r_riic_advance(priic_info_s[1]); /* Calls advance function */
+
+    }
+} /* End of function riic1_txi_sub() */
+
+/***********************************************************************************************************************
+ * Outline      : 
+ * Function Name: riic1_rxi_sub
+ * Description  : Interrupt RXI handler for channel 1.
+ *                Types of interrupt requests reception end.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic1_rxi_sub (void)
+{
+    riic_info_t * p_riic_info;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(1);
+    #endif
+
+    if (RIIC_STS_AL == riic_api_info[1].N_status)
+    {
+        /* Sets the internal status. */
+        riic_api_status_set(priic_info_s[1], RIIC_STS_IDLE_EN_SLV);
+    }
+
+    if (RIIC_MODE_S_READY == riic_api_info[1].N_Mode)
+    {
+        /* Sets the internal mode. */
+        riic_api_info[1].N_Mode = RIIC_MODE_S_RECEIVE;
+    }
+
+    if ((RIIC_STS_IDLE_EN_SLV == riic_api_info[1].N_status))
+    {
+        /* Updates the channel status. */
+        riic_set_ch_status(priic_info_s[1], RIIC_COMMUNICATION);
+    }
+
+    switch (riic_api_info[1].N_Mode)
+    {
+        case RIIC_MODE_M_RECEIVE :
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Master mode data */
+            p_riic_info = priic_info_m[1];
+        break;
+
+        case RIIC_MODE_S_RECEIVE :
+
+            /* Slave mode data */
+            p_riic_info = priic_info_s[1];
+        break;
+
+        default :
+
+            /* Internal error */
+            return;
+        break;
+    }
+
+    /* Sets interrupted data receiving. */
+    riic_api_event[1] = RIIC_EV_INT_RECEIVE;
+
+    r_riic_advance(p_riic_info); /* Calls advance function */
+} /* End of function riic1_rxi_sub() */
+
+/***********************************************************************************************************************
+ * Outline      : 
+ * Function Name: riic1_tei_sub
+ * Description  : Interrupt TEI handler for channel 1.
+ *                Types of interrupt requests transmission end.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic1_tei_sub (void)
+{
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(1);
+    #endif
+
+    /* Clears ICSR2.TEND. */
+    RIIC1.ICSR2.BIT.TEND = 0U;
+    /* WAIT_LOOP */
+    while (0U != RIIC1.ICSR2.BIT.TEND)
+    {
+        /* Do Nothing */
+    }
+
+    /* Sets event. */
+    switch (riic_api_info[1].N_status)
+    {
+        case RIIC_STS_SEND_SLVADR_W_WAIT :
+        case RIIC_STS_SEND_SLVADR_R_WAIT :
+
+            /* Sets interrupted address sending. */
+            riic_api_event[1] = RIIC_EV_INT_ADD;
+
+        break;
+
+        case RIIC_STS_SEND_DATA_WAIT :
+
+            /* Sets interrupted data sending. */
+            riic_api_event[1] = RIIC_EV_INT_SEND;
+
+        break;
+
+        default :
+
+            /* Does nothing. */
+        break;
+
+    }
+
+    r_riic_advance(priic_info_m[1]); /* Calls advance function */
+} /* End of function riic1_tei_sub() */
+#endif
+
+#if (RIIC_CFG_CH2_INCLUDED == 1U)
+/***********************************************************************************************************************
+ * Function Name: riic2_eei_sub
+ * Description  : Interrupt EEI handler for channel 2.
+ *                Types of interrupt requests transfer error or event generation.
+ *                The event generations are arbitration-lost, NACK detection, timeout detection, 
+ *                start condition detection, and stop condition detection.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic2_eei_sub (void)
+{
+    riic_info_t * p_riic_info;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(2);
+    #endif
+
+    /* Checks Time Out. */
+    if ((0U != RIIC2.ICSR2.BIT.TMOF) && (0U != RIIC2.ICIER.BIT.TMOIE))
+    {
+        /* all interrupt disable */
+        RIIC2.ICIER.BIT.TMOIE = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC2.ICIER.BIT.TMOIE)
+        {
+            /* Do Nothing */
+        }
+        riic_api_event[2] = RIIC_EV_INT_TMO;
+    }
+
+    /* Checks Arbitration Lost. */
+    if ((0U != RIIC2.ICSR2.BIT.AL) && (0U != RIIC2.ICIER.BIT.ALIE))
+    {
+        RIIC2.ICIER.BIT.ALIE = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC2.ICIER.BIT.ALIE)
+        {
+            /* Do Nothing */
+        }
+        riic_api_event[2] = RIIC_EV_INT_AL;
+        if(RIIC_MODE_S_READY == riic_api_info[2].B_Mode)
+        {
+            riic_set_ch_status(priic_info_s[2], RIIC_COMMUNICATION);
+        }
+    }
+
+    /* Checks stop condition detection. */
+    if ((0U != RIIC2.ICSR2.BIT.STOP) && (0U != RIIC2.ICIER.BIT.SPIE))
+    {
+        if (((RIIC_MODE_S_READY == riic_api_info[2].N_Mode) || (RIIC_MODE_S_SEND == riic_api_info[2].N_Mode))
+                || (RIIC_MODE_S_RECEIVE == riic_api_info[2].N_Mode))
+        {
+            /* Sets the internal status. */
+            riic_api_status_set(priic_info_s[2], RIIC_STS_SP_COND_WAIT);
+        }
+
+        /* Prohibits STOP interrupt. */
+        RIIC2.ICIER.BIT.SPIE = 0U;
+
+        RIIC2.ICMR3.BIT.RDRFS = 0U; /* Refer to the technical update. */
+        RIIC2.ICMR3.BIT.ACKWP = 1U; /* Refer to the technical update. */
+        RIIC2.ICMR3.BIT.ACKBT = 0U; /* Refer to the technical update. */
+        RIIC2.ICMR3.BIT.ACKWP = 0U; /* Refer to the technical update. */
+        /* WAIT_LOOP */
+        while ((0U != RIIC2.ICMR3.BIT.RDRFS) || (0U != RIIC2.ICMR3.BIT.ACKBT))
+        {
+            /* Do Nothing */
+        }
+
+        /* Clears each status flag. */
+        RIIC2.ICSR2.BIT.STOP = 0U;
+        /* WAIT_LOOP */
+        while (0U != RIIC2.ICSR2.BIT.STOP)
+        {
+            /* Do Nothing */
+        }
+
+        /* Sets event flag. */
+        riic_api_event[2] = RIIC_EV_INT_STOP;
+    }
+
+    /* Checks NACK reception. */
+    if ((0U != RIIC2.ICSR2.BIT.NACKF) && (0U != RIIC2.ICIER.BIT.NAKIE))
+    {
+        /* Prohibits NACK interrupt to generate stop condition. */
+        RIIC2.ICIER.BIT.NAKIE = 0U;
+
+        /* Prohibits these interrupt. */
+        /* After NACK interrupt, these interrupts will occur when they do not stop the following interrupts. */
+        RIIC2.ICIER.BIT.TEIE = 0U;
+        RIIC2.ICIER.BIT.TIE = 0U;
+        RIIC2.ICIER.BIT.RIE = 0U;
+        /* WAIT_LOOP */
+        while (((0U != RIIC2.ICIER.BIT.TEIE) || (0U != RIIC2.ICIER.BIT.TIE)) || (0U != RIIC2.ICIER.BIT.RIE) )
+        {
+            /* Do Nothing */
+        }
+
+        if (0U == RIIC2.ICCR2.BIT.TRS)
+        {
+            riic_mcu_clear_ir_rxi(2);
+        }
+
+        /* Sets event flag. */
+        riic_api_event[2] = RIIC_EV_INT_NACK;
+    }
+
+    /* Checks start condition detection. */
+    if ((0U != RIIC2.ICSR2.BIT.START) && (0U != RIIC2.ICIER.BIT.STIE))
+    {
+        /* Disable start condition detection interrupt. */
+        /* Clears status flag. */
+        RIIC2.ICIER.BIT.STIE = 0U;
+        RIIC2.ICSR2.BIT.START = 0U;
+        /* WAIT_LOOP */
+        while ((0U != RIIC2.ICSR2.BIT.START) || (0U != RIIC2.ICIER.BIT.STIE))
+        {
+            /* Do Nothing */
+        }
+
+        /* Sets event flag. */
+        riic_api_event[2] = RIIC_EV_INT_START;
+    }
+
+    switch(riic_api_info[2].N_Mode)
+    {
+        case RIIC_MODE_M_SEND :
+        case RIIC_MODE_M_RECEIVE :
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Master mode data */
+            p_riic_info = priic_info_m[2];
+        break;
+
+        case RIIC_MODE_S_READY :
+        case RIIC_MODE_S_SEND :
+        case RIIC_MODE_S_RECEIVE :
+
+            /* Slave mode data */
+            p_riic_info = priic_info_s[2];
+        break;
+
+        default :
+
+            /* Internal error */
+            return;
+        break;
+    }
+
+    r_riic_advance(p_riic_info); /* Calls advance function */
+} /* End of function riic2_eei_sub() */
+
+/***********************************************************************************************************************
+ * Function Name: riic2_txi_sub
+ * Description  : Interrupt TXI handler for channel 2.
+ *                Types of interrupt requests transmission data empty.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic2_txi_sub (void)
+{
+    uint8_t tmp;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(2);
+    #endif
+
+    /* TXI processing is performed only when the following conditions are all met.                 */
+    /*  - The address part of data has been received and the received address matches the RX's     */
+    /*    own address.                                                                             */
+    /*  - The RX device is in slave mode.                                                          */
+    /*  - The RX device is in transmission mode (the R/W bit received is 'R' (slave transmission)) */
+    tmp = RIIC2.ICCR2.BYTE;
+    if ((RIIC_ICCR2_MST_SET != (tmp & RIIC_ICCR2_MST)) && (RIIC_ICCR2_TRS_SET == (tmp & RIIC_ICCR2_TRS)))
+    {
+        /* Processing when the addresses match (slave send specified) */
+
+        /* Determines whether the state is arbitration-lost detected.                           */
+        /* When an arbitration-lost is detected, the riic_after_receive_slvadr function is not  */
+        /* executed. Thus the internal status needs to be changed to "RIIC_STS_SEND_DATA_WAIT". */
+        if (RIIC_STS_AL == riic_api_info[2].N_status)
+        {
+            /* Processing when an arbitration-lost is detected. */
+            /* Sets the internal status. */
+            riic_api_status_set(priic_info_s[2], RIIC_STS_SEND_DATA_WAIT);
+        }
+
+        /* Determines if the slave transmission is the first slave transmission.             */
+        /* N_mode is updated from "RIIC_MODE_S_READY" to "RIIC_MODE_S_SEND" on the first TXI */
+        /* interrupt after the slave transmission is determined.                             */
+        if (RIIC_MODE_S_READY == riic_api_info[2].N_Mode)
+        {
+            /* Processing for the first slave transmission */
+            /* Sets the internal mode. */
+            riic_api_info[2].N_Mode = RIIC_MODE_S_SEND; /* Set slave transmission mode. */
+        }
+
+        /* Sets event. */
+        switch (riic_api_info[2].N_status)
+        {
+            case RIIC_STS_IDLE_EN_SLV :
+
+                /* Updates the channel status. */
+                riic_set_ch_status(priic_info_s[2], RIIC_COMMUNICATION);
+
+                /* Sets interrupted address sending. */
+                riic_api_event[2] = RIIC_EV_INT_ADD;
+
+            break;
+
+            case RIIC_STS_SEND_DATA_WAIT :
+
+                /* Sets interrupted data sending. */
+                riic_api_event[2] = RIIC_EV_INT_SEND;
+
+            break;
+
+            default :
+
+                /* Does nothing. */
+            break;
+
+        }
+
+        r_riic_advance(priic_info_s[2]); /* Calls advance function */
+
+    }
+} /* End of function riic2_txi_sub() */
+
+/***********************************************************************************************************************
+ * Outline      : 
+ * Function Name: riic2_rxi_sub
+ * Description  : Interrupt RXI handler for channel 2.
+ *                Types of interrupt requests reception end.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic2_rxi_sub (void)
+{
+    riic_info_t * p_riic_info;
+
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(2);
+    #endif
+
+    if (RIIC_STS_AL == riic_api_info[2].N_status)
+    {
+        /* Sets the internal status. */
+        riic_api_status_set(priic_info_s[2], RIIC_STS_IDLE_EN_SLV);
+    }
+
+    if (RIIC_MODE_S_READY == riic_api_info[2].N_Mode)
+    {
+        /* Sets the internal mode. */
+        riic_api_info[2].N_Mode = RIIC_MODE_S_RECEIVE;
+    }
+
+    if ((RIIC_STS_IDLE_EN_SLV == riic_api_info[2].N_status))
+    {
+        /* Updates the channel status. */
+        riic_set_ch_status(priic_info_s[2], RIIC_COMMUNICATION);
+    }
+
+    switch (riic_api_info[2].N_Mode)
+    {
+        case RIIC_MODE_M_RECEIVE :
+        case RIIC_MODE_M_SEND_RECEIVE :
+
+            /* Master mode data */
+            p_riic_info = priic_info_m[2];
+        break;
+
+        case RIIC_MODE_S_RECEIVE :
+
+            /* Slave mode data */
+            p_riic_info = priic_info_s[2];
+        break;
+
+        default :
+
+            /* Internal error */
+            return;
+        break;
+    }
+
+    /* Sets interrupted data receiving. */
+    riic_api_event[2] = RIIC_EV_INT_RECEIVE;
+
+    r_riic_advance(p_riic_info); /* Calls advance function */
+} /* End of function riic2_rxi_sub() */
+
+/***********************************************************************************************************************
+ * Outline      : 
+ * Function Name: riic2_tei_sub
+ * Description  : Interrupt TEI handler for channel 2.
+ *                Types of interrupt requests transmission end.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic2_tei_sub (void)
+{
+    #ifdef TN_RXA012A
+    riic_timeout_counter_clear(2);
+    #endif
+
+    /* Clears ICSR2.TEND. */
+    RIIC2.ICSR2.BIT.TEND = 0U;
+    /* WAIT_LOOP */
+    while (0U != RIIC2.ICSR2.BIT.TEND)
+    {
+        /* Do Nothing */
+    }
+
+    /* Sets event. */
+    switch (riic_api_info[2].N_status)
+    {
+        case RIIC_STS_SEND_SLVADR_W_WAIT :
+        case RIIC_STS_SEND_SLVADR_R_WAIT :
+
+            /* Sets interrupted address sending. */
+            riic_api_event[2] = RIIC_EV_INT_ADD;
+
+        break;
+
+        case RIIC_STS_SEND_DATA_WAIT :
+
+            /* Sets interrupted data sending. */
+            riic_api_event[2] = RIIC_EV_INT_SEND;
+
+        break;
+
+        default :
+
+            /* Does nothing. */
+        break;
+
+    }
+
+    r_riic_advance(priic_info_m[2]); /* Calls advance function */
+} /* End of function riic2_tei_sub() */
+#endif
+
+/***********************************************************************************************************************
+ * Function Name: riic_timeout_counter_clear
+ * Description  : Technical update No.TN-RX*-A012A process.
+ *                Time out internal counter clear.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+#ifdef TN_RXA012A
+static void riic_timeout_counter_clear (uint8_t channel)
+{
+    volatile uint8_t * const picmr2_reg = RIIC_ICMR2_ADR(channel);
+    volatile uint8_t * const ptmocntl_reg = RIIC_TMOCNTL_ADR(channel);
+    volatile uint8_t * const ptmocnth_reg = RIIC_TMOCNTH_ADR(channel);
+
+    /* time out internal counter write enable */
+    (*picmr2_reg) |= RIIC_ICMR2_TMWE_SET;
+    if (RIIC_ICMR2_TMWE == ((*picmr2_reg) & RIIC_ICMR2_TMWE))
+    {
+        /* Do Nothing */
+    }
+
+    /* time out iternal counter clear */
+    (*ptmocntl_reg) = 0x00;
+    (*ptmocnth_reg) = 0x00;
+    if (0xFF == (*ptmocnth_reg))
+    {
+        /* Do Nothing */
+    }
+
+    /* time out internal counter write disable */
+    (*picmr2_reg) &= RIIC_ICMR2_TMWE_CLR;
+    if (0x00 == ((*picmr2_reg) & RIIC_ICMR2_TMWE))
+    {
+        /* Do Nothing */
+    }
+} /* End of function riic_timeout_counter_clear() */
+#endif
+

--- a/drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx_private.h
+++ b/drivers/rx/rdp/src/r_riic_rx/src/r_riic_rx_private.h
@@ -1,0 +1,808 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+ * File Name    : r_riic_private.h
+ * Description  : Functions for using RIIC on RX devices. 
+ **********************************************************************************************************************/
+/**********************************************************************************************************************
+ * History : DD.MM.YYYY Version  Description
+ *         : 01.07.2013 1.00     First Release
+ *         : 30.09.2013 1.10     Change symbol of return value and status
+ *         : 08.10.2013 1.20     Modified processing for the I/O register initialization and mode transition 
+ *                                when a stop condition is detected while the slave is communicating.
+ *                               Modified processing for mode transition when an API function is called
+ *                                while the bus is busy.
+ *                               Modified processing for mode transition
+ *                                when an arbitration lost occurred and the addresses do not match.
+ *                               Modified incorrect slave transmission after the master reception.
+ *                               Modified processing for the I/O register initialization
+ *                                when generating a start condition and receiving the slave address.
+ *         : 17.07.2014 1.30     Added the parameters for the timeout detection.
+ *                               The number of channels varies depending on the MCU.
+ *                               Therefore, parameter setting for each channel is set 
+ *                               in the private header file(r_riic_rx###_private.h) for each MCU folder
+ *                               instead of this file.
+ *                               (### is 111 or 110 or 113 or 64m)
+ *         : 22.09.2014 1.40     The module is updated to measure the issue that slave communication 
+ *                               is not available after an arbitration-lost occurs and the bus is locked. 
+ *                                 The issue occurs when the following four conditions are all met.
+ *                                    - RIIC FIT module rev. 1.30 or earlier is used.
+ *                                    - RX device operates as both the master and the slave 
+ *                                      in multi-master communication.
+ *                                    - An arbitration-lost is detected when communicating as the master.
+ *                                    - Communication other than master reception or slave reception is performed.
+ *         : 14.11.2014 1.50     Added RX113 support.
+ *         : 09.10.2014 1.60     Added RX71M support.
+ *         : 20.10.2014 1.70     Added RX231 support.
+ *         : 31.10.2015 1.80     Added RX130, RX230, RX23T support.
+ *         : 04.03.2016 1.90     Added RX24T support.Changed about the pin definisions.
+ *         : 01.10.2016 2.00     Added RX65N support.
+ *         : 02.06.2017 2.10     Deleted RIIC port definitions of RIIC3.
+ *                               Changed include path becuase changed file structure.
+ *                               Added include of the RX24U header file.
+ *                               Added macro definition RIIC_PRV_PCR_BASE_REG, RIIC_PRV_PDR_BASE_REG,
+ *                                RIIC_PRV_PMR_BASE_REG and RIIC_PRV_PFS_BASE_REG.
+ *                               Deleted interrupt functions of RIIC3.
+ *                               Deleted macro definition RIIC_TMOE.
+ *         : 31.08.2017 2.20     Fixed the macro definition conversion processing of pin.
+ *         : 30.10.2017 2.30     Added RX66T support. 
+ *         : 15.10.2018 2.40     Added RX72T support.
+ *         : 20.06.2019 2.42     Added RX23W support.
+ *         : 30.07.2019 2.43     Added RX72M support.
+ *         : 10.10.2019 2.44     Added RX13T support.
+ *         : 22.11.2019 2.45     Added RX66N, RX72N support.
+ *         : 10.03.2020 2.46     Added RX23E-A support.
+ *         : 30.06.2021 2.48     Added RX671 support.
+ *         : 31.07.2021 2.49     Added RX140 support.
+ *         : 31.12.2021 2.50     Added RX660 support.
+ *         : 31.03.2023 2.70     Added RX26T support.
+ *         : 29.05.2023 2.80     Added RX23E-B support.
+ *                               Fixed to comply with GSCE Coding Standards Rev.6.5.0
+ *         : 08.08.2024 3.00     Added RX260, RX261 support.
+ *         : 15.03.2025 3.01     Updated disclaimer.
+ **********************************************************************************************************************/
+/* Guards against multiple inclusion */
+#ifndef RIIC_PRIVATE_H
+    #define RIIC_PRIVATE_H
+/***********************************************************************************************************************
+ Includes   <System Includes> , "Project Includes"
+ **********************************************************************************************************************/
+/* Fixed width integer support. */
+    #include "r_riic_rx_if.h"
+    #include "r_riic_rx_pin_config.h"
+    #include "r_riic_rx_config.h"
+
+/* Include specifics for chosen MCU.  */
+    #if defined(BSP_MCU_RX111)
+        #include "./targets/rx111/r_riic_rx111_private.h"
+    #elif defined(BSP_MCU_RX110)
+        #include "./targets/rx110/r_riic_rx110_private.h"
+    #elif defined(BSP_MCU_RX113)
+        #include "./targets/rx113/r_riic_rx113_private.h"
+    #elif defined(BSP_MCU_RX64M)
+        #include "./targets/rx64m/r_riic_rx64m_private.h"
+    #elif defined(BSP_MCU_RX65N)
+        #include "./targets/rx65n/r_riic_rx65n_private.h"
+    #elif defined(BSP_MCU_RX660)
+        #include "./targets/rx660/r_riic_rx660_private.h"
+    #elif defined(BSP_MCU_RX66T)
+        #include "./targets/rx66t/r_riic_rx66t_private.h"
+    #elif defined(BSP_MCU_RX671)
+        #include "./targets/rx671/r_riic_rx671_private.h"
+    #elif defined(BSP_MCU_RX71M)
+        #include "./targets/rx71m/r_riic_rx71m_private.h"
+    #elif defined(BSP_MCU_RX231)
+        #include "./targets/rx231/r_riic_rx231_private.h"
+    #elif defined(BSP_MCU_RX130)
+        #include "./targets/rx130/r_riic_rx130_private.h"
+    #elif defined(BSP_MCU_RX140)
+        #include "./targets/rx140/r_riic_rx140_private.h"
+    #elif defined(BSP_MCU_RX230)
+        #include "./targets/rx230/r_riic_rx230_private.h"
+    #elif defined(BSP_MCU_RX23T)
+        #include "./targets/rx23t/r_riic_rx23t_private.h"
+    #elif defined(BSP_MCU_RX24T)
+        #include "./targets/rx24t/r_riic_rx24t_private.h"
+    #elif defined(BSP_MCU_RX24U)
+        #include "./targets/rx24u/r_riic_rx24u_private.h"
+    #elif defined(BSP_MCU_RX72T)
+        #include "./targets/rx72t/r_riic_rx72t_private.h"
+    #elif defined(BSP_MCU_RX23W)
+        #include "./targets/rx23w/r_riic_rx23w_private.h"
+    #elif defined(BSP_MCU_RX72M)
+        #include "./targets/rx72m/r_riic_rx72m_private.h"
+    #elif defined(BSP_MCU_RX13T)
+        #include "./targets/rx13t/r_riic_rx13t_private.h"
+    #elif defined(BSP_MCU_RX66N)
+        #include "./targets/rx66n/r_riic_rx66n_private.h"
+    #elif defined(BSP_MCU_RX72N)
+        #include "./targets/rx72n/r_riic_rx72n_private.h"
+    #elif defined(BSP_MCU_RX23E_A)
+        #include "./targets/rx23e-a/r_riic_rx23e_a_private.h"
+    #elif defined(BSP_MCU_RX26T)
+        #include "./targets/rx26t/r_riic_rx26t_private.h"
+    #elif defined(BSP_MCU_RX23E_B)
+        #include "./targets/rx23e-b/r_riic_rx23e_b_private.h"
+    #elif defined(BSP_MCU_RX260)
+        #include "./targets/rx260/r_riic_rx260_private.h"
+    #elif defined(BSP_MCU_RX261)
+        #include "./targets/rx261/r_riic_rx261_private.h"
+    #else
+        #error "This MCU is not supported by the current r_riic_rx module."
+    #endif
+
+/***********************************************************************************************************************
+ Macro definitions
+ **********************************************************************************************************************/
+/*----------------------------------------------------------------------------*/
+/*   Define for calculation processing.                                       */
+/*----------------------------------------------------------------------------*/
+/* Bit position masks */
+    #define BIT0                      ((uint8_t)(0x01))
+    #define BIT1                      ((uint8_t)(0x02))
+    #define BIT2                      ((uint8_t)(0x04))
+    #define BIT3                      ((uint8_t)(0x08))
+    #define BIT4                      ((uint8_t)(0x10))
+    #define BIT5                      ((uint8_t)(0x20))
+    #define BIT6                      ((uint8_t)(0x40))
+    #define BIT7                      ((uint8_t)(0x80))
+
+    #define RIIC_MAX_DIV              ((uint8_t)(0x08))
+    #define RIIC_STAD_SPPED_MAX       ((uint8_t)(100))
+    #define RIIC_FAST_SPPED_MAX       ((uint16_t)(400))
+    #define RIIC_ICBR_MAX             ((uint8_t)(32))
+
+/*----------------------------------------------------------------------------*/
+/*   Define send data of blank.                                               */
+/*----------------------------------------------------------------------------*/
+    #define BLANK                     ((uint8_t)(0xFF))
+
+/*----------------------------------------------------------------------------*/
+/*   Define R/W code for slave address.                                       */
+/*----------------------------------------------------------------------------*/
+    #define W_CODE                    ((uint8_t)(0xFE))       /* Write code for slave address */
+    #define R_CODE                    ((uint8_t)(0x01))       /* Read code for slave address */
+
+/*----------------------------------------------------------------------------*/
+/*   Define of port control.                                                  */
+/*----------------------------------------------------------------------------*/
+    #define RIIC_OUT                  ((uint8_t)(0x01))       /* Port Output */
+    #define RIIC_IN                   ((uint8_t)(0x00))       /* Port Input */
+
+/*----------------------------------------------------------------------------*/
+/*   Define bool type.                                                        */
+/*----------------------------------------------------------------------------*/
+    #define RIIC_FALSE                ((bool)(0))             /* False */
+    #define RIIC_TRUE                 ((bool)(1))             /* True */
+
+/*----------------------------------------------------------------------------*/
+/* Define software SCL Low check counter                                      */
+/*----------------------------------------------------------------------------*/
+    #define RIIC_CFG_SCL_CHECK_COUNTER      (1000U)
+
+/* RIIC port (ascii to number) */
+/* RIIC0 */
+    #if ((('0') <= R_RIIC_CFG_RIIC0_SCL0_PORT) && (('9') >= R_RIIC_CFG_RIIC0_SCL0_PORT))
+        #define RIIC_CH0_SCL0_GP (R_RIIC_CFG_RIIC0_SCL0_PORT - 0x30)
+    #elif ((('A') <= R_RIIC_CFG_RIIC0_SCL0_PORT) && (('H') >= R_RIIC_CFG_RIIC0_SCL0_PORT))
+        #define RIIC_CH0_SCL0_GP (R_RIIC_CFG_RIIC0_SCL0_PORT - 0x37)
+    #elif ((('J') <= R_RIIC_CFG_RIIC0_SCL0_PORT) && (('K') >= R_RIIC_CFG_RIIC0_SCL0_PORT))
+/* PORTI does not exist in the PORT group. PORTJ register is placed at the position of PORTI register. */
+        #define RIIC_CH0_SCL0_GP (R_RIIC_CFG_RIIC0_SCL0_PORT - 0x38)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC0_SCL0_PORT in r_riic_rx_pin_config.h"
+    #endif
+    #if ((('0') <= R_RIIC_CFG_RIIC0_SCL0_BIT) && (('7') >= R_RIIC_CFG_RIIC0_SCL0_BIT))
+        #define RIIC_CH0_SCL0_PIN    (R_RIIC_CFG_RIIC0_SCL0_BIT - 0x30)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC0_SCL0_BIT in r_riic_rx_pin_config.h"
+    #endif
+
+    #if ((('0') <= R_RIIC_CFG_RIIC0_SDA0_PORT) && (('9') >= R_RIIC_CFG_RIIC0_SDA0_PORT))
+        #define RIIC_CH0_SDA0_GP (R_RIIC_CFG_RIIC0_SDA0_PORT - 0x30)
+    #elif ((('A') <= R_RIIC_CFG_RIIC0_SDA0_PORT) && (('H') >= R_RIIC_CFG_RIIC0_SDA0_PORT))
+        #define RIIC_CH0_SDA0_GP (R_RIIC_CFG_RIIC0_SDA0_PORT - 0x37)
+    #elif ((('J') <= R_RIIC_CFG_RIIC0_SDA0_PORT) && (('K') >= R_RIIC_CFG_RIIC0_SDA0_PORT))
+/* PORTI does not exist in the PORT group. PORTJ register is placed at the position of PORTI register. */
+        #define RIIC_CH0_SDA0_GP (R_RIIC_CFG_RIIC0_SDA0_PORT - 0x38)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC0_SDA0_PORT in r_riic_rx_pin_config.h"
+    #endif
+    #if ((('0') <= R_RIIC_CFG_RIIC0_SDA0_BIT) && (('7') >= R_RIIC_CFG_RIIC0_SDA0_BIT))
+        #define RIIC_CH0_SDA0_PIN    (R_RIIC_CFG_RIIC0_SDA0_BIT - 0x30)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC0_SDA0_BIT in r_riic_rx_pin_config.h"
+    #endif
+
+/* RIIC1 */
+    #if ((('0') <= R_RIIC_CFG_RIIC1_SCL1_PORT) && (('9') >= R_RIIC_CFG_RIIC1_SCL1_PORT))
+        #define RIIC_CH1_SCL1_GP (R_RIIC_CFG_RIIC1_SCL1_PORT - 0x30)
+    #elif ((('A') <= R_RIIC_CFG_RIIC1_SCL1_PORT) && (('H') >= R_RIIC_CFG_RIIC1_SCL1_PORT))
+        #define RIIC_CH1_SCL1_GP (R_RIIC_CFG_RIIC1_SCL1_PORT - 0x37)
+    #elif ((('J') <= R_RIIC_CFG_RIIC1_SCL1_PORT) && (('K') >= R_RIIC_CFG_RIIC1_SCL1_PORT))
+/* PORTI does not exist in the PORT group. PORTJ register is placed at the position of PORTI register. */
+        #define RIIC_CH1_SCL1_GP (R_RIIC_CFG_RIIC1_SCL1_PORT - 0x38)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC1_SCL1_PORT in r_riic_rx_pin_config.h"
+    #endif
+    #if ((('0') <= R_RIIC_CFG_RIIC1_SCL1_BIT) && (('7') >= R_RIIC_CFG_RIIC1_SCL1_BIT))
+        #define RIIC_CH1_SCL1_PIN    (R_RIIC_CFG_RIIC1_SCL1_BIT - 0x30)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC1_SCL1_BIT in r_riic_rx_pin_config.h"
+    #endif
+
+    #if ((('0') <= R_RIIC_CFG_RIIC1_SDA1_PORT) && (('9') >= R_RIIC_CFG_RIIC1_SDA1_PORT))
+        #define RIIC_CH1_SDA1_GP (R_RIIC_CFG_RIIC1_SDA1_PORT - 0x30)
+    #elif ((('A') <= R_RIIC_CFG_RIIC1_SDA1_PORT) && (('H') >= R_RIIC_CFG_RIIC1_SDA1_PORT))
+        #define RIIC_CH1_SDA1_GP (R_RIIC_CFG_RIIC1_SDA1_PORT - 0x37)
+    #elif ((('J') <= R_RIIC_CFG_RIIC1_SDA1_PORT) && (('K') >= R_RIIC_CFG_RIIC1_SDA1_PORT))
+/* PORTI does not exist in the PORT group. PORTJ register is placed at the position of PORTI register. */
+        #define RIIC_CH1_SDA1_GP (R_RIIC_CFG_RIIC1_SDA1_PORT - 0x38)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC1_SDA1_PORT in r_riic_rx_pin_config.h"
+    #endif
+    #if ((('0') <= R_RIIC_CFG_RIIC1_SDA1_BIT) && (('7') >= R_RIIC_CFG_RIIC1_SDA1_BIT))
+        #define RIIC_CH1_SDA1_PIN    (R_RIIC_CFG_RIIC1_SDA1_BIT - 0x30)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC1_SDA1_BIT in r_riic_rx_pin_config.h"
+    #endif
+
+/* RIIC2 */
+    #if ((('0') <= R_RIIC_CFG_RIIC2_SCL2_PORT) && (('9') >= R_RIIC_CFG_RIIC2_SCL2_PORT))
+        #define RIIC_CH2_SCL2_GP (R_RIIC_CFG_RIIC2_SCL2_PORT - 0x30)
+    #elif ((('A') <= R_RIIC_CFG_RIIC2_SCL2_PORT) && (('H') >= R_RIIC_CFG_RIIC2_SCL2_PORT))
+        #define RIIC_CH2_SCL2_GP (R_RIIC_CFG_RIIC2_SCL2_PORT - 0x37)
+    #elif ((('J') <= R_RIIC_CFG_RIIC2_SCL2_PORT) && (('K') >= R_RIIC_CFG_RIIC2_SCL2_PORT))
+/* PORTI does not exist in the PORT group. PORTJ register is placed at the position of PORTI register. */
+        #define RIIC_CH2_SCL2_GP (R_RIIC_CFG_RIIC2_SCL2_PORT - 0x38)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC2_SCL2_PORT in r_riic_rx_pin_config.h"
+    #endif
+    #if ((('0') <= R_RIIC_CFG_RIIC2_SCL2_BIT) && (('7') >= R_RIIC_CFG_RIIC2_SCL2_BIT))
+        #define RIIC_CH2_SCL2_PIN    (R_RIIC_CFG_RIIC2_SCL2_BIT - 0x30)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC2_SCL2_BIT in r_riic_rx_pin_config.h"
+    #endif
+
+    #if ((('0') <= R_RIIC_CFG_RIIC2_SDA2_PORT) && (('9') >= R_RIIC_CFG_RIIC2_SDA2_PORT))
+        #define RIIC_CH2_SDA2_GP (R_RIIC_CFG_RIIC2_SDA2_PORT - 0x30)
+    #elif ((('A') <= R_RIIC_CFG_RIIC2_SDA2_PORT) && (('H') >= R_RIIC_CFG_RIIC2_SDA2_PORT))
+        #define RIIC_CH2_SDA2_GP (R_RIIC_CFG_RIIC2_SDA2_PORT - 0x37)
+    #elif ((('J') <= R_RIIC_CFG_RIIC2_SDA2_PORT) && (('K') >= R_RIIC_CFG_RIIC2_SDA2_PORT))
+/* PORTI does not exist in the PORT group. PORTJ register is placed at the position of PORTI register. */
+        #define RIIC_CH2_SDA2_GP (R_RIIC_CFG_RIIC2_SDA2_PORT - 0x38)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC2_SDA2_PORT in r_riic_rx_pin_config.h"
+    #endif
+    #if ((('0') <= R_RIIC_CFG_RIIC2_SDA2_BIT) && (('7') >= R_RIIC_CFG_RIIC2_SDA2_BIT))
+        #define RIIC_CH2_SDA2_PIN    (R_RIIC_CFG_RIIC2_SDA2_BIT - 0x30)
+    #else
+        #error "Error! Invalid setting for R_RIIC_CFG_RIIC2_SDA2_BIT in r_riic_rx_pin_config.h"
+    #endif
+
+/*============================================================================*/
+/*  Configuration Options of non support                                      */
+/*============================================================================*/
+/* Setting to */
+/* 0 = disable, 1 = enable */
+    #define RIIC_CFG_NACK_AL_ENABLE         (0)
+    #define RIIC_CFG_SLAVE_AL_ENABLE        (0)
+    #define RIIC_CFG_NACK_SUSPEND_ENABLE    (1)
+    #define RIIC_CFG_SCL_SYNC_ENABLE        (1)
+
+/*============================================================================*/
+/*  Parameter check of Configuration Options                                  */
+/*============================================================================*/
+    #if ((0 != RIIC_CFG_PARAM_CHECKING_ENABLE) && (1 != RIIC_CFG_PARAM_CHECKING_ENABLE))
+        #error "ERROR - RIIC_CFG_PARAM_CHECKING_ENABLE - Parameter error in configures file.  "
+    #endif
+
+    #if ((0 != RIIC_CFG_PORT_SET_PROCESSING) && (1 != RIIC_CFG_PORT_SET_PROCESSING))
+        #error "ERROR - RIIC_CFG_PORT_SET_PROCESSING - Parameter error in configures file.  "
+    #endif
+
+    #if ((0 != RIIC_CFG_NACK_AL_ENABLE) && (1 != RIIC_CFG_NACK_AL_ENABLE))
+        #error "ERROR - RIIC_CFG_NACK_AL_ENABLE - Parameter error in configures file.  "
+    #endif
+
+    #if ((0 != RIIC_CFG_SLAVE_AL_ENABLE) && (1 != RIIC_CFG_SLAVE_AL_ENABLE))
+        #error "ERROR - RIIC_CFG_SLAVE_AL_ENABLE - Parameter error in configures file.  "
+    #endif
+
+    #if ((0 != RIIC_CFG_NACK_SUSPEND_ENABLE) && (1 != RIIC_CFG_NACK_SUSPEND_ENABLE))
+        #error "ERROR - RIIC_CFG_NACK_SUSPEND_ENABLE - Parameter error in configures file.  "
+    #endif
+
+    #if ((0 != RIIC_CFG_SCL_SYNC_ENABLE) && (1 != RIIC_CFG_SCL_SYNC_ENABLE))
+        #error "ERROR - RIIC_CFG_SCL_SYNC_ENABLE - Parameter error in configures file.  "
+    #endif
+
+    #if ((0x00000000 > RIIC_CFG_BUS_CHECK_COUNTER) || (0xFFFFFFFF < RIIC_CFG_BUS_CHECK_COUNTER))
+        #error "ERROR - RIIC_CFG_BUS_CHECK_COUNTER - Parameter error in configures file.  "
+    #endif
+
+/*============================================================================*/
+/*   Define for register setting.                                             */
+/*============================================================================*/
+/* Interrupt register setting */
+    #define RIIC_IR_CLR             ((uint8_t)(0x00))       /* Clears interrupt request register. */
+    #define RIIC_IR_SET             ((uint8_t)(0x01))       /* Sets interrupt request register. */
+    #define RIIC_IER_DISABLE        (0U)                    /* Disables interrupt request enable register. */
+    #define RIIC_IER_ENABLE         (1U)                    /* Enables interrupt request enable register. */
+
+/* RIIC register setting */
+    #define RIIC_ICCR1_NOT_DRIVEN   ((uint8_t)(0x00))       /* Clears ICCR1.ICE bit. */
+    #define RIIC_ICCR1_ICE          ((uint8_t)(0x80))       /* ICCR1.ICE bit. */
+    #define RIIC_ICCR1_ICE_SET      ((uint8_t)(0x80))       /* Sets ICCR1.ICE bit. */
+    #define RIIC_ICCR1_ICE_CLR      ((uint8_t)(0x7F))       /* Clears ICCR1.ICE bit. */
+    #define RIIC_ICCR1_RIIC_RESET   ((uint8_t)(0x40))       /* Sets ICCR1.IICRST bit. */
+    #define RIIC_ICCR1_ENABLE       ((uint8_t)(0xBF))       /* Clears ICCR1.IICRST bit. */
+    #define RIIC_ICCR1_CLO_SET      ((uint8_t)(0x20))       /* Sets ICCR1.CLO bit. */
+    #define RIIC_ICCR1_SOWP         ((uint8_t)(0x10))       /* ICCR1.SOWP bit. */
+    #define RIIC_ICCR1_SOWP_SET     ((uint8_t)(0x10))       /* Sets ICCR1.SOWP bit. */
+    #define RIIC_ICCR1_SOWP_CLR     ((uint8_t)(0xEF))       /* Clears ICCR1.SOWP bit. */
+    #define RIIC_ICCR1_SDAO_SCLO_SET ((uint8_t)(0x1F))      /* Clears ICCR1.SOWP bit. Sets ICCR1.SDAO and SCL0 bit*/
+    #define RIIC_ICCR1_SDAI         ((uint8_t)(0x01))       /* Mask for ICCR1.SDAI bit. */
+    #define RIIC_ICCR1_SDAI_SET     ((uint8_t)(0x01))       /* Sets for ICCR1.SDAI bit. */
+    #define RIIC_ICCR1_SCLI         ((uint8_t)(0x02))       /* Mask for ICCR1.SCLI bit. */
+    #define RIIC_ICCR1_SCLI_SET     ((uint8_t)(0x02))       /* Sets for ICCR1.SCLI bit. */
+    #define RIIC_ICCR1_SDAO         ((uint8_t)(0x04))       /* Mask for ICCR1.SDAO bit. */
+    #define RIIC_ICCR1_SDAO_SET     ((uint8_t)(0x04))       /* Sets for ICCR1.SDAO bit. */
+    #define RIIC_ICCR1_SCLO         ((uint8_t)(0x08))       /* Mask for ICCR1.SCLO bit. */
+    #define RIIC_ICCR1_SCLO_SET     ((uint8_t)(0x08))       /* Sets for ICCR1.SCLO bit. */
+    #define RIIC_SARL0_INIT         ((uint8_t)(0x00))       /* Sets SARLy and SARUy.(y=0,1,2) */
+    #define RIIC_SARU0_INIT         ((uint8_t)(0x00))       /* Sets SARLy and SARUy.(y=0,1,2) */
+    #define RIIC_SARL1_INIT         ((uint8_t)(0x00))       /* Sets SARLy and SARUy.(y=0,1,2) */
+    #define RIIC_SARU1_INIT         ((uint8_t)(0x00))       /* Sets SARLy and SARUy.(y=0,1,2) */
+    #define RIIC_SARL2_INIT         ((uint8_t)(0x00))       /* Sets SARLy and SARUy.(y=0,1,2) */
+    #define RIIC_SARU2_INIT         ((uint8_t)(0x00))       /* Sets SARLy and SARUy.(y=0,1,2) */
+    #define RIIC_SARL_MASK          ((uint16_t)(0x00FF))    /* Mask for SARLy setting. */
+    #define RIIC_SARU_MASK          ((uint16_t)(0x0300))    /* Mask for SARUy setting. */
+    #define RIIC_SARU_10BIT_FORMAT_SET ((uint8_t)(0x01))    /* Sets SARUy.FS bit. */
+    #define RIIC_ICSER_INIT         ((uint8_t)(0x00))       /* Sets ICSER */
+    #define RIIC_ICSER_SAR_DASABLE  ((uint8_t)(0xF8))       /* Clears ICSER.SAR0E,SAR1E,SAR2E bit */
+    #define RIIC_ICSER_SAR0E_SET    ((uint8_t)(0x01))       /* Sets ICSER.SAR0E bit */
+    #define RIIC_ICSER_SAR0E_CLR    ((uint8_t)(0xFE))       /* Clears ICSER.SAR0E bit */
+    #define RIIC_ICSER_SAR1E_SET    ((uint8_t)(0x02))       /* Sets ICSER.SAR1E bit */
+    #define RIIC_ICSER_SAR1E_CLR    ((uint8_t)(0xFD))       /* Clears ICSER.SAR1E bit */
+    #define RIIC_ICSER_SAR2E_SET    ((uint8_t)(0x04))       /* Sets ICSER.SAR2E bit */
+    #define RIIC_ICSER_SAR2E_CLR    ((uint8_t)(0xFB))       /* Clears ICSER.SAR2E bit */
+    #define RIIC_ICSER_GCAE_SET     ((uint8_t)(0x08))       /* Sets ICSER.GCAE bit */
+    #define RIIC_ICSER_GCAE_CLR     ((uint8_t)(0xF7))       /* Clears ICSER.GCAE bit */
+    #define RIIC_ICSER_DIDE_SET     ((uint8_t)(0x20))       /* Sets ICSER.DIDE bit */
+    #define RIIC_ICSER_DIDE_CLR     ((uint8_t)(0xDF))       /* Clears ICSER.DIDE bit */
+
+    #define RIIC_ICMR1_MTWP_SET     ((uint8_t)(0x80))       /* Sets ICMR1.MTWP bit. */
+    #define RIIC_ICMR1_MTWP_CLR     ((uint8_t)(0x7F))       /* Clears ICMR1.MTWP bit. */
+    #define RIIC_ICMR2_INIT         ((uint8_t)(0x00))       /* Sets ICMR2 */
+
+    #if RIIC_CFG_NACK_AL_ENABLE == 0
+        #define RIIC_NALE               ((uint8_t)(0x00))       /* Mask for ICFER.NALE bit. */
+    #elif RIIC_CFG_NACK_AL_ENABLE == 1
+        #define RIIC_NALE               ((uint8_t)(0x04))       /* Mask for ICFER.NALE bit. */
+    #endif
+
+    #if RIIC_CFG_SLAVE_AL_ENABLE == 0
+        #define RIIC_SALE               ((uint8_t)(0x00))       /* Mask for ICFER.SALE bit. */
+    #elif RIIC_CFG_SLAVE_AL_ENABLE == 1
+        #define RIIC_SALE               ((uint8_t)(0x08))       /* Mask for ICFER.SALE bit. */
+    #endif
+
+    #if RIIC_CFG_NACK_SUSPEND_ENABLE == 0
+        #define RIIC_NACKE              ((uint8_t)(0x00))       /* Mask for ICFER.NACKE bit. */
+    #elif RIIC_CFG_NACK_SUSPEND_ENABLE == 1
+        #define RIIC_NACKE              ((uint8_t)(0x10))       /* Mask for ICFER.NACKE bit. */
+    #endif
+
+    #if RIIC_CFG_SCL_SYNC_ENABLE == 0
+        #define RIIC_SCLE               ((uint8_t)(0x00))       /* Mask for ICFER.SCLE bit. */
+    #elif RIIC_CFG_SCL_SYNC_ENABLE == 1
+        #define RIIC_SCLE               ((uint8_t)(0x40))       /* Mask for ICFER.SCLE bit. */
+    #endif
+
+    #define RIIC_ICCR2_ST           ((uint8_t)(0x02))       /* Mask for ICCR2.ST bit. */
+    #define RIIC_ICCR2_RS           ((uint8_t)(0x04))       /* Mask for ICCR2.RS bit. */
+    #define RIIC_ICCR2_SP           ((uint8_t)(0x08))       /* Mask for ICCR2.SP bit. */
+    #define RIIC_ICCR2_TRS          ((uint8_t)(0x20))       /* Mask for ICCR2.TRS bit. */
+    #define RIIC_ICCR2_TRS_SET      ((uint8_t)(0x20))       /* Sets ICCR2.TRS bit. */
+    #define RIIC_ICCR2_TRS_CLR      ((uint8_t)(0xDF))       /* Clears ICCR2.TRS bit. */
+    #define RIIC_ICCR2_MST          ((uint8_t)(0x40))       /* Mask for ICCR2.MST bit. */
+    #define RIIC_ICCR2_MST_SET      ((uint8_t)(0x40))       /* Sets ICCR2.MST bit. */
+    #define RIIC_ICCR2_BBSY         ((uint8_t)(0x80))       /* Mask for ICCR2.BBSY bit. */
+    #define RIIC_ICCR2_BBSY_SET     ((uint8_t)(0x80))       /* Sets ICCR2.BBSY bit. */
+    #define RIIC_ICMR2_TMWE         ((uint8_t)(0x08))       /* Mask for ICMR2.TMWE bit. */
+    #define RIIC_ICMR2_TMWE_SET     ((uint8_t)(0x08))       /* Sets ICMR2.TMWE bit. */
+    #define RIIC_ICMR2_TMWE_CLR     ((uint8_t)(0xF7))       /* Clear ICMR2.TMWE bit. */
+    #define RIIC_ICMR3_WAIT_SET     ((uint8_t)(0x40))       /* Sets ICMR3.WAIT bit. */
+    #define RIIC_ICMR3_WAIT_CLR     ((uint8_t)(0xBF))       /* Clears ICMR3.WAIT bit. */
+    #define RIIC_ICMR3_RDRFS_SET    ((uint8_t)(0x20))       /* Sets ICMR3.RDRFS bit. */
+    #define RIIC_ICMR3_RDRFS_CLR    ((uint8_t)(0xDF))       /* Clears ICMR3.RDRFS bit. */
+    #define RIIC_ICMR3_ACKWP_SET    ((uint8_t)(0x10))       /* Sets ICMR3.ACKWP bit. */
+    #define RIIC_ICMR3_ACKWP_CLR    ((uint8_t)(0xEF))       /* Clears ICMR3.ACKWP bit. */
+    #define RIIC_ICMR3_ACKBT_SET    ((uint8_t)(0x08))       /* Sets ICMR3.ACKBT bit. */
+    #define RIIC_ICMR3_ACKBT_CLR    ((uint8_t)(0xF7))       /* Clears ICMR3.ACKBT bit. */
+    #define RIIC_ICSR1_AAS0         ((uint8_t)(0x01))       /* Mask for ICSR1.AAS0 bit. */
+    #define RIIC_ICSR1_AAS0_SET     ((uint8_t)(0x01))       /* Sets ICSR1.AAS0 bit. */
+    #define RIIC_ICSR1_AAS1         ((uint8_t)(0x02))       /* Mask for ICSR1.AAS1 bit. */
+    #define RIIC_ICSR1_AAS1_SET     ((uint8_t)(0x02))       /* Sets ICSR1.AAS1 bit. */
+    #define RIIC_ICSR1_AAS2         ((uint8_t)(0x04))       /* Mask for ICSR1.AAS2 bit. */
+    #define RIIC_ICSR1_AAS2_SET     ((uint8_t)(0x04))       /* Sets ICSR1.AAS2 bit. */
+    #define RIIC_ICSR1_GCA          ((uint8_t)(0x08))       /* Mask for ICSR1.GCA bit. */
+    #define RIIC_ICSR1_GCA_SET      ((uint8_t)(0x08))       /* Sets ICSR1.GCA bit. */
+    #define RIIC_ICSR1_DID          ((uint8_t)(0x20))       /* Mask for ICSR1.DID bit. */
+    #define RIIC_ICSR1_DID_SET      ((uint8_t)(0x20))       /* Sets ICSR1.DID bit. */
+    #define RIIC_ICSR1_HOA          ((uint8_t)(0x80))       /* Mask for ICSR1.HOA bit. */
+    #define RIIC_ICSR1_HOA_SET      ((uint8_t)(0x80))       /* Sets ICSR1.HOA bit. */
+    #define RIIC_ICSR2_TMOF         ((uint8_t)(0x01))       /* Mask for ICSR2.TMOF bit. */
+    #define RIIC_ICSR2_TMOF_SET     ((uint8_t)(0x01))       /* Sets ICSR2.TMOF bit. */
+    #define RIIC_ICSR2_AL           ((uint8_t)(0x02))       /* Mask for ICSR2.AL bit. */
+    #define RIIC_ICSR2_AL_SET       ((uint8_t)(0x02))       /* Sets ICSR2.AL bit. */
+    #define RIIC_ICSR2_AL_CLR       ((uint8_t)(0xFD))       /* Clears ICSR2.AL bit. */
+    #define RIIC_ICSR2_START        ((uint8_t)(0x04))       /* Mask for ICSR2.START bit. */
+    #define RIIC_ICSR2_START_SET    ((uint8_t)(0x04))       /* Sets ICSR2.START bit. */
+    #define RIIC_ICSR2_START_CLR    ((uint8_t)(0xFB))       /* Clears ICSR2.START bit. */
+    #define RIIC_ICSR2_STOP         ((uint8_t)(0x08))       /* Mask for ICSR2.STOP bit. */
+    #define RIIC_ICSR2_STOP_SET     ((uint8_t)(0x08))       /* Sets ICSR2.STOP bit. */
+    #define RIIC_ICSR2_STOP_CLR     ((uint8_t)(0xF7))       /* Clears ICSR2.STOP bit. */
+    #define RIIC_ICSR2_NACKF        ((uint8_t)(0x10))       /* Mask for ICSR2.NACKF bit. */
+    #define RIIC_ICSR2_NACKF_SET    ((uint8_t)(0x10))       /* Sets ICSR2.NACKF bit. */
+    #define RIIC_ICSR2_NACKF_CLR    ((uint8_t)(0xEF))       /* Clears ICSR2.NACKF bit. */
+    #define RIIC_ICSR2_RDRF         ((uint8_t)(0x20))       /* Mask for ICSR2.RDRF bit. */
+    #define RIIC_ICSR2_RDRF_SET     ((uint8_t)(0x20))       /* Sets ICSR2.RDRF bit. */
+    #define RIIC_ICSR2_TDRE         ((uint8_t)(0x80))       /* Mask for ICSR2.TDRE bit. */
+    #define RIIC_ICSR2_TDRE_SET     ((uint8_t)(0x80))       /* Sets ICSR2.TDRE bit. */
+    #define RIIC_ICSR2_DISABLE      ((uint8_t)(0xE7))       /* Clears ICSR2.NACKF bit and STOP bit. */
+
+    #define RIIC_ICIER_INIT         ((uint8_t)(0x00))       /* Initializes ICIER. */
+    #define RIIC_ICIER_ST_NAK_AL    ((uint8_t)(0x16))       /* Sets ICIER.STIE bit. */
+/* Enable bit  : ALIE, STIE, NAKIE          */
+/* Disable bit : TMOIE, SPIE, RIE, TEIE, TIE */
+    #define RIIC_ICIER_SP_NAK_AL    ((uint8_t)(0x1A))       /* Sets ICIER.SPIE bit and NAKIE. */
+/* Enable bit  : ALIE, SPIE, NAKIE          */
+/* Disable bit : TMOIE, STIE, RIE, TEIE, TIE */
+    #define RIIC_ICIER_TEND_NAK_AL  ((uint8_t)(0x52))       /* Sets ICIER.TEIE bit. */
+/* Enable bit  : ALIE, NAKIE, TEIE          */
+/* Disable bit : TMOIE, STIE, SPIE, RIE, TIE */
+    #define RIIC_ICIER_RX_NAK_AL    ((uint8_t)(0x32))       /* Sets ICIER.RIE bit. */
+/* Enable bit  : ALIE, NAKIE, RIE           */
+/* Disable bit : TMOIE, STIE, SPIE, TEIE, TIE */
+    #define RIIC_ICIER_SP_AL        ((uint8_t)(0x0A))       /* Sets ICIER.SPIE bit and clears ICIER.NAKIE bit. */
+/* Enable bit  : ALIE, SPIE                 */
+/* Disable bit : TMOIE, STIE, NAKIE, RIE, TEIE, TIE */
+    #define RIIC_ICIER_AL           ((uint8_t)(0x02))       /* Sets ICIER.ALIE bit. */
+/* Enable bit  : ALIE                       */
+/* Disable bit : TMOIE, STIE, SPIE, NAKIE, RIE, TEIE, TIE */
+    #define RIIC_ICIER_SP           ((uint8_t)(0x08))       /* Sets ICIER.SPIE bit. */
+/* Enable bit  : SPIE                       */
+/* Disable bit : TMOIE, ALIE, STIE, NAKIE, RIE, TEIE, TIE */
+    #define RIIC_ICIER_TX_RX_SP_NAK_AL ((uint8_t)(0xBA))    /* Sets ICIER register. */
+/* Enable bit  : ALIE, SPIE, NAKIE, RIE, TIE */
+/* Disable bit : TMOIE, STIE, TEIE          */
+    #define RIIC_ICIER_TX_SP_NAK_AL ((uint8_t)(0x9A))       /* Sets ICIER register. */
+/* Enable bit  : ALIE, SPIE, NAKIE, TIE     */
+/* Disable bit : TMOIE, STIE, TEIE, RIE     */
+    #define RIIC_ICIER_RX_SP_NAK_AL ((uint8_t)(0x3A))       /* Sets ICIER register. */
+/* Enable bit  : ALIE, SPIE, NAKIE, RIE     */
+/* Disable bit : TMOIE, STIE, TEIE, TIE     */
+    #define RIIC_ICIER_TX_RX_SP_NAK ((uint8_t)(0xB8))       /* Sets ICIER register. */
+/* Enable bit  : SPIE, NAKIE, RIE, TIE      */
+/* Disable bit : ALIE, TMOIE, STIE, TEIE    */
+    #define RIIC_ICIER_TX_SP_NAK    ((uint8_t)(0x98))       /* Sets ICIER register. */
+/* Enable bit  : SPIE, NAKIE, TIE           */
+/* Disable bit : ALIE, TMOIE, STIE, TEIE, RIE */
+    #define RIIC_ICIER_RX_SP        ((uint8_t)(0x28))       /* Sets ICIER register. */
+/* Enable bit  : SPIE, RIE           */
+/* Disable bit : ALIE, TMOIE, NAKIE, STIE, TEIE, TIE */
+    #define RIIC_ICIER_TX_RX        ((uint8_t)(0xA0))       /* Sets ICIER register. */
+/* Enable bit  : RIE, TIE                   */
+/* Disable bit : SPIE, NAKIE, ALIE, TMOIE, STIE, TEIE */
+    #define RIIC_ICIER_TX           ((uint8_t)(0x80))       /* Sets ICIER register. */
+/* Enable bit  : TIE                        */
+/* Disable bit : SPIE, NAKIE, ALIE, TMOIE, STIE, RIE, TEIE */
+    #define RIIC_ICIER_RX           ((uint8_t)(0x20))       /* Sets ICIER register. */
+/* Enable bit  : RIE                        */
+/* Disable bit : SPIE, NAKIE, ALIE, TMOIE, STIE, TEIE, TIE */
+    #define RIIC_ICIER_TMO          ((uint8_t)(0x01))       /* Sets ICIER register. */
+/* Enable bit  : TMOIE                        */
+    #define RIIC_MSK_BBSY           ((uint8_t)(0x80))       /* Mask ICCR2.BBSY bit  */
+    #define RIIC_MSK_SCLSDA         ((uint8_t)(0x03))       /* Mask ICCR1.SDAI bit and SCLI bit */
+    #define RIIC_SCLI_LOW           ((uint8_t)(0x00))       /* input SCL Low */
+
+/* Common registers setting */
+    #define RIIC_PWPR_BOWI          (MPC.PWPR.BIT.B0WI)     /* PWPR PFSWE Bit Write Disable */
+
+/* Control registers address defines */
+    #define RIIC_ICCR1_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x00 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICCR2_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x01 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICMR1_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x02 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICMR2_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x03 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICMR3_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x04 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICFER_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x05 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICSER_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x06 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICIER_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x07 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICSR1_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x08 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICSR2_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x09 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_SARL0_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x0A + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_SARU0_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x0B + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_SARL1_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x0C + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_SARU1_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x0D + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_SARL2_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x0E + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_SARU2_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x0F + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICBRL_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x10 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICBRH_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x11 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICDRT_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x12 + ((32 * (n)) / sizeof(uint8_t)) )
+    #define RIIC_ICDRR_ADR(n)    ( (volatile uint8_t *)&RIIC0 + 0x13 + ((32 * (n)) / sizeof(uint8_t)) )
+
+    #ifdef TN_RXA012A
+        #define RIIC_TMOCNTL_ADR(n)  ( (volatile uint8_t *)&RIIC0 + 0x0A + ((32 * (n)) / sizeof(uint8_t)) )
+        #define RIIC_TMOCNTH_ADR(n)  ( (volatile uint8_t *)&RIIC0 + 0x0B + ((32 * (n)) / sizeof(uint8_t)) )
+    #endif
+
+/* Base register of PCR used to calculate all PCR register addresses. This is constant for all supported MCUs. */
+    #define RIIC_PRV_PCR_BASE_REG ((uint8_t volatile *)(&MPC.PWPR.BYTE-95))
+/* Base register of PDR used to calculate all PDR register addresses. This is constant for all supported MCUs. */
+    #define RIIC_PRV_PDR_BASE_REG ((uint8_t volatile *)(&MPC.PWPR.BYTE-287))
+/* Base register of PMR used to calculate all PMR register addresses. This is constant for all supported MCUs. */
+    #define RIIC_PRV_PMR_BASE_REG ((uint8_t volatile *)(&MPC.PWPR.BYTE-191))
+/* Base register of PFS used to calculate all PFS register addresses. This is constant for all supported MCUs. */
+    #define RIIC_PRV_PFS_BASE_REG ((uint8_t volatile *)(&MPC.PWPR.BYTE+33))
+
+/***********************************************************************************************************************
+ Typedef definitions
+ **********************************************************************************************************************/
+/*----------------------------------------------------------------------------*/
+/*   Define internal iic information structure type.                          */
+/*----------------------------------------------------------------------------*/
+/* ---- Internal Mode. ---- */
+typedef enum
+{
+    RIIC_MODE_NONE = 0U, /* Non-communication mode */
+    RIIC_MODE_M_SEND, /* Master transmission mode */
+    RIIC_MODE_M_RECEIVE, /* Master reception mode */
+    RIIC_MODE_M_SEND_RECEIVE, /* Master transmission reception mode */
+    RIIC_MODE_S_READY, /* Multi master transfer mode */
+    RIIC_MODE_S_SEND, /* Slave transmission mode */
+    RIIC_MODE_S_RECEIVE /* Slave reception mode */
+} riic_api_mode_t;
+
+/* ---- Internal Status. ---- */
+typedef enum
+{
+    RIIC_STS_NO_INIT = 0U, /* None initialization state */
+    RIIC_STS_IDLE, /* Idle state */
+    RIIC_STS_IDLE_EN_SLV, /* Idle state on enable slave transfer */
+    RIIC_STS_ST_COND_WAIT, /* Start condition generation completion wait state */
+    RIIC_STS_SEND_SLVADR_W_WAIT, /* Slave address [Write] transmission completion wait state */
+    RIIC_STS_SEND_SLVADR_R_WAIT, /* Slave address [Read] transmission completion wait state */
+    RIIC_STS_SEND_DATA_WAIT, /* Data transmission completion wait state */
+    RIIC_STS_RECEIVE_DATA_WAIT, /* Data reception completion wait state */
+    RIIC_STS_SP_COND_WAIT, /* Stop condition generation completion wait state */
+    RIIC_STS_AL, /* Detect Arbitration Lost */
+    RIIC_STS_TMO, /* Detect Time out */
+    RIIC_STS_MAX /* Prohibition of setup above here */
+
+} riic_api_status_t;
+
+/* ---- Internal Event. ---- */
+typedef enum
+{
+    RIIC_EV_INIT = 0U, /* Called function of Initializes IIC driver */
+    RIIC_EV_EN_SLV_TRANSFER, /* Enable Slave Transfer */
+    RIIC_EV_GEN_START_COND, /* Called function of Start condition generation */
+    RIIC_EV_INT_START, /* Interrupted start codition generation */
+    RIIC_EV_INT_ADD, /* Interrupted address sending */
+    RIIC_EV_INT_SEND, /* Interrupted data sending */
+    RIIC_EV_INT_RECEIVE, /* Interrupted data receiving */
+    RIIC_EV_INT_STOP, /* Interrupted Stop condition generation */
+    RIIC_EV_INT_AL, /* Interrupted Arbitration-Lost */
+    RIIC_EV_INT_NACK, /* Interrupted No Acknowledge */
+    RIIC_EV_INT_TMO, /* Interrupted Time out */
+    RIIC_EV_MAX /* Prohibition of setup above here */
+} riic_api_event_t;
+
+/* ---- Internal Infomation structure. ---- */
+typedef struct
+{
+    riic_api_mode_t   N_Mode; /* Internal mode of control protocol */
+    riic_api_mode_t   B_Mode; /* Internal mode of control protocol */
+    riic_api_status_t N_status; /* Internal Status of Now */
+    riic_api_status_t B_status; /* Internal Status of Before */
+} riic_api_info_t;
+
+/* ---- Internal state transition structure ---- */
+typedef struct
+{
+    riic_api_event_t event_type; /* Event */
+    riic_return_t    (*proc) (riic_info_t *); /* handler */
+} riic_mtx_t;
+
+/***********************************************************************************************************************
+ Exported global functions (to be accessed by other files)
+ **********************************************************************************************************************/
+/******************************************************************************
+ * Function Name: riic_mcu_check_channel
+ * Description  : .
+ * Argument     : channe
+ * Return Value : .
+ *****************************************************************************/
+bool riic_mcu_check_channel (uint8_t channe);
+
+/******************************************************************************
+ * Function Name: riic_mcu_int_init
+ * Description  : .
+ * Argument     : channe
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_int_init (uint8_t channe);
+
+/******************************************************************************
+ * Function Name: riic_mcu_check_ir_txi
+ * Description  : .
+ * Argument     : channel
+ * Return Value : .
+ *****************************************************************************/
+uint8_t riic_mcu_check_ir_txi (uint8_t channel);
+
+/******************************************************************************
+ * Function Name: riic_mcu_check_ir_rxi
+ * Description  : .
+ * Argument     : channel
+ * Return Value : .
+ *****************************************************************************/
+uint8_t riic_mcu_check_ir_rxi (uint8_t channel);
+
+/******************************************************************************
+ * Function Name: riic_mcu_clear_ir_txi
+ * Description  : .
+ * Argument     : channel
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_clear_ir_txi (uint8_t channel);
+
+/******************************************************************************
+ * Function Name: riic_mcu_clear_ir_rxi
+ * Description  : .
+ * Argument     : channel
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_clear_ir_rxi (uint8_t channel);
+
+/******************************************************************************
+ * Function Name: riic_mcu_int_enable
+ * Description  : .
+ * Argument     : channe
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_int_enable (uint8_t channe);
+
+/******************************************************************************
+ * Function Name: riic_mcu_int_disable
+ * Description  : .
+ * Argument     : channe
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_int_disable (uint8_t channe);
+
+/******************************************************************************
+ * Function Name: riic_mcu_power_on
+ * Description  : .
+ * Argument     : channel
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_power_on (uint8_t channel);
+
+/******************************************************************************
+ * Function Name: riic_mcu_power_off
+ * Description  : .
+ * Argument     : channel
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_power_off (uint8_t channel);
+
+/******************************************************************************
+ * Function Name: riic_mcu_hardware_lock
+ * Description  : .
+ * Argument     : channel
+ * Return Value : .
+ *****************************************************************************/
+bool riic_mcu_hardware_lock (uint8_t channel);
+
+/******************************************************************************
+ * Function Name: riic_mcu_hardware_unlock
+ * Description  : .
+ * Argument     : channel
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_hardware_unlock (uint8_t channel);
+
+/******************************************************************************
+ * Function Name: riic_mcu_check_freq
+ * Description  : .
+ * Return Value : .
+ *****************************************************************************/
+double riic_mcu_check_freq (void);
+
+/******************************************************************************
+ * Function Name: riic_mcu_int_icier_setting
+ * Description  : .
+ * Arguments    : channel
+ *              : New_icier
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_int_icier_setting (uint8_t channel, uint8_t New_icier);
+
+    #if (1U == RIIC_CFG_PORT_SET_PROCESSING)
+/******************************************************************************
+ * Function Name: riic_mcu_io_open
+ * Description  : .
+ * Argument     : channe
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_io_open (uint8_t channe);
+
+/******************************************************************************
+ * Function Name: riic_mcu_mpc_enable
+ * Description  : .
+ * Argument     : channe
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_mpc_enable (uint8_t channe);
+
+/******************************************************************************
+ * Function Name: riic_mcu_mpc_disable
+ * Description  : .
+ * Argument     : channe
+ * Return Value : .
+ *****************************************************************************/
+void riic_mcu_mpc_disable (uint8_t channe);
+    #endif
+
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+/******************************************************************************
+ * Function Name: riic0_eei_sub
+ * Description  : .
+ * Return Value : .
+ *****************************************************************************/
+void riic0_eei_sub (void);
+
+/******************************************************************************
+ * Function Name: riic0_txi_sub
+ * Description  : .
+ * Return Value : .
+ *****************************************************************************/
+void riic0_txi_sub (void);
+
+/******************************************************************************
+ * Function Name: riic0_rxi_sub
+ * Description  : .
+ * Return Value : .
+ *****************************************************************************/
+void riic0_rxi_sub (void);
+
+/******************************************************************************
+ * Function Name: riic0_tei_sub
+ * Description  : .
+ * Return Value : .
+ *****************************************************************************/
+void riic0_tei_sub (void);
+    #endif
+
+    #if (1U == RIIC_CFG_CH1_INCLUDED)
+void riic1_eei_sub (void);
+void riic1_txi_sub (void);
+void riic1_rxi_sub (void);
+void riic1_tei_sub (void);
+    #endif
+
+    #if (1U == RIIC_CFG_CH2_INCLUDED)
+void riic2_eei_sub (void);
+void riic2_txi_sub (void);
+void riic2_rxi_sub (void);
+void riic2_tei_sub (void);
+    #endif
+
+#endif /* RIIC_PRIVATE_H */
+

--- a/drivers/rx/rdp/src/r_riic_rx/src/targets/rx130/r_riic_rx130.c
+++ b/drivers/rx/rdp/src/r_riic_rx/src/targets/rx130/r_riic_rx130.c
@@ -1,0 +1,750 @@
+/***********************************************************************************************************************
+* Copyright (c) 2015 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+ * File Name    : r_riic_rx130.c
+ * Description  : Functions for using RIIC on RX devices. 
+ **********************************************************************************************************************/
+/**********************************************************************************************************************
+ * History : DD.MM.YYYY Version  Description
+ *         : 31.10.2015 1.80     First Release
+ *         : 04.03.2016 1.90     Changed about the pin definisions.
+ *         : 01.10.2016 2.00     Fixed a program according to the Renesas coding rules.
+ *         : 02.06.2017 2.10     Changed include path becuase changed file structure.
+ *                               Changed about the calculation processing for address of PFS, PCR, 
+ *                               PDR and PMR register.
+ *         : 20.05.2019 2.41     Added support for GNUC and ICCRX.
+ *                               Fixed coding style.
+ *         : 10.10.2019 2.44     Added support for atomic control.
+ *         : 15.03.2025 3.01     Updated disclaimer.
+ **********************************************************************************************************************/
+
+/***********************************************************************************************************************
+ Includes   <System Includes> , "Project Includes"
+ **********************************************************************************************************************/
+/* Defines for RIIC support */
+#include "r_riic_rx_if.h"
+
+/* Check MCU Group */
+#if defined(BSP_MCU_RX130)
+
+    #include "r_riic_rx_private.h"
+
+/***********************************************************************************************************************
+ Exported global variables (to be accessed by other files)
+ **********************************************************************************************************************/
+/* Array of bit rate for RIICn (n=0) */
+const uint16_t g_riic_bps[] =
+{
+    (uint16_t) RIIC_CFG_CH0_kBPS
+};
+
+/* Array of data of Slave Address 0 Register (SARL0 and SARU0) for RIICn (n=0) */
+const uint16_t g_riic_slv_ad0_val[] =
+{
+    RIIC_CFG_CH0_SLV_ADDR0
+};
+
+/* Array of data of Slave Address 1 Register (SARL1 and SARU1) for RIICn (n=0) */
+const uint16_t g_riic_slv_ad1_val[] =
+{
+    RIIC_CFG_CH0_SLV_ADDR1
+};
+
+/* Array of data of Slave Address 2 Register (SARL2 and SARU2) for RIICn (n=0) */
+const uint16_t g_riic_slv_ad2_val[] =
+{
+    RIIC_CFG_CH0_SLV_ADDR2
+};
+
+/* Array of slave address 0 format for RIICn (n=0) */
+const uint8_t g_riic_slv_ad0_format[] =
+{
+    RIIC_CFG_CH0_SLV_ADDR0_FORMAT
+};
+
+/* Array of slave address 1 format for RIICn (n=0) */
+const uint8_t g_riic_slv_ad1_format[] =
+{
+    RIIC_CFG_CH0_SLV_ADDR1_FORMAT
+};
+
+/* Array of slave address 2 format for RIICn (n=0) */
+const uint8_t g_riic_slv_ad2_format[] =
+{
+    RIIC_CFG_CH0_SLV_ADDR2_FORMAT
+};
+
+/* Array of general call address enable for RIICn (n=0) */
+const uint8_t g_riic_gca_enable[] =
+{
+    RIIC_CFG_CH0_SLV_GCA_ENABLE
+};
+
+/* Array of initialize data of I2C-bus Mode Register 2 (ICMR2) for RIICn (n=0) */
+const uint8_t g_riic_icmr2_init[] =
+{
+    RIIC_CH0_ICMR2_INIT
+};
+
+/* Array of initialize data of I2C-bus Mode Register 3 (ICMR3) for RIICn (n=0) */
+const uint8_t g_riic_icmr3_init[] =
+{
+    RIIC_CH0_ICMR3_INIT
+};
+
+/* Array of initialize data of I2C-bus Function Enable Register (ICFER) for RIICn (n=0) */
+const uint8_t g_riic_icfer_init[] =
+{
+    RIIC_CH0_ICFER_INIT
+};
+
+/***********************************************************************************************************************
+ Private global variables and functions
+ **********************************************************************************************************************/
+    #if (1U == RIIC_CFG_PORT_SET_PROCESSING)
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_io_open
+ * Description  : Sets ports to input mode.
+ *              : Ports input pull-up becomes "Off".
+ * Arguments    : uint8_t channel
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic_mcu_io_open (uint8_t channel)
+{
+    volatile uint8_t uctmp = 0x00;
+    R_BSP_VOLATILE_EVENACCESS uint8_t * ppcr = NULL;
+    R_BSP_VOLATILE_EVENACCESS uint8_t * ppdr = NULL;
+    uint8_t port_gr = 0;
+    uint8_t pin_num = 0;
+
+    /* Channel number? */
+    switch (channel)
+    {
+        #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 : /* Channel 0 */
+
+            /* Sets the port register of SCL pin. */
+            port_gr = RIIC_CH0_SCL0_GP;
+            pin_num = RIIC_CH0_SCL0_PIN;
+            ppcr = (uint8_t *)((uint32_t)RIIC_PRV_PCR_BASE_REG + (uint32_t)port_gr);
+            ppdr = (uint8_t *)((uint32_t)RIIC_PRV_PDR_BASE_REG + (uint32_t)port_gr);
+            (*ppcr) &= (~(1U << pin_num)); /* SCL0 input pull-up resister : off */
+            (*ppdr) &= (~(RIIC_IN << pin_num)); /* SCL0 input mode */
+
+            /* Sets the port register of SDA pin. */
+            port_gr = RIIC_CH0_SDA0_GP;
+            pin_num = RIIC_CH0_SDA0_PIN;
+            ppcr = (uint8_t *)((uint32_t)RIIC_PRV_PCR_BASE_REG + (uint32_t)port_gr);
+            ppdr = (uint8_t *)((uint32_t)RIIC_PRV_PDR_BASE_REG + (uint32_t)port_gr);
+            (*ppcr) &= (~(1U << pin_num)); /* SDA0 input pull-up resister : off */
+            (*ppdr) &= (~(RIIC_IN << pin_num)); /* SDA0 input mode */
+            uctmp = (*ppdr); /* Reads PDR. */
+        break;
+        #endif
+
+        default :
+
+            /* Please add a channel as needed. */
+        break;
+    }
+} /* End of function riic_mcu_io_open() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_mpc_enable
+ * Description  : Enables RIIC multi-function pin controller.
+ * Arguments    : uint8_t channel
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic_mcu_mpc_enable (uint8_t channel)
+{
+    volatile uint8_t uctmp = 0x00;
+    R_BSP_VOLATILE_EVENACCESS uint8_t * ppmr = NULL;
+    R_BSP_VOLATILE_EVENACCESS uint8_t * ppfs = NULL;
+    uint8_t port_gr = 0;
+    uint8_t pin_num = 0;
+
+    /* The upper layer software should call "riic_disable()." */
+    /* The upper layer software should set SCL and SDA ports to input mode using PDR. */
+    /* The upper layer software should perform RIIC reset or internal reset. */
+
+    /* Channel number? */
+    switch (channel)
+    {
+        #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 : /* Channel 0 */
+            port_gr = RIIC_CH0_SCL0_GP;
+            pin_num = RIIC_CH0_SCL0_PIN;
+            ppmr = (uint8_t *)((uint32_t)RIIC_PRV_PMR_BASE_REG + (uint32_t)port_gr);
+            (*ppmr) &= (~(1U << pin_num)); /* Uses as a GPIO (Input port). */
+
+            port_gr = RIIC_CH0_SDA0_GP;
+            pin_num = RIIC_CH0_SDA0_PIN;
+            ppmr = (uint8_t *)((uint32_t)RIIC_PRV_PMR_BASE_REG + (uint32_t)port_gr);
+            (*ppmr) &= (~(1U << pin_num)); /* Uses as a GPIO (Input port). */
+
+            /* Specifies the assignments of input/output signals for peripheral functions to the desired pins.
+             But SCL and SDA are already in a high-impedance state.
+             Because the upper layer software called "riic_reset_set()". */
+
+            R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_MPC); /* Enables the PFS register writing. */
+
+            port_gr = RIIC_CH0_SCL0_GP;
+            pin_num = RIIC_CH0_SCL0_PIN;
+            ppfs = (uint8_t *)((uint32_t)RIIC_PRV_PFS_BASE_REG + (uint32_t)((port_gr * 8) + pin_num));
+            (*ppfs) = RIIC_MPC_SCL0_ENABLE; /* Pin function select to RIIC SCL pin. */
+
+            port_gr = RIIC_CH0_SDA0_GP;
+            pin_num = RIIC_CH0_SDA0_PIN;
+            ppfs = (uint8_t *)((uint32_t)RIIC_PRV_PFS_BASE_REG + (uint32_t)((port_gr * 8) + pin_num));
+            (*ppfs) = RIIC_MPC_SDA0_ENABLE; /* Pin function select to RIIC SDA pin. */
+
+            R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_MPC); /* Disables the PFS register writing. */
+
+            port_gr = RIIC_CH0_SCL0_GP;
+            pin_num = RIIC_CH0_SCL0_PIN;
+            ppmr = (uint8_t *)((uint32_t)RIIC_PRV_PMR_BASE_REG + (uint32_t)port_gr);
+            (*ppmr) |= (1U << pin_num); /* Uses as RIIC (SCL). */
+            uctmp = (*ppmr); /* Reads PMR. */
+
+            port_gr = RIIC_CH0_SDA0_GP;
+            pin_num = RIIC_CH0_SDA0_PIN;
+            ppmr = (uint8_t *)((uint32_t)RIIC_PRV_PMR_BASE_REG + (uint32_t)port_gr);
+            (*ppmr) |= (1U << pin_num); /* Uses as RIIC (SDA). */
+            uctmp = (*ppmr); /* Reads PMR. */
+        break;
+        #endif
+
+        default :
+
+            /* Please add a channel as needed. */
+        break;
+    }
+} /* End of function riic_mcu_mpc_enable() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_mpc_disable
+ * Description  : Disables RIIC multi-function pin controller.
+ * Arguments    : uint8_t channel
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic_mcu_mpc_disable (uint8_t channel)
+{
+    volatile uint8_t uctmp = 0x00;
+    R_BSP_VOLATILE_EVENACCESS uint8_t * ppmr = NULL;
+    R_BSP_VOLATILE_EVENACCESS uint8_t * ppfs = NULL;
+    uint8_t port_gr = 0;
+    uint8_t pin_num = 0;
+
+    /* The upper layer software should set SCL snd SDA ports to input mode using PDR. */
+
+    /* Channel number? */
+    switch (channel)
+    {
+        #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 : /* Channel 0 */
+            port_gr = RIIC_CH0_SCL0_GP;
+            pin_num = RIIC_CH0_SCL0_PIN;
+            ppmr = (uint8_t *)((uint32_t)RIIC_PRV_PMR_BASE_REG + (uint32_t)port_gr);
+            (*ppmr) &= (~(1U << pin_num)); /* Uses as a GPIO (Input port). */
+
+            port_gr = RIIC_CH0_SDA0_GP;
+            pin_num = RIIC_CH0_SDA0_PIN;
+            ppmr = (uint8_t *)((uint32_t)RIIC_PRV_PMR_BASE_REG + (uint32_t)port_gr);
+            (*ppmr) &= (~(1U << pin_num)); /* Uses as a GPIO (Input port). */
+
+            R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_MPC); /* Enables the PFS register writing. */
+
+            port_gr = RIIC_CH0_SCL0_GP;
+            pin_num = RIIC_CH0_SCL0_PIN;
+            ppfs = (uint8_t *)((uint32_t)RIIC_PRV_PFS_BASE_REG + (uint32_t)((port_gr * 8) + pin_num));
+            (*ppfs) = RIIC_MPC_SCL0_INIT; /* Pin function select to Hi-Z. */
+
+            port_gr = RIIC_CH0_SDA0_GP;
+            pin_num = RIIC_CH0_SDA0_PIN;
+            ppfs = (uint8_t *)((uint32_t)RIIC_PRV_PFS_BASE_REG + (uint32_t)((port_gr * 8) + pin_num));
+            (*ppfs) = RIIC_MPC_SDA0_INIT; /* Pin function select to Hi-Z. */
+
+            R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_MPC); /* Disables the PFS register writing. */
+        break;
+        #endif
+
+        default :
+
+            /* Please add a channel as needed. */
+        break;
+    }
+    uctmp = RIIC_PWPR_BOWI; /* Reads PWPR. */
+} /* End of function riic_mcu_mpc_disable() */
+    #endif
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_check_channel
+ * Description  : Checks channel is valid or not.
+ * Arguments    : uint8_t channel
+ * Return Value : true                   : RIIC channel is valid.
+ *                false                  : RIIC channel is invalid.
+ **********************************************************************************************************************/
+bool riic_mcu_check_channel (uint8_t channel)
+{
+    bool ret = false;
+
+    switch (channel)
+    {
+
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+            ret = true;
+        break;
+    #endif
+
+        default :
+
+            /* The channel number is invalid. */
+            ret = false;
+        break;
+    }
+
+    return ret;
+} /* End of function riic_mcu_check_channel() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_hardware_lock
+ * Description  : Attempt to acquire the lock that has been sent in.
+ * Arguments    : uint8_t channel
+ * Return Value : true                   ; Successful operation
+ *              : false                  ; error operation
+ **********************************************************************************************************************/
+bool riic_mcu_hardware_lock (uint8_t channel)
+{
+    bool chk = false;
+
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+            chk = R_BSP_HardwareLock(BSP_LOCK_RIIC0);
+        break;
+    #endif
+
+        default :
+
+            /* Do Nothing */
+        break;
+    }
+    return chk;
+} /* End of function riic_mcu_hardware_lock() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_hardware_unlock
+ * Description  : Release hold on lock.
+ * Arguments    : uint8_t channel
+ * Return Value : none
+ **********************************************************************************************************************/
+void riic_mcu_hardware_unlock (uint8_t channel)
+{
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+            R_BSP_HardwareUnlock(BSP_LOCK_RIIC0);
+        break;
+    #endif
+
+        default :
+
+            /* Do Nothing */
+        break;
+    }
+} /* End of function riic_mcu_hardware_unlock() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_power_on
+ * Description  : Turns on power to a RIIC channel.
+ * Arguments    : uint8_t channel
+ * Return Value : none
+ **********************************************************************************************************************/
+void riic_mcu_power_on (uint8_t channel)
+{
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+    #if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    bsp_int_ctrl_t int_ctrl;
+    #endif
+    #endif
+    /* Enable writing to MSTP registers. */
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_LPC_CGC_SWR);
+
+    /* Enable selected RIIC Channel. */
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+        
+        #if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+            R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_DISABLE, &int_ctrl);
+        #endif
+        
+            /* Bring module out of stop state. */
+            MSTP(RIIC0) = 0U;
+        
+        #if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+            R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_ENABLE, &int_ctrl);
+        #endif
+        break;
+    #endif
+
+        default :
+
+            /* Should never get here. Valid channel number is checked above. */
+        break;
+    }
+
+    /* Disable writing to MSTP registers. */
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_CGC_SWR);
+} /* End of function riic_mcu_power_on() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_power_off
+ * Description  : Turns off power to a RIIC channel.
+ * Arguments    : uint8_t channel
+ * Return Value : none
+ **********************************************************************************************************************/
+void riic_mcu_power_off (uint8_t channel)
+{
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+    #if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    bsp_int_ctrl_t int_ctrl;
+    #endif
+    #endif
+    /* Enable writing to MSTP registers. */
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_LPC_CGC_SWR);
+
+    /* Disable selected CMT Channel. */
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+        
+        #if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+            R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_DISABLE, &int_ctrl);
+        #endif
+        
+            /* Put module in stop state. */
+            MSTP(RIIC0) = 1U;
+        
+        #if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+            R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_ENABLE, &int_ctrl);
+        #endif
+        break;
+    #endif
+
+        default :
+
+            /* Should never get here. Valid channel number is checked above. */
+        break;
+    }
+
+    /* Disable writing to MSTP registers. */
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_CGC_SWR);
+} /* End of function riic_mcu_power_off() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_int_init
+ * Description  : Registers a callback function for supported TEI and EEI group interrupts.
+ * Arguments    : uint8_t channel
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic_mcu_int_init (uint8_t channel)
+{
+    /* Do Nothing */
+} /* End of function riic_mcu_int_init() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_check_ir_txi
+ * Description  : Check TXI interrupt request register.
+ * Arguments    : uint8_t channel
+ * Return Value : RIIC_IR_CLR         : TXI Interrupt request (IR) register is cleared.
+ *              : RIIC_IR_SET         : TXI Interrupt request (IR) register is set.
+ **********************************************************************************************************************/
+uint8_t riic_mcu_check_ir_txi (uint8_t channel)
+{
+    uint8_t ret = RIIC_IR_CLR;
+
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+            ret = RIIC_IR_TXI0;
+        break;
+    #endif
+        default :
+
+            /* Should never get here. Valid channel number is checked above. */
+        break;
+    }
+
+    return ret;
+} /* End of function riic_mcu_check_ir_txi() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_check_ir_rxi
+ * Description  : Check RXI interrupt request register.
+ * Arguments    : uint8_t channel
+ * Return Value : RIIC_IR_CLR         : TXI Interrupt request (IR) register is cleared.
+ *              : RIIC_IR_SET         : TXI Interrupt request (IR) register is set.
+ **********************************************************************************************************************/
+uint8_t riic_mcu_check_ir_rxi (uint8_t channel)
+{
+    uint8_t ret = RIIC_IR_CLR;
+
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+            ret = RIIC_IR_RXI0;
+        break;
+    #endif
+        default :
+
+            /* Should never get here. Valid channel number is checked above. */
+        break;
+    }
+
+    return ret;
+} /* End of function riic_mcu_check_ir_rxi() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_clear_ir_txi
+ * Description  : Clear TXI interrupt request register.
+ * Arguments    : uint8_t channel
+ * Return Value : none
+ **********************************************************************************************************************/
+void riic_mcu_clear_ir_txi (uint8_t channel)
+{
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+            RIIC_IR_TXI0 = RIIC_IR_CLR; /* Clears TXI interrupt request register. */
+            if (RIIC_IR_CLR == RIIC_IR_TXI0)
+            {
+                /* Do Nothing */
+            }
+        break;
+    #endif
+        default :
+
+            /* Should never get here. Valid channel number is checked above. */
+        break;
+    }
+} /* End of function riic_mcu_clear_ir_txi() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_clear_ir_rxi
+ * Description  : Clear RXI interrupt request register.
+ * Arguments    : uint8_t channel
+ * Return Value : none
+ **********************************************************************************************************************/
+void riic_mcu_clear_ir_rxi (uint8_t channel)
+{
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 :
+            RIIC_IR_RXI0 = RIIC_IR_CLR; /* Clears TXI interrupt request register. */
+            if (RIIC_IR_CLR == RIIC_IR_RXI0)
+            {
+                /* Do Nothing */
+            }
+        break;
+    #endif
+        default :
+
+            /* Should never get here. Valid channel number is checked above. */
+        break;
+    }
+} /* End of function riic_mcu_clear_ir_rxi() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_int_icier_setting
+ * Description  : Time out interrupt enable bit setting.
+ * Arguments    : uint8_t channel
+ *              : uint8_t New_icier       ; New ICIER value
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic_mcu_int_icier_setting (uint8_t channel, uint8_t New_icier)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Channel number? */
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 : /* Channel 0 */
+        #if (1U == RIIC_CFG_CH0_TMO_ENABLE)
+            RIIC0.ICIER.BYTE = (New_icier | RIIC_ICIER_TMO);
+            uctmp = RIIC0.ICIER.BYTE; /* Reads ICIER. */
+        #else
+            RIIC0.ICIER.BYTE = New_icier;
+            uctmp = RIIC0.ICIER.BYTE; /* Reads ICIER. */
+        #endif
+        break;
+    #endif
+
+        default :
+
+            /* Please add a channel as needed. */
+        break;
+    }
+} /* End of function riic_mcu_int_icier_setting() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_int_enable
+ * Description  : Clears interrupt request register.
+ *              : Enables interrupt.
+ * Arguments    : uint8_t channel
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic_mcu_int_enable (uint8_t channel)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Channel number? */
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0x00 : /* Channel 0 */
+
+            /* Enables interrupt. */
+            RIIC_IER_EEI0 = RIIC_IER_ENABLE; /* Enables EEI0 interrupt request enable register. */
+            RIIC_IER_RXI0 = RIIC_IER_ENABLE; /* Enables RXI0 interrupt request enable register. */
+            RIIC_IER_TXI0 = RIIC_IER_ENABLE; /* Enables TXI0 interrupt request enable register. */
+            RIIC_IER_TEI0 = RIIC_IER_ENABLE; /* Enables TEI0 interrupt request enable register. */
+
+            /* Sets interrupt source priority. */
+            RIIC_IPR_EEI0 = RIIC_IPR_CH0_EEI_SET; /* Sets EEI0 interrupt source priority register. */
+            RIIC_IPR_RXI0 = RIIC_IPR_CH0_RXI_SET; /* Sets RXI0 interrupt source priority register. */
+            RIIC_IPR_TXI0 = RIIC_IPR_CH0_TXI_SET; /* Sets TXI0 interrupt source priority register. */
+            RIIC_IPR_TEI0 = RIIC_IPR_CH0_TEI_SET; /* Sets TEI0 interrupt source priority register. */
+            uctmp = RIIC_IER_TEI0; /* Reads IER. */
+        break;
+    #endif
+
+        default :
+
+            /* Please add a channel as needed. */
+        break;
+    }
+} /* End of function riic_mcu_int_enable() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_int_disable
+ * Description  : Disables interrupt.
+ *              : Sets interrupt source priority.
+ *              : Clears interrupt request register.
+ * Arguments    : uint8_t channel
+ * Return Value : None
+ **********************************************************************************************************************/
+void riic_mcu_int_disable (uint8_t channel)
+{
+    volatile uint8_t uctmp = 0x00;
+
+    /* Channel number? */
+    switch (channel)
+    {
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+        case 0U : /* Channel 0 */
+
+            /* Disables interrupt. */
+            RIIC_IER_EEI0 = RIIC_IER_DISABLE; /* Disables EEI0 interrupt request enable register. */
+            RIIC_IER_RXI0 = RIIC_IER_DISABLE; /* Disables RXI0 interrupt request enable register. */
+            RIIC_IER_TXI0 = RIIC_IER_DISABLE; /* Disables TXI0 interrupt request enable register. */
+            RIIC_IER_TEI0 = RIIC_IER_DISABLE; /* Disables TEI0 interrupt request enable register. */
+
+            /* Sets interrupt source priority. */
+            RIIC_IPR_EEI0 = RIIC_IPR_CH0_EEI_INIT; /* Sets EEI0 interrupt source priority register. */
+            RIIC_IPR_RXI0 = RIIC_IPR_CH0_RXI_INIT; /* Sets RXI0 interrupt source priority register. */
+            RIIC_IPR_TXI0 = RIIC_IPR_CH0_TXI_INIT; /* Sets TXI0 interrupt source priority register. */
+            RIIC_IPR_TEI0 = RIIC_IPR_CH0_TEI_INIT; /* Sets TEI0 interrupt source priority register. */
+            uctmp = RIIC_IPR_TEI0; /* Reads IPR. */
+        break;
+    #endif
+
+        default :
+
+            /* Please add a channel as needed. */
+        break;
+    }
+} /* End of function riic_mcu_int_disable() */
+
+/***********************************************************************************************************************
+ * Function Name: riic_mcu_check_freq
+ * Description  : check pclk frequency and return that value.
+ * Arguments    : None
+ * Return Value : PCLK frequency
+ **********************************************************************************************************************/
+double riic_mcu_check_freq (void)
+{
+    return BSP_PCLKB_HZ;
+} /* End of function riic_mcu_check_freq() */
+
+    #if (1U == RIIC_CFG_CH0_INCLUDED)
+/***********************************************************************************************************************
+ * Function Name: riic0_eei_isr
+ * Description  : Interrupt EEI handler for channel 0.
+ *                Types of interrupt requests transfer error or event generation.
+ *                The event generations are arbitration-lost, NACK detection, timeout detection, 
+ *                start condition detection, and stop condition detection.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+R_BSP_PRAGMA_STATIC_INTERRUPT(riic0_eei_isr, VECT(RIIC0, EEI0))
+R_BSP_ATTRIB_STATIC_INTERRUPT void riic0_eei_isr (void)
+{
+    riic0_eei_sub();
+} /* End of function riic0_eei_isr() */
+
+/***********************************************************************************************************************
+ * Function Name: riic0_txi_isr
+ * Description  : Interrupt TXI handler for channel 0.
+ *                Types of interrupt requests transmission data empty.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+R_BSP_PRAGMA_STATIC_INTERRUPT(riic0_txi_isr, VECT(RIIC0, TXI0))
+R_BSP_ATTRIB_STATIC_INTERRUPT void riic0_txi_isr (void)
+{
+    riic0_txi_sub();
+} /* End of function riic0_txi_isr() */
+
+/***********************************************************************************************************************
+ * Function Name: riic0_rxi_isr
+ * Description  : Interrupt RXI handler for channel 0.
+ *                Types of interrupt requests reception end.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+R_BSP_PRAGMA_STATIC_INTERRUPT(riic0_rxi_isr, VECT(RIIC0, RXI0))
+R_BSP_ATTRIB_STATIC_INTERRUPT void riic0_rxi_isr (void)
+{
+    riic0_rxi_sub();
+} /* End of function riic0_rxi_isr() */
+
+/***********************************************************************************************************************
+ * Function Name: riic0_tei_isr
+ * Description  : Interrupt TEI handler for channel 0.
+ *                Types of interrupt requests transmission end.
+ * Arguments    : None
+ * Return Value : None
+ **********************************************************************************************************************/
+R_BSP_PRAGMA_STATIC_INTERRUPT(riic0_tei_isr, VECT(RIIC0, TEI0))
+R_BSP_ATTRIB_STATIC_INTERRUPT void riic0_tei_isr (void)
+{
+    riic0_tei_sub();
+} /* End of function riic0_tei_isr() */
+    #endif
+
+#endif /* defined(BSP_MCU_RX130) */
+

--- a/drivers/rx/rdp/src/r_riic_rx/src/targets/rx130/r_riic_rx130.c
+++ b/drivers/rx/rdp/src/r_riic_rx/src/targets/rx130/r_riic_rx130.c
@@ -31,6 +31,7 @@
 #if defined(BSP_MCU_RX130)
 
     #include "r_riic_rx_private.h"
+    #include "r_bsp_locking.h"
 
 /***********************************************************************************************************************
  Exported global variables (to be accessed by other files)

--- a/drivers/rx/rdp/src/r_riic_rx/src/targets/rx130/r_riic_rx130_private.h
+++ b/drivers/rx/rdp/src/r_riic_rx/src/targets/rx130/r_riic_rx130_private.h
@@ -1,0 +1,270 @@
+/***********************************************************************************************************************
+* Copyright (c) 2015 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+ * File Name    : r_riic_rx130_private.h
+ * Description  : Functions for using RIIC on RX devices. 
+ **********************************************************************************************************************/
+/***********************************************************************************************************************
+ * History : DD.MM.YYYY Version  Description
+ *         : 31.10.2015 1.80     First Release
+ *         : 04.03.2016 1.90     Changed about the pin definisions.
+ *         : 01.10.2016 2.00     Fixed a program according to the Renesas coding rules.
+ *         : 02.06.2017 2.10     Deleted definition of PORT_PFS_OFFSET.
+ *                               Deleted definitions of RIIC3.
+ *         : 31.08.2017 2.20     Deleted definition of "RIIC_CFG_CH1_INCLUDED".
+ *         : 15.03.2025 3.01     Updated disclaimer.
+ **********************************************************************************************************************/
+/* Guards against multiple inclusion */
+#ifndef RIIC_RX130_PRIVATE_H
+    #define RIIC_RX130_PRIVATE_H
+/***********************************************************************************************************************
+ Macro definitions
+ **********************************************************************************************************************/
+
+/*----------------------------------------------------------------------------*/
+/*   Define channel No.(max) + 1                                              */
+/*----------------------------------------------------------------------------*/
+    #define MAX_RIIC_CH_NUM         (1U)                  /* Set number of RIIC channel */
+
+/*----------------------------------------------------------------------------*/
+/*   Define technical update[No.TN-RX*-A012A] process                         */
+/*----------------------------------------------------------------------------*/
+/* Unnecessary technical update [No.TN-RX*-A012A] process */
+
+/*============================================================================*/
+/*  Parameter check of Configuration Options                                  */
+/*============================================================================*/
+    #if (1U == RIIC_CFG_CH1_INCLUDED)
+        #error "ERROR - RIIC_CFG_CH1_INCLUDED - RIIC1 is not supported in this device. "
+    #endif
+    #if (1U == RIIC_CFG_CH2_INCLUDED)
+        #error "ERROR - RIIC_CFG_CH2_INCLUDED - RIIC2 is not supported in this device. "
+    #endif
+
+    #ifdef TN_RXA012A
+        #error "ERROR - TN_RXA012A - Parameter error in configures file.  "
+    #endif  /* TN_RXA012A */
+
+    #if ((0U != RIIC_CFG_CH0_INCLUDED) && (1U != RIIC_CFG_CH0_INCLUDED))
+        #error "ERROR - RIIC_CFG_CH0_INCLUDED - Parameter error in configures file.  "
+    #endif
+
+    #if ((0U >= RIIC_CFG_CH0_kBPS) || (400U < RIIC_CFG_CH0_kBPS))
+        #error "ERROR - RIIC_CFG_CH0_kBPS - Parameter error in configures file.  "
+    #endif
+
+    #if ((0U > RIIC_CFG_CH0_DIGITAL_FILTER) || (4U < RIIC_CFG_CH0_DIGITAL_FILTER))
+        #error "ERROR - RIIC_CFG_CH0_DIGITAL_FILTER - Parameter error in configures file.  "
+    #endif
+
+    #if ((0U != RIIC_CFG_CH0_MASTER_MODE) && (1U != RIIC_CFG_CH0_MASTER_MODE))
+        #error "ERROR - RIIC_CFG_CH0_MASTER_MODE - Parameter error in configures file.  "
+    #endif
+
+    #if (0U == RIIC_CFG_CH0_SLV_ADDR0_FORMAT)
+/* Do Nothing */
+    #elif (1U == RIIC_CFG_CH0_SLV_ADDR0_FORMAT)
+        #if ((0x0000 > RIIC_CFG_CH0_SLV_ADDR0) || (0x007F < RIIC_CFG_CH0_SLV_ADDR0))
+            #error "ERROR - RIIC_CFG_CH0_SLV_ADDR0 - Parameter error in configures file.  "
+        #endif
+    #elif (2U == RIIC_CFG_CH0_SLV_ADDR0_FORMAT)
+        #if ((0x0000 > RIIC_CFG_CH0_SLV_ADDR0) || (0x03FF < RIIC_CFG_CH0_SLV_ADDR0))
+            #error "ERROR - RIIC_CFG_CH0_SLV_ADDR0 - Parameter error in configures file.  "
+        #endif
+    #else
+        #error "ERROR - RIIC_CFG_CH0_SLV_ADDR0_FORMAT - Parameter error in configures file.  "
+    #endif
+
+    #if (0U == RIIC_CFG_CH0_SLV_ADDR1_FORMAT)
+/* Do Nothing */
+    #elif (1U == RIIC_CFG_CH0_SLV_ADDR1_FORMAT)
+        #if ((0x0000 > RIIC_CFG_CH0_SLV_ADDR1) || (0x007F < RIIC_CFG_CH0_SLV_ADDR1))
+            #error "ERROR - RIIC_CFG_CH0_SLV_ADDR1 - Parameter error in configures file.  "
+        #endif
+    #elif (2U == RIIC_CFG_CH0_SLV_ADDR1_FORMAT)
+        #if ((0x0000 > RIIC_CFG_CH0_SLV_ADDR1) || (0x03FF < RIIC_CFG_CH0_SLV_ADDR1))
+            #error "ERROR - RIIC_CFG_CH0_SLV_ADDR1 - Parameter error in configures file.  "
+        #endif
+    #else
+        #error "ERROR - RIIC_CFG_CH0_SLV_ADDR1_FORMAT - Parameter error in configures file.  "
+    #endif
+
+    #if (0U == RIIC_CFG_CH0_SLV_ADDR2_FORMAT)
+/* Do Nothing */
+    #elif (1U == RIIC_CFG_CH0_SLV_ADDR2_FORMAT)
+        #if ((0x0000 > RIIC_CFG_CH0_SLV_ADDR2) || (0x007F < RIIC_CFG_CH0_SLV_ADDR2))
+            #error "ERROR - RIIC_CFG_CH0_SLV_ADDR2 - Parameter error in configures file.  "
+        #endif
+    #elif (2U == RIIC_CFG_CH0_SLV_ADDR2_FORMAT)
+        #if ((0x0000 > RIIC_CFG_CH0_SLV_ADDR2) || (0x03FF < RIIC_CFG_CH0_SLV_ADDR2))
+            #error "ERROR - RIIC_CFG_CH0_SLV_ADDR2 - Parameter error in configures file.  "
+        #endif
+    #else
+        #error "ERROR - RIIC_CFG_CH0_SLV_ADDR2_FORMAT - Parameter error in configures file.  "
+    #endif
+
+    #if ((0U != RIIC_CFG_CH0_SLV_GCA_ENABLE) && (1U != RIIC_CFG_CH0_SLV_GCA_ENABLE))
+        #error "ERROR - RIIC_CFG_CH0_SLV_GCA_ENABLE - Parameter error in configures file.  "
+    #endif
+
+    #if ((1U > RIIC_CFG_CH0_RXI_INT_PRIORITY) || (15U < RIIC_CFG_CH0_RXI_INT_PRIORITY))
+        #error "ERROR - RIIC_CFG_CH0_RXI_INT_PRIORITY - Parameter error in configures file.  "
+    #endif
+
+    #if ((1U > RIIC_CFG_CH0_TXI_INT_PRIORITY) || (15U < RIIC_CFG_CH0_TXI_INT_PRIORITY))
+        #error "ERROR - RIIC_CFG_CH0_TXI_INT_PRIORITY - Parameter error in configures file.  "
+    #endif
+
+    #if ((1U > RIIC_CFG_CH0_TEI_INT_PRIORITY) || (15U < RIIC_CFG_CH0_TEI_INT_PRIORITY) || \
+     (RIIC_CFG_CH0_RXI_INT_PRIORITY > RIIC_CFG_CH0_TEI_INT_PRIORITY) || \
+     (RIIC_CFG_CH0_TXI_INT_PRIORITY > RIIC_CFG_CH0_TEI_INT_PRIORITY))
+        #error "ERROR - RIIC_CFG_CH0_TEI_INT_PRIORITY - Parameter error in configures file.  "
+    #endif
+
+    #if ((1U > RIIC_CFG_CH0_EEI_INT_PRIORITY) || (15U < RIIC_CFG_CH0_EEI_INT_PRIORITY) || \
+     (RIIC_CFG_CH0_RXI_INT_PRIORITY > RIIC_CFG_CH0_EEI_INT_PRIORITY) || \
+     (RIIC_CFG_CH0_TXI_INT_PRIORITY > RIIC_CFG_CH0_EEI_INT_PRIORITY))
+        #error "ERROR - RIIC_CFG_CH0_EEI_INT_PRIORITY - Parameter error in configures file.  "
+    #endif
+
+    #if ((0U != RIIC_CFG_CH0_TMO_ENABLE) && (1U != RIIC_CFG_CH0_TMO_ENABLE))
+        #error "ERROR - RIIC_CFG_CH0_TMO_ENABLE - Parameter error in configures file.  "
+    #endif
+
+    #if ((0U != RIIC_CFG_CH0_TMO_DET_TIME) && (1U != RIIC_CFG_CH0_TMO_DET_TIME))
+        #error "ERROR - RIIC_CFG_CH0_TMO_DET_TIME - Parameter error in configures file.  "
+    #endif
+
+    #if ((0U != RIIC_CFG_CH0_TMO_LCNT) && (1U != RIIC_CFG_CH0_TMO_LCNT))
+        #error "ERROR - RIIC_CFG_CH0_TMO_LCNT - Parameter error in configures file.  "
+    #endif
+
+    #if ((0U != RIIC_CFG_CH0_TMO_HCNT) && (1U != RIIC_CFG_CH0_TMO_HCNT))
+        #error "ERROR - RIIC_CFG_CH0_TMO_HCNT - Parameter error in configures file.  "
+    #endif
+
+/*============================================================================*/
+/*   Define Channel setting.                                                  */
+/*============================================================================*/
+/*----------------------------------------------------------------------------*/
+/*   PORT/ICU register setting for RIIC Channel 0.                            */
+/*----------------------------------------------------------------------------*/
+/* Sets interrupt source priority initialization. */
+    #define RIIC_IPR_CH0_EEI_INIT  ((uint8_t)(0x00))            /* EEI0 interrupt source priority initialization */
+    #define RIIC_IPR_CH0_RXI_INIT  ((uint8_t)(0x00))            /* RXI0 interrupt source priority initialization */
+    #define RIIC_IPR_CH0_TXI_INIT  ((uint8_t)(0x00))            /* TXI0 interrupt source priority initialization */
+    #define RIIC_IPR_CH0_TEI_INIT  ((uint8_t)(0x00))            /* TEI0 interrupt source priority initialization */
+
+/* EEI0 interrupt source priority initialization*/
+    #define RIIC_IPR_CH0_EEI_SET   ((uint8_t)(RIIC_CFG_CH0_EEI_INT_PRIORITY))
+/* RXI0 interrupt source priority initialization*/
+    #define RIIC_IPR_CH0_RXI_SET   ((uint8_t)(RIIC_CFG_CH0_RXI_INT_PRIORITY))
+/* TXI0 interrupt source priority initialization*/
+    #define RIIC_IPR_CH0_TXI_SET   ((uint8_t)(RIIC_CFG_CH0_TXI_INT_PRIORITY))
+/* TEI0 interrupt source priority initialization*/
+    #define RIIC_IPR_CH0_TEI_SET   ((uint8_t)(RIIC_CFG_CH0_TEI_INT_PRIORITY))
+
+/* Sets to use multi-function pin controller. */
+    #define RIIC_MPC_SDA0_INIT     ((uint8_t)(0x00))           /* Pin function select to Hi-Z */
+    #define RIIC_MPC_SCL0_INIT     ((uint8_t)(0x00))           /* Pin function select to Hi-Z */
+    #define RIIC_MPC_SDA0_ENABLE   ((uint8_t)(0x0F))           /* Pin function select to RIIC0 SDA pin */
+    #define RIIC_MPC_SCL0_ENABLE   ((uint8_t)(0x0F))           /* Pin function select to RIIC0 SCL pin */
+
+/* Define interrupt request registers */
+    #define RIIC_IR_RXI0   (ICU.IR[IR_RIIC0_RXI0].BIT.IR)      /* RXI0 Interrupt request register */
+    #define RIIC_IR_TXI0   (ICU.IR[IR_RIIC0_TXI0].BIT.IR)      /* TXI0 Interrupt request register */
+
+/* Define interrupt request enable registers */
+    #define RIIC_IER_EEI0  (ICU.IER[IER_RIIC0_EEI0].BIT.IEN6)  /* EEI0 Interrupt request enable register */
+    #define RIIC_IER_RXI0  (ICU.IER[IER_RIIC0_RXI0].BIT.IEN7)  /* RXI0 Interrupt request enable register */
+    #define RIIC_IER_TXI0  (ICU.IER[IER_RIIC0_TXI0].BIT.IEN0)  /* TXI0 Interrupt request enable register */
+    #define RIIC_IER_TEI0  (ICU.IER[IER_RIIC0_TEI0].BIT.IEN1)  /* TEI0 Interrupt request enable register */
+
+/* Define interrupt source priority registers */
+    #define RIIC_IPR_EEI0  (ICU.IPR[IPR_RIIC0_EEI0].BYTE)      /* EEI0 Interrupt source priority register */
+    #define RIIC_IPR_RXI0  (ICU.IPR[IPR_RIIC0_RXI0].BYTE)      /* RXI0 Interrupt source priority register */
+    #define RIIC_IPR_TXI0  (ICU.IPR[IPR_RIIC0_TXI0].BYTE)      /* TXI0 Interrupt source priority register */
+    #define RIIC_IPR_TEI0  (ICU.IPR[IPR_RIIC0_TEI0].BYTE)      /* TEI0 Interrupt source priority register */
+
+/*============================================================================*/
+/*   Define for register setting.                                             */
+/*============================================================================*/
+/*----------------------------------------------------------------------------*/
+/*   RIIC Channel 0 register setting.                                         */
+/*----------------------------------------------------------------------------*/
+    #if (0U == RIIC_CFG_CH0_TMO_ENABLE)
+        #define RIIC_CH0_TMOE           ((uint8_t)(0x00))       /* Mask for ICFER.TMOE bit. */
+    #elif (1U == RIIC_CFG_CH0_TMO_ENABLE)
+        #define RIIC_CH0_TMOE           ((uint8_t)(0x01))       /* Mask for ICFER.TMOE bit. */
+    #endif
+
+    #if (0U == RIIC_CFG_CH0_MASTER_MODE)
+        #define RIIC_CH0_MALE           ((uint8_t)(0x00))       /* Mask for RIIC0.ICFER.MALE bit. */
+    #elif (1U == RIIC_CFG_CH0_MASTER_MODE)
+        #define RIIC_CH0_MALE           ((uint8_t)(0x02))       /* Mask for RIIC0.ICFER.MALE bit. */
+    #endif
+
+    #if (0U == RIIC_CFG_CH0_DIGITAL_FILTER)
+        #define RIIC_CH0_NFE            ((uint8_t)(0x00))       /* Mask for RIIC0.ICFER.NFE bit. */
+    #elif (1U <= RIIC_CFG_CH0_DIGITAL_FILTER) && (4U >= RIIC_CFG_CH0_DIGITAL_FILTER)
+        #define RIIC_CH0_NFE            ((uint8_t)(0x20))       /* Mask for RIIC0.ICFER.NFE bit. */
+    #endif
+
+/* Sets ICFER */
+    #define RIIC_CH0_ICFER_INIT ((uint8_t)(RIIC_CH0_TMOE | RIIC_CH0_MALE | RIIC_NALE | \
+                                       RIIC_SALE | RIIC_NACKE | RIIC_CH0_NFE | RIIC_SCLE))
+
+    #if (0U == RIIC_CFG_CH0_TMO_DET_TIME)
+        #define RIIC_CH0_TMOS           ((uint8_t)(0x00))       /* long mode for the timeout detection time */
+    #elif (1U == RIIC_CFG_CH0_TMO_DET_TIME)
+        #define RIIC_CH0_TMOS           ((uint8_t)(0x01))       /* short mode for the timeout detection time */
+    #endif
+
+    #if (0U == RIIC_CFG_CH0_TMO_LCNT)
+        #define RIIC_CH0_TMOL           ((uint8_t)(0x00))       /* Count is disable while the SCL is held LOW */
+    #elif (1U == RIIC_CFG_CH0_TMO_LCNT)
+        #define RIIC_CH0_TMOL           ((uint8_t)(0x02))       /* Count is enable while the SCL is held LOW */
+    #endif
+
+    #if (0U == RIIC_CFG_CH0_TMO_HCNT)
+        #define RIIC_CH0_TMOH           ((uint8_t)(0x00))       /* Count is disable while the SCL is held HIGH */
+    #elif (1U == RIIC_CFG_CH0_TMO_HCNT)
+        #define RIIC_CH0_TMOH           ((uint8_t)(0x04))       /* Count is enable while the SCL is held HIGH */
+    #endif
+
+/* Sets ICMR2 */
+    #define RIIC_CH0_ICMR2_INIT     ((uint8_t)(RIIC_CH0_TMOS | RIIC_CH0_TMOL | RIIC_CH0_TMOH))
+
+/* Sets ICMR3 */
+    #if (0U == RIIC_CFG_CH0_DIGITAL_FILTER) || (1U == RIIC_CFG_CH0_DIGITAL_FILTER)
+        #define RIIC_CH0_ICMR3_INIT ((uint8_t)(0x00)) /* Sets RIIC0.ICMR3(Noise Filter Stage: single-stage filter.) */
+    #elif (2U == RIIC_CFG_CH0_DIGITAL_FILTER)
+        #define RIIC_CH0_ICMR3_INIT ((uint8_t)(0x01)) /* Sets RIIC0.ICMR3(Noise Filter Stage: 2-stage filter.) */
+    #elif (3U == RIIC_CFG_CH0_DIGITAL_FILTER)
+        #define RIIC_CH0_ICMR3_INIT ((uint8_t)(0x02)) /* Sets RIIC0.ICMR3(Noise Filter Stage: 3-stage filter.) */
+    #elif (4U == RIIC_CFG_CH0_DIGITAL_FILTER)
+        #define RIIC_CH0_ICMR3_INIT ((uint8_t)(0x03)) /* Sets RIIC0.ICMR3(Noise Filter Stage: 4-stage filter.) */
+    #endif
+
+/***********************************************************************************************************************
+Exported global variables
+***********************************************************************************************************************/
+extern const uint16_t g_riic_bps[MAX_RIIC_CH_NUM];
+extern const uint16_t g_riic_slv_ad0_val[MAX_RIIC_CH_NUM];
+extern const uint16_t g_riic_slv_ad1_val[MAX_RIIC_CH_NUM];
+extern const uint16_t g_riic_slv_ad2_val[MAX_RIIC_CH_NUM];
+
+extern const uint8_t g_riic_slv_ad0_format[MAX_RIIC_CH_NUM];
+extern const uint8_t g_riic_slv_ad1_format[MAX_RIIC_CH_NUM];
+extern const uint8_t g_riic_slv_ad2_format[MAX_RIIC_CH_NUM];
+extern const uint8_t g_riic_gca_enable[MAX_RIIC_CH_NUM];
+
+extern const uint8_t g_riic_icmr2_init[MAX_RIIC_CH_NUM];
+extern const uint8_t g_riic_icmr3_init[MAX_RIIC_CH_NUM];
+extern const uint8_t g_riic_icfer_init[MAX_RIIC_CH_NUM];
+
+#endif /* RIIC_RX130_PRIVATE_H */
+

--- a/zephyr/rx/rdp_cfg/r_config/r_riic_rx_config.h
+++ b/zephyr/rx/rdp_cfg/r_config/r_riic_rx_config.h
@@ -1,0 +1,236 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+ * File Name    : r_riic_rx_config.h
+ * Description  : Configures the RIIC drivers
+ **********************************************************************************************************************/
+/***********************************************************************************************************************
+ * History : DD.MM.YYYY Version  Description
+ *         : 01.07.2013 1.00     First Release
+ *         : 30.09.2013 1.10     Change symbol of return value and status
+ *         : 08.10.2013 1.20     Modified processing for the I/O register initialization and mode transition 
+ *                                when a stop condition is detected while the slave is communicating.
+ *                               Modified processing for mode transition when an API function is called
+ *                                while the bus is busy.
+ *                               Modified processing for mode transition
+ *                                when an arbitration lost occurred and the addresses do not match.
+ *                               Modified incorrect slave transmission after the master reception.
+ *                               Modified processing for the I/O register initialization
+ *                                when generating a start condition and receiving the slave address.
+ *         : 17.07.2014 1.30     Added the parameters of channel 2.
+ *                               Deleted the parameters of PCLK.
+ *                               Added the parameters of the port function assignment.
+ *                               Changed the parameters of interrupt priority level.
+ *                               Added the parameters for the time out detection.
+ *         : 22.09.2014 1.40     The module is updated to measure the issue that slave communication 
+ *                               is not available after an arbitration-lost occurs and the bus is locked. 
+ *                                 The issue occurs when the following four conditions are all met.
+ *                                    - RIIC FIT module rev. 1.30 or earlier is used.
+ *                                    - RX device operates as both the master and the slave 
+ *                                      in multi-master communication.
+ *                                    - An arbitration-lost is detected when communicating as the master.
+ *                                    - Communication other than master reception or slave reception is performed.
+ *         : 14.11.2014 1.50     Added RX113 support.
+ *         : 09.10.2014 1.60     Added RX71M support.
+ *         : 20.10.2014 1.70     Added RX231 support.
+ *         : 31.10.2015 1.80     Added RX130, RX230, RX23T support.
+ *         : 04.03.2016 1.90     Added RX24T support.Changed about the pin definisions.
+ *         : 01.10.2016 2.00     Added RX65N support.
+ *         : 02.06.2017 2.10     Added RX24U support.
+ *         : 31.08.2017 2.20     Added definitions for Channel 1.
+ *         : 30.10.2017 2.30     Added RX66T support.
+ *         : 30.01.2018 2.30     Remove integer literal of setting value.
+ *         : 15.10.2018 2.40     Added RX72T support.
+ *         : 20.06.2019 2.42     Added RX23W support.
+ *         : 30.07.2019 2.43     Added RX72M support.
+ *         : 10.10.2019 2.44     Added RX13T support.
+ *         : 22.11.2019 2.45     Added RX66N, RX72N support.
+ *         : 10.03.2020 2.46     Added RX23E-A support.
+ *         : 30.06.2021 2.48     Added RX671 support.
+ *         : 31.07.2021 2.49     Added RX140 support.
+ *         : 31.12.2021 2.50     Added RX660 support.
+ *         : 31.03.2023 2.70     Added RX26T support.
+ *                               Added new macros for SCL rise time and SCL fall time.
+ *         : 29.05.2023 2.80     Added RX23E-B support.
+ *         : 10.10.2023 2.90     Modified source code comments of RIIC_CFG_CHi_RXI_INT_PRIORITY,
+ *                                RIIC_CFG_CHi_TXI_INT_PRIORITY, RIIC_CFG_CHi_EEI_INT_PRIORITY,
+ *                                RIIC_CFG_CHi_TEI_INT_PRIORITY (i = 0 to 2).
+ *         : 01.08.2024 2.91     Added RX651 group to source code comments of RIIC_CFG_CHi_RXI_INT_PRIORITY,
+ *                                RIIC_CFG_CHi_TXI_INT_PRIORITY, RIIC_CFG_CHi_EEI_INT_PRIORITY,
+ *                                RIIC_CFG_CHi_TEI_INT_PRIORITY (i = 0 to 2).
+ *         : 08.08.2024 3.00     Added RX260, RX261 support.
+ *         : 15.03.2025 3.01     Updated disclaimer.
+ **********************************************************************************************************************/
+/* Guards against multiple inclusion */
+#ifndef RIIC_CONFIG_H
+    #define RIIC_CONFIG_H
+/***********************************************************************************************************************
+ Configuration Options
+ **********************************************************************************************************************/
+/* SPECIFY WHETHER TO INCLUDE CODE FOR API PARAMETER CHECKING */
+/* Setting to BSP_CFG_PARAM_CHECKING_ENABLE utilizes the system default setting */
+/* Setting to 1 includes parameter checking; 0 compiles out parameter checking */
+    #define RIIC_CFG_PARAM_CHECKING_ENABLE  (1)
+
+/* SPECIFY CHANNELS TO INCLUDE SOFTWARE SUPPORT FOR 1=included, 0=not */
+/* mcu supported channels */
+/*  RX110: ch0,    ,     */
+/*  RX111: ch0,    ,     */
+/*  RX113: ch0,    ,     */
+/*  RX130: ch0,    ,     */
+/*  RX140: ch0,    ,     */
+/*  RX13T: ch0,    ,     */
+/*  RX230: ch0,    ,     */
+/*  RX231: ch0,    ,     */
+/*  RX23E-A: ch0,    ,   */
+/*  RX23E-B: ch0,    ,   */
+/*  RX23T: ch0,    ,     */
+/*  RX23W: ch0,    ,     */
+/*  RX24T: ch0,    ,     */
+/*  RX24U: ch0,    ,     */
+/*  RX260: ch0,    ,     */
+/*  RX261: ch0,    ,     */
+/*  RX26T: ch0,    ,     */
+/*  RX64M: ch0,    , ch2 */
+/*  RX65N: ch0, ch1, ch2 */
+/*  RX660: ch0,    , ch2 */
+/*  RX66T: ch0,    ,     */
+/*  RX66N: ch0, ch1, ch2 */
+/*  RX671: ch0, ch1, ch2 */
+/*  RX71M: ch0,    , ch2 */
+/*  RX72T: ch0,    ,     */
+/*  RX72M: ch0, ch1, ch2 */
+/*  RX72N: ch0, ch1, ch2 */
+    #define RIIC_CFG_CH0_INCLUDED           (DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i2c0)))
+    #define RIIC_CFG_CH1_INCLUDED           (DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i2c1)))
+    #define RIIC_CFG_CH2_INCLUDED           (DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i2c2)))
+
+/* Set RIIC bps(kbps) */
+    #define RIIC_CFG_CH0_kBPS               (400)
+    #define RIIC_CFG_CH1_kBPS               (400)
+    #define RIIC_CFG_CH2_kBPS               (400)
+
+/* Set SCL rise time (s) and SCL fall time (s) */
+    #define RIIC_CFG_SCL100K_UP_TIME        (1000E-9)
+    #define RIIC_CFG_SCL100K_DOWN_TIME      (300E-9)
+    #define RIIC_CFG_SCL400K_UP_TIME        (300E-9)
+    #define RIIC_CFG_SCL400K_DOWN_TIME      (300E-9)
+    #define RIIC_CFG_SCL1M_UP_TIME          (120E-9)
+    #define RIIC_CFG_SCL1M_DOWN_TIME        (120E-9)    
+
+/* Set using digital filter(Selected IIC phi cycle is filtered out) */
+/* 0 = not, 1 = one IIC phi, 2 = two IIC phi, 3 = three IIC phi, 4 = four IIC phi */
+    #define RIIC_CFG_CH0_DIGITAL_FILTER     (2)
+    #define RIIC_CFG_CH1_DIGITAL_FILTER     (2)
+    #define RIIC_CFG_CH2_DIGITAL_FILTER     (2)
+
+/* Setting to */
+/* 1: includes riic port setting processing */
+/* 0: compiles out riic port setting processing */
+    #define RIIC_CFG_PORT_SET_PROCESSING    (1)
+
+/* Set mode */
+/* 0 = single master mode, 1 = multi master mode(Master arbitration-lost detection is enabled.) */
+    #define RIIC_CFG_CH0_MASTER_MODE        (1)
+    #define RIIC_CFG_CH1_MASTER_MODE        (1)
+    #define RIIC_CFG_CH2_MASTER_MODE        (1)
+
+/* Set slave address */
+/* 0 = not, 1 = 7bit address format, 2 = 10bit address format */
+    #define RIIC_CFG_CH0_SLV_ADDR0_FORMAT   (1)
+    #define RIIC_CFG_CH0_SLV_ADDR1_FORMAT   (0)
+    #define RIIC_CFG_CH0_SLV_ADDR2_FORMAT   (0)
+
+    #define RIIC_CFG_CH0_SLV_ADDR0          (0x0025)
+    #define RIIC_CFG_CH0_SLV_ADDR1          (0x0000)
+    #define RIIC_CFG_CH0_SLV_ADDR2          (0x0000)
+
+    #define RIIC_CFG_CH1_SLV_ADDR0_FORMAT   (1)
+    #define RIIC_CFG_CH1_SLV_ADDR1_FORMAT   (0)
+    #define RIIC_CFG_CH1_SLV_ADDR2_FORMAT   (0)
+
+    #define RIIC_CFG_CH1_SLV_ADDR0          (0x0025)
+    #define RIIC_CFG_CH1_SLV_ADDR1          (0x0000)
+    #define RIIC_CFG_CH1_SLV_ADDR2          (0x0000)
+
+    #define RIIC_CFG_CH2_SLV_ADDR0_FORMAT   (1)
+    #define RIIC_CFG_CH2_SLV_ADDR1_FORMAT   (0)
+    #define RIIC_CFG_CH2_SLV_ADDR2_FORMAT   (0)
+
+    #define RIIC_CFG_CH2_SLV_ADDR0          (0x0025)
+    #define RIIC_CFG_CH2_SLV_ADDR1          (0x0000)
+    #define RIIC_CFG_CH2_SLV_ADDR2          (0x0000)
+
+/* Select General call address */
+/* 0 = not use, 1 = use(General call address detection is enabled.) */
+    #define RIIC_CFG_CH0_SLV_GCA_ENABLE     (0)
+    #define RIIC_CFG_CH1_SLV_GCA_ENABLE     (0)
+    #define RIIC_CFG_CH2_SLV_GCA_ENABLE     (0)
+
+/* This #define sets the priority level for the riic interrupt */
+/* 1 lowest, 15 highest */
+/* The following devices can not individually specify the interrupt priority level for EEI0, TEI0, EEI2, TEI2. */
+/* EEI and TEI interrupts are grouped as the BL1 interrupt in the RX26T, RX64M, RX65N, RX651, RX660, RX66N, RX66T,
+   RX671, RX71M, RX72M, RX72N, and RX72T groups. */
+    #define RIIC_CFG_CH0_RXI_INT_PRIORITY   (1)
+    #define RIIC_CFG_CH0_TXI_INT_PRIORITY   (1)
+/* The priority level of the EEI, please do not lower than the priority level of TXI and RXI.
+   For devices with EEI assigned to group interrupts, set the priority level of the EEI higher than the priority level of TXI and RXI. */
+    #define RIIC_CFG_CH0_EEI_INT_PRIORITY   (1)
+/* The priority level of the TEI, please do not lower than the priority level of TXI and RXI.
+   For devices with TEI assigned to group interrupts, set the priority level of the TEI higher than the priority level of TXI and RXI. */
+    #define RIIC_CFG_CH0_TEI_INT_PRIORITY   (1)
+
+    #define RIIC_CFG_CH1_RXI_INT_PRIORITY   (1)
+    #define RIIC_CFG_CH1_TXI_INT_PRIORITY   (1)
+/* The priority level of the EEI, please do not lower than the priority level of TXI and RXI.
+   For devices with EEI assigned to group interrupts, set the priority level of the EEI higher than the priority level of TXI and RXI. */
+    #define RIIC_CFG_CH1_EEI_INT_PRIORITY   (1)
+/* The priority level of the TEI, please do not lower than the priority level of TXI and RXI.
+   For devices with TEI assigned to group interrupts, set the priority level of the TEI higher than the priority level of TXI and RXI. */
+    #define RIIC_CFG_CH1_TEI_INT_PRIORITY   (1)
+
+    #define RIIC_CFG_CH2_RXI_INT_PRIORITY   (1)
+    #define RIIC_CFG_CH2_TXI_INT_PRIORITY   (1)
+/* The priority level of the EEI, please do not lower than the priority level of TXI and RXI.
+   For devices with EEI assigned to group interrupts, set the priority level of the EEI higher than the priority level of TXI and RXI. */
+    #define RIIC_CFG_CH2_EEI_INT_PRIORITY   (1)
+/* The priority level of the TEI, please do not lower than the priority level of TXI and RXI.
+   For devices with TEI assigned to group interrupts, set the priority level of the TEI higher than the priority level of TXI and RXI. */
+    #define RIIC_CFG_CH2_TEI_INT_PRIORITY   (1)
+
+/* Select Timeout function enable or disable */
+/* 0 = disable, 1 = enable */
+    #define RIIC_CFG_CH0_TMO_ENABLE         (1)
+    #define RIIC_CFG_CH1_TMO_ENABLE         (1)
+    #define RIIC_CFG_CH2_TMO_ENABLE         (1)
+
+/* Select long mode or short mode for the timeout detection time */
+/*    when the timeout function is enabled. */
+/* 0 = Long mode, 1 = short mode */
+    #define RIIC_CFG_CH0_TMO_DET_TIME       (0)
+    #define RIIC_CFG_CH1_TMO_DET_TIME       (0)
+    #define RIIC_CFG_CH2_TMO_DET_TIME       (0)
+
+/* Select enable or disable the internal counter of the timeout function to count up while the */
+/* SCL line is held LOW when the timeout function is enabled. */
+/* 0 = Count is disabled, 1 = Count is enabled */
+    #define RIIC_CFG_CH0_TMO_LCNT           (1)
+    #define RIIC_CFG_CH1_TMO_LCNT           (1)
+    #define RIIC_CFG_CH2_TMO_LCNT           (1)
+
+/* Select enable or disable the internal counter of the timeout function to count up while the */
+/* SCL line is held HIGH when the timeout function is enabled. */
+/* 0 = Count is disabled, 1 = Count is enabled */
+    #define RIIC_CFG_CH0_TMO_HCNT           (1)
+    #define RIIC_CFG_CH1_TMO_HCNT           (1)
+    #define RIIC_CFG_CH2_TMO_HCNT           (1)
+
+/* Define software bus busy check counter. */
+    #define RIIC_CFG_BUS_CHECK_COUNTER      (1000)     /* Counter of checking bus busy */
+
+#endif /* RIIC_CONFIG_H */
+

--- a/zephyr/rx/rdp_cfg/r_config/r_riic_rx_pin_config.h
+++ b/zephyr/rx/rdp_cfg/r_config/r_riic_rx_pin_config.h
@@ -1,0 +1,58 @@
+/***********************************************************************************************************************
+* Copyright (c) 2016 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+ * File Name    : r_riic_rx_pin_config.h
+ * Description  : Pin configures the RIIC drivers
+ **********************************************************************************************************************/
+/***********************************************************************************************************************
+ * History : DD.MM.YYYY Version  Description
+ *         : 04.03.2016 1.90     First Release
+ *         : 02.06.2017 2.10     Deleted RIIC port definitions of RIIC3.
+ *         : 30.10.2017 2.30     Port K is added.
+ *         : 15.03.2025 3.01     Updated disclaimer.
+ **********************************************************************************************************************/
+/* Guards against multiple inclusion */
+#ifndef RIIC_PIN_CONFIG_H
+    #define RIIC_PIN_CONFIG_H
+/***********************************************************************************************************************
+ Configuration Options
+ **********************************************************************************************************************/
+/*------------------------------------------------------------------------------*/
+/*   Set using port as riic port                                                */
+/*------------------------------------------------------------------------------*/
+/* Set using port as riic port.                                                                 */
+/* If you want to include the port configuration process(RIIC_CFG_PORT_SET_PROCESSING is "1"),  */
+/* please choose which ports to use for the SCL/SDA of RIIC with the following setting.         */
+/* Select the port group and pin used by setting
+ "R_RIIC_CFG_RIICx_SCLx_PORT (select from port group 0 to K)"
+ and "R_RIIC_CFG_RIICx_SCLx_BIT (select from pin number 0 to 7)"
+ and "R_RIIC_CFG_RIICx_SDAx_PORT (select from port group 0 to K)"
+ and "R_RIIC_CFG_RIICx_SDAx_BIT (select from pin number 0 to 7)",
+ respectively. */
+
+/* Select the ports (SCL0 and SDA0) to use in RIIC0 */
+    #define R_RIIC_CFG_RIIC0_SCL0_PORT   '1'     /* Port Number */
+    #define R_RIIC_CFG_RIIC0_SCL0_BIT    '2'     /* Bit Number  */
+
+    #define R_RIIC_CFG_RIIC0_SDA0_PORT   '1'     /* Port Number */
+    #define R_RIIC_CFG_RIIC0_SDA0_BIT    '3'     /* Bit Number  */
+
+/* Select the ports (SCL1 and SDA1) to use in RIIC1 */
+    #define R_RIIC_CFG_RIIC1_SCL1_PORT   '2'     /* Port Number */
+    #define R_RIIC_CFG_RIIC1_SCL1_BIT    '1'     /* Bit Number  */
+
+    #define R_RIIC_CFG_RIIC1_SDA1_PORT   '2'     /* Port Number */
+    #define R_RIIC_CFG_RIIC1_SDA1_BIT    '0'     /* Bit Number  */
+
+/* Select the ports (SCL2 and SDA2) to use in RIIC2 */
+    #define R_RIIC_CFG_RIIC2_SCL2_PORT   '1'     /* Port Number */
+    #define R_RIIC_CFG_RIIC2_SCL2_BIT    '6'     /* Bit Number  */
+
+    #define R_RIIC_CFG_RIIC2_SDA2_PORT   '1'     /* Port Number */
+    #define R_RIIC_CFG_RIIC2_SDA2_BIT    '7'     /* Bit Number  */
+
+#endif /* RIIC_PIN_CONFIG_H */
+


### PR DESCRIPTION
Add support for I2C driver on Renesas RX with r_riic_rx (RDP)
The license is BSD-3-Clause now

Note: I’ve updated the version in the README to 1.47 (the latest version with the updated license). This doesn’t affect the current version of BSP and SCI that was already supported in the previous PR.