### PR TITLE
hal: renesas: rx: Add IWDT driver support for Renesas RX

### DIFF
--- a/drivers/rx/CMakeLists.txt
+++ b/drivers/rx/CMakeLists.txt
@@ -115,3 +115,13 @@ if(CONFIG_USE_RX_RDP_ADC)
 		rdp/src/r_s12ad_rx/src/targets/${CONFIG_SOC_SERIES}/r_s12ad_${CONFIG_SOC_SERIES}.c
 	)
 endif()
+
+if(CONFIG_USE_RX_RDP_IWDT)
+	zephyr_include_directories(
+		rdp/src/r_iwdt_rx
+		rdp/src/r_iwdt_rx/src
+	)
+	zephyr_library_sources(
+		rdp/src/r_iwdt_rx/src/r_iwdt_rx.c
+	)
+endif()

--- a/drivers/rx/README
+++ b/drivers/rx/README
@@ -67,3 +67,7 @@ Patch List:
    because Zephyr SDK hasn't support it yet
    Impacted files:
       drivers/rx/rdp/src/r_bsp/mcu/all/r_rx_intrinsic_functions.h
+
+   * Fix the build warnings in IWDT driver
+   Impacted files:
+      drivers/rx/rdp/src/r_iwdt_rx/src/r_iwdt_rx.c

--- a/drivers/rx/rdp/src/r_iwdt_rx/r_iwdt_rx_if.h
+++ b/drivers/rx/rdp/src/r_iwdt_rx/r_iwdt_rx_if.h
@@ -1,0 +1,198 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_iwdt_rx_if.h
+* Description  : Functions for using IWDT on RX devices.
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* History : DD.MM.YYYY Version Description           
+*           07.06.2013 1.00    First Release
+*           06.09.2013 1.10    Change enumeration name
+*           19.03.2014 1.20    Removed unnecessary #includes. Added #ifdef to e_iwdt_timeout. Changed version number.
+*           30.12.2014 1.30    Added support for RX113.
+*           06.03.2015 1.40    Added support for RX64M & RX71M
+*           02.06.2015 1.50    Added support for RX231
+*           01.03.2016 1.51    Added support for RX130, RX230 and RX23T
+*           30.06.2016 1.60    Added support for RX65N
+*           19.12.2016 1.70    Added support for RX24U, RX24T(512KB)
+*           21.07.2017 1.80    Added support for RX130_512KB, RX65N-2M
+*           31.10.2017 1.81    Added the demo for RX65N, RX65N-2M
+*           28.09.2018 1.90    Added support for RX66T
+*           16.11.2018 1.91    Added XML document number
+*           01.02.2019 2.00    Added support for RX72T, RX65N-64pin.
+*                              Bug fix: R_WDT_Open(), R_IWDT_Open() invalidated if either module is in auto-start mode.
+*           20.05.2019 3.00    Added support for GNUC and ICCRX.
+*           28.06.2019 3.10    Added support for RX23W.
+*           15.08.2019 3.20    Added support for RX72M.
+*           25.11.2019 3.30    Added support for RX13T.
+*                              Removed support for Generation 1 devices.
+*                              Fixed to comply with GSCE Coding Standards Rev.6.00.
+*           30.12.2019 3.40    Added support for RX66N, RX72N.
+*           31.03.2020 3.50    Added support for RX23E-A.
+*           30.06.2020 3.60    Changed revision to reflect demo upgrade.
+*           31.03.2021 3.70    Added support for RX671.
+*           15.04.2021 3.80    Added support for RX140.
+*           13.09.2021 3.90    Added the demo for RX671.
+*           14.03.2022 4.00    Added support for RX66T-48Pin.
+*           31.03.2022 4.10    Added support for RX660.
+*           28.06.2022 4.20    Updated demo projects.
+*           15.08.2022 4.30    Added support for RX26T.
+*                              Fixed to comply with GSCE Coding Standards Rev.6.5.0
+*           29.05.2023 4.40    Added support for RX23E-B.
+*                              Fixed to comply with GSCE Coding Standards Rev.6.5.0
+*           28.06.2024 4.50    Added support for RX260, RX261.
+*           15.03.2025 4.51    Updated disclaimer
+***********************************************************************************************************************/
+
+#ifndef IWDT_RX_IF_H
+#define IWDT_RX_IF_H
+
+/***********************************************************************************************************************
+Includes   <System Includes> , "Project Includes"
+***********************************************************************************************************************/
+#include "platform.h"
+/* Used for configuring the IWDT code */
+#include "r_iwdt_rx_config.h"
+
+/***********************************************************************************************************************
+Macro definitions
+***********************************************************************************************************************/
+#if R_BSP_VERSION_MAJOR < 5
+    #error "This module must use BSP module of Rev.5.00 or higher. Please use the BSP module of Rev.5.00 or higher."
+#endif
+/* Version Number of API. */
+#define IWDT_RX_VERSION_MAJOR   (4)
+#define IWDT_RX_VERSION_MINOR   (51)
+
+#define OFS0_IWDT_DISABLED      (0x00000002)
+
+/***********************************************************************************************************************
+Typedef definitions
+***********************************************************************************************************************/
+
+/* API ERROR RETURN CODES */
+
+#define IWDT_STAT_REFRESH_ERR_MASK      (0x8000)
+#define IWDT_STAT_UNDERFLOW_ERR_MASK    (0x4000)
+#define IWDT_STAT_ERROR_MASK            (0xC000)
+#define IWDT_STAT_COUNTER_MASK          (0x3FFF)
+
+typedef enum e_iwdt_err       // IWDT API error codes
+{
+    IWDT_SUCCESS=0,
+    IWDT_ERR_OPEN_IGNORED,    // The module has already been Open
+    IWDT_ERR_INVALID_ARG,     // Argument is not valid for parameter
+    IWDT_ERR_NULL_PTR,        // Received null pointer or missing required argument
+    IWDT_ERR_NOT_OPENED,      // Open function has not yet been called
+    IWDT_ERR_BUSY,            // IWDT resource locked
+} iwdt_err_t;
+
+
+/* Open() DEFINITIONS */
+
+typedef enum e_iwdt_timeout           // IWDT Time-Out Period
+{
+#if defined(BSP_MCU_RX11_ALL) || defined(BSP_MCU_RX130) || defined(BSP_MCU_RX13T) || defined(BSP_MCU_RX23_ALL) \
+    || defined(BSP_MCU_RX24U)|| defined(BSP_MCU_RX140) || defined(BSP_MCU_RX260) || defined(BSP_MCU_RX261)
+    IWDT_TIMEOUT_128 =0x0000u,        // 128  (cycles) 
+    IWDT_TIMEOUT_512 =0x0001u,        // 512  (cycles)
+    IWDT_TIMEOUT_1024=0x0002u,        // 1024 (cycles)
+    IWDT_TIMEOUT_2048=0x0003u,        // 2048 (cycles)
+#else /* RX64M, RX71M, RX65N, RX66T, RX66N, RX72T, RX72M, RX72N, RX671, RX660, RX26T */
+    IWDT_TIMEOUT_1024 =0x0000u,        // 1024 (cycles)
+    IWDT_TIMEOUT_4096 =0x0001u,        // 4096 (cycles)
+    IWDT_TIMEOUT_8192 =0x0002u,        // 8192 (cycles)
+    IWDT_TIMEOUT_16384=0x0003u,        // 16,384 (cycles)
+#endif
+    IWDT_NUM_TIMEOUTS
+} iwdt_timeout_t;
+
+typedef enum e_iwdt_clock_div           // IWDT Clock Division Ratio
+{
+    IWDT_CLOCK_DIV_1  =0x0000u,       // IWDTCLK/1
+    IWDT_CLOCK_DIV_16 =0x0020u,       // IWDTCLK/16
+    IWDT_CLOCK_DIV_32 =0x0030u,       // IWDTCLK/32
+    IWDT_CLOCK_DIV_64 =0x0040u,       // IWDTCLK/64
+    IWDT_CLOCK_DIV_128=0x00F0u,       // IWDTCLK/128
+    IWDT_CLOCK_DIV_256=0x0050u        // IWDTCLK/256
+} iwdt_clock_div_t;
+
+typedef enum e_iwdt_window_end           // Window End Position
+{
+    IWDT_WINDOW_END_75=0x0000u,       // 75%
+    IWDT_WINDOW_END_50=0x0100u,       // 50%
+    IWDT_WINDOW_END_25=0x0200u,       // 25%
+    IWDT_WINDOW_END_0 =0x0300u        // 0% (window end position is not specified)
+} iwdt_window_end_t;
+
+typedef enum e_iwdt_window_start         // Window Start Position
+{
+    IWDT_WINDOW_START_25 =0x0000u,    // 25%
+    IWDT_WINDOW_START_50 =0x1000u,    // 50%
+    IWDT_WINDOW_START_75 =0x2000u,    // 75%
+    IWDT_WINDOW_START_100=0x3000u     // 100% (window start position is not specified)
+} iwdt_window_start_t;
+
+typedef enum e_iwdt_timeout_control   // Signal control when Time-out and Refresh error
+{
+    IWDT_TIMEOUT_NMI  =0x00u,         // Non-maskable interrupt request output is enabled
+    IWDT_TIMEOUT_RESET=0x80u          // Reset output is enabled
+} iwdt_timeout_control_t;
+
+typedef enum e_iwdt_count_stop        // Sleep mode count stop
+{
+    IWDT_COUNT_STOP_DISABLE=0x00u,    // 0: Count stop is disabled 
+    IWDT_COUNT_STOP_ENABLE =0x80u     // 1: Count stop is enabled
+} iwdt_count_stop_t;
+
+typedef struct st_iwdt_config                 // IWDT configuration options used in Open function
+{
+    iwdt_timeout_t          timeout;          // Time-out period   
+    iwdt_clock_div_t        iwdtclk_div;      // IWDT clock division ratio
+    iwdt_window_start_t     window_start;     // Window start position
+    iwdt_window_end_t       window_end;       // Window end position
+    iwdt_timeout_control_t  timeout_control;  // Reset or NMI output when time-out  
+    iwdt_count_stop_t       count_stop_enable;// Sleep mode count stop function 
+} iwdt_config_t;
+
+
+/* Control() DEFINITIONS */
+
+typedef enum e_iwdt_cmd                 // Command used in Control and GetStatus function
+{
+    IWDT_CMD_GET_STATUS,                // Get IWDT status
+    IWDT_CMD_REFRESH_COUNTING           // Refresh the counter
+} iwdt_cmd_t;
+
+/***********************************************************************************************************************
+Public Functions
+***********************************************************************************************************************/
+#if ((BSP_CFG_OFS0_REG_VALUE & OFS0_IWDT_DISABLED) == OFS0_IWDT_DISABLED) /* Register start mode */
+/******************************************************************************
+ * Function Name: R_IWDT_Open
+ * Description  : Initializes the IWDT counter options by initializing the associated registers
+ * Argument     : p_cfg
+ * Return Value : .
+ *****************************************************************************/
+iwdt_err_t    R_IWDT_Open (void * const p_cfg);
+#endif
+/******************************************************************************
+ * Function Name: R_IWDT_Control
+ * Description  : Getting the IWDT status and refreshing the down-counter of IWDT
+ * Arguments    : cmd
+ *              : p_status
+ * Return Value : .
+ *****************************************************************************/
+iwdt_err_t    R_IWDT_Control (iwdt_cmd_t const cmd, uint16_t * p_status);
+
+/******************************************************************************
+ * Function Name: R_IWDT_GetVersion
+ * Description  : Returns the version number of the module
+ * Return Value : .
+ *****************************************************************************/
+uint32_t      R_IWDT_GetVersion (void);
+
+#endif /* IWDT_RX_IF_H */

--- a/drivers/rx/rdp/src/r_iwdt_rx/src/r_iwdt_rx.c
+++ b/drivers/rx/rdp/src/r_iwdt_rx/src/r_iwdt_rx.c
@@ -1,0 +1,369 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_iwdt_rx.c
+* Description  : Functions for using IWDT on RX devices.
+***********************************************************************************************************************/
+/**********************************************************************************************************************
+* History : DD.MM.YYYY Version Description
+*           07.06.2013 1.00    First Release
+*           06.09.2013 1.10    Add NMI interrupt enable, update name of enumeration
+*           19.03.2014 1.20    Removed unnecessary #includes. Changed parameter check for p_cfg->timeout.
+*           19.12.2016 1.30    Added support for RX24U, RX24T(512KB)
+*                              FIT_NO_PTR check added to NULL check.
+*           21.07.2017 1.80    Added support for RX65N-2M, RX130-512KB
+*           28.09.2018 1.90    Added support for RX66T
+*                              Updated follow GSCE coding rule 5.0
+*           01.02.2019 2.00    Added support for RX72T, RX65N-64pin.
+*                              Bug fix: R_WDT_Open(), R_IWDT_Open() invalidated if either module is in auto-start mode.
+*           20.05.2019 3.00    Added support for GNUC and ICCRX.
+*           15.08.2019 3.20    Fixed warnings in IAR.
+*           25.11.2019 3.30    Added support for RX13T.
+*                              Modified comment of API function to Doxygen style.
+*                              Fixed to comply with GSCE Coding Standards Rev.6.00.
+*           15.08.2022 4.30    Fixed to comply with GSCE Coding Standards Rev.6.5.0
+*           29.05.2023 4.40    Fixed to comply with GSCE Coding Standards Rev.6.5.0
+*           28.06.2024 4.50    Added support for RX260, RX261.
+*           15.03.2025 4.51    Updated disclaimer
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Includes   <System Includes> , "Project Includes"
+***********************************************************************************************************************/
+#include "platform.h"
+/* Defines for IWDT support */
+#include "r_iwdt_rx_config.h"
+#include "r_iwdt_rx_if.h"
+
+/***********************************************************************************************************************
+Macro definitions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Typedef definitions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Private global variables and functions
+***********************************************************************************************************************/
+#if ((BSP_CFG_OFS0_REG_VALUE & OFS0_IWDT_DISABLED) == OFS0_IWDT_DISABLED) /* Register start mode */
+/* State variable for this package. */
+static bool s_already_opened = false;
+
+/* Internal functions. */
+static iwdt_err_t iwdt_init_register_start_mode (iwdt_config_t * p_cfg);
+#if (1 == IWDT_CFG_PARAM_CHECKING_ENABLE)
+static bool iwdt_parameter_check (iwdt_config_t * p_cfg);
+#endif /* IWDT_CFG_PARAM_CHECKING_ENABLE */
+#endif /* BSP_CFG_OFS0_REG_VALUE */
+
+static inline bool acquire_hw_lock (void);
+static inline void release_hw_lock (void);
+
+/***********************************************************************************************************************
+* Function Name: R_IWDT_Open
+********************************************************************************************************************//**
+* @brief This function configures the IWDT counter options by initializing the associated registers. It is unavailable
+* if the IWDT is initialized by the OFS0 register in r_bsp_config.h (Auto-Start mode).\n
+* This function must be called before calling any other API functions.
+* @param[in] p_cfg Pointer to configuration structure of type iwdt_ config_t.
+* See Section 3 in the application note for details.
+* @retval IWDT_SUCCESS IWDT initialized
+* @retval IWDT_ERR_OPEN_IGNORED The module has already been opened
+* @retval IWDT_ERR_INVALID_ARG An element of the p_cfg structure contains an invalid value
+* @retval IWDT_ERR_NULL_PTR p_cfg pointer is NULL
+* @retval IWDT_ERR_BUSY IWDT resource is locked
+* @details Sets all configurable options for the Independent Watchdog Timer.
+* @note
+* See Section 3 in the application note for details.
+*/
+#if ((BSP_CFG_OFS0_REG_VALUE & OFS0_IWDT_DISABLED) == OFS0_IWDT_DISABLED) /* Register start mode */
+iwdt_err_t R_IWDT_Open(void * const p_cfg)
+{
+    iwdt_err_t   err;
+    bool         ret;
+
+    err = IWDT_SUCCESS;
+
+    /* CHECK ARGUMENTS */
+#if (1 == IWDT_CFG_PARAM_CHECKING_ENABLE)
+    /* Check argument p_cfg */
+    if ((NULL == p_cfg) || (FIT_NO_PTR == p_cfg))
+    {
+        return IWDT_ERR_NULL_PTR;
+    }
+
+    /* Casting void* type to iwdt_config_t* type is valid */
+    ret = iwdt_parameter_check((iwdt_config_t *)p_cfg);
+    if (false == ret)
+    {
+        return IWDT_ERR_INVALID_ARG;
+    }
+#endif
+
+    ret = acquire_hw_lock();
+    if (false == ret)
+    {
+        /* Lock not obtained, return error */
+        return IWDT_ERR_BUSY;
+    }
+
+    /* Lock obtained, we can change state */
+    if (true == s_already_opened)
+    {
+        /* Open function is already called */
+        release_hw_lock();
+        return IWDT_ERR_OPEN_IGNORED;
+    }
+
+    /* Casting void* type to iwdt_config_t* type is valid */
+    err = iwdt_init_register_start_mode((iwdt_config_t *)p_cfg);
+
+    /* Update status */
+    s_already_opened = true;
+
+    release_hw_lock();
+    return err;
+}
+/******************************************************************************
+End of function R_IWDT_Open
+******************************************************************************/
+
+/***********************************************************************************************************************
+* Function Name: iwdt_init_register_start_mode
+* Description  : Make setting to IWDT register for initialization.
+* Arguments    : p_cfg -
+*                    Pointer to configuration structure of type iwdt_config_t.
+* Return Value : IWDT_SUCCESS -
+*                    IWDT is initialized successful.
+***********************************************************************************************************************/
+static iwdt_err_t iwdt_init_register_start_mode(iwdt_config_t *p_cfg)
+{
+    /* Set Time-out period, Clock Division Ratio, Window Start/End Position */
+    IWDT.IWDTCR.WORD = ((((uint16_t)p_cfg->timeout) | ((uint16_t)p_cfg->iwdtclk_div)) | (((uint16_t)p_cfg->window_start) | ((uint16_t)p_cfg->window_end)));
+
+    /* Set reset output or NMI output */
+    IWDT.IWDTRCR.BYTE = (uint8_t)p_cfg->timeout_control;
+
+    if (IWDT_TIMEOUT_NMI == p_cfg->timeout_control)
+    {
+        /* Enable NMI interrupt */
+        ICU.NMIER.BIT.IWDTEN = 0x1;
+    }
+
+    /* Set enable or disable count stop in low-power mode */
+    IWDT.IWDTCSTPR.BYTE = (uint8_t)p_cfg->count_stop_enable;
+
+    return IWDT_SUCCESS;
+}
+/******************************************************************************
+End of function iwdt_init_register_start_mode
+******************************************************************************/
+
+/***********************************************************************************************************************
+* Function Name: iwdt_parameter_check
+* Description  : Check validity of input parameter of R_IWDT_Open().
+* Arguments    : p_cfg -
+*                    Pointer to configuration structure of type iwdt_config_t.
+* Return Value : true -
+*                    Input is valid.
+*                false -
+*                    Input is invalid.
+***********************************************************************************************************************/
+#if (1 == IWDT_CFG_PARAM_CHECKING_ENABLE)
+static bool iwdt_parameter_check(iwdt_config_t *p_cfg)
+{
+    bool ret = true;
+
+    if (p_cfg->timeout >= IWDT_NUM_TIMEOUTS)
+    {
+        ret = false;
+    }
+
+    if (((IWDT_CLOCK_DIV_1   != p_cfg->iwdtclk_div)  && \
+        (IWDT_CLOCK_DIV_16  != p_cfg->iwdtclk_div)) && \
+        (((IWDT_CLOCK_DIV_32  != p_cfg->iwdtclk_div)  && \
+        (IWDT_CLOCK_DIV_64  != p_cfg->iwdtclk_div)) && \
+        ((IWDT_CLOCK_DIV_128 != p_cfg->iwdtclk_div)  && \
+        (IWDT_CLOCK_DIV_256 != p_cfg->iwdtclk_div))))
+    {
+        ret = false;
+    }
+
+    if (((IWDT_WINDOW_END_75 != p_cfg->window_end)  && \
+        (IWDT_WINDOW_END_50 != p_cfg->window_end)) && \
+        ((IWDT_WINDOW_END_25 != p_cfg->window_end)  && \
+        (IWDT_WINDOW_END_0  != p_cfg->window_end)))
+    {
+        ret = false;
+    }
+
+    if (((IWDT_WINDOW_START_25  != p_cfg->window_start)  && \
+        (IWDT_WINDOW_START_50  != p_cfg->window_start)) && \
+        ((IWDT_WINDOW_START_75  != p_cfg->window_start)  && \
+        (IWDT_WINDOW_START_100 != p_cfg->window_start)))
+    {
+        ret = false;
+    }
+
+    if ((IWDT_TIMEOUT_RESET != p_cfg->timeout_control) && \
+        (IWDT_TIMEOUT_NMI   != p_cfg->timeout_control))
+    {
+        ret = false;
+    }
+
+    if ((IWDT_COUNT_STOP_DISABLE != p_cfg->count_stop_enable) && \
+        (IWDT_COUNT_STOP_ENABLE  != p_cfg->count_stop_enable))
+    {
+        ret = false;
+    }
+
+    return ret;
+}
+/******************************************************************************
+End of function iwdt_parameter_check
+******************************************************************************/
+#endif /* 1 == IWDT_CFG_PARAM_CHECKING_ENABLE */
+#endif /* BSP_CFG_OFS0_REG_VALUE & OFS0_IWDT_DISABLED == OFS0_IWDT_DISABLED */
+
+
+/***********************************************************************************************************************
+* Function Name: R_IWDT_Control
+********************************************************************************************************************//**
+* @brief This function performs getting the IWDT status and refreshing the down-counter of IWDT. This function may be
+* used in both Auto-Start and Register-Start modes.
+* @param[in] cmd Command to run.
+* See Section 3 in the application note for details.
+* @param[in] p_status Pointer to the storage of the counter and status flags.
+* @retval IWDT_SUCCESS Command completed successfully
+* @retval IWDT_ERR_INVALID_ARG Invalid argument
+* @retval IWDT_ERR_NULL_PTR p_status is NULL
+* @retval IWDT_ERR_NOT_OPENED Open function has not yet been called
+* @retval IWDT_ERR_BUSY IWDT resource is locked
+* @details If command IWDT_CMD_REFRESH_COUNTING is selected, the watchdog counter is initialized to its start value
+* and counting continues.\n If command IWDT_CMD_GET_STATUS is selected, the IWDT status register is loaded into
+* *p_status. The high order 2 bits indicate whether a refresh error occurred (refresh called outside of legal window)
+*  or an underflow occurred (counter expired). The remaining bits indicate the current counter value.
+* @note This second argument is ignored for command IWDT_CMD_REFRESH_COUNTING. When initializing the watchdog timer
+* with the IWDT_CMD_REFRESH_COUNTING command, up to four count cycles is required (the number of cycles of the
+* IWDT-dedicated clock (IWDTCLK) for one count cycle varies depending on the clock division ratio specified in the
+* Open). Therefore, an execution of the IWDT_CMD_REFRESH_COUNTING command should be completed four count cycles
+* before the end position of the refresh-permitted period or a counter underflow.
+*/
+iwdt_err_t R_IWDT_Control(iwdt_cmd_t const cmd, uint16_t * p_status)
+{
+    bool ret = false;
+
+    /* CHECK ARGUMENTS */
+#if (1 == IWDT_CFG_PARAM_CHECKING_ENABLE)
+    if ((IWDT_CMD_REFRESH_COUNTING != cmd) && (IWDT_CMD_GET_STATUS != cmd))
+    {
+        return IWDT_ERR_INVALID_ARG;
+    }
+
+    /* Check argument p_status */
+    if (((NULL == p_status) || (FIT_NO_PTR == p_status)) && (IWDT_CMD_GET_STATUS == cmd))
+    {
+        return IWDT_ERR_NULL_PTR;
+    }
+#endif
+
+    ret = acquire_hw_lock();
+    if (false == ret)
+    {
+        /* Lock not obtained, return error */
+        return IWDT_ERR_BUSY;
+    }
+
+    /* Lock obtained */
+#if ((BSP_CFG_OFS0_REG_VALUE & OFS0_IWDT_DISABLED) == OFS0_IWDT_DISABLED) /* Register start mode */
+    if (false == s_already_opened)
+    {
+        /* Open function has not called yet */
+        release_hw_lock();
+        return IWDT_ERR_NOT_OPENED;
+    }
+#endif
+
+    switch (cmd)
+    {
+        case IWDT_CMD_REFRESH_COUNTING:
+        {
+            /* Make settings to IWDTRR register to refresh the counter */
+            IWDT.IWDTRR = 0x00u;
+
+            /* Write FFh to register IWDTRR to refresh the counter */
+            IWDT.IWDTRR = 0xFFu;
+            break;
+        }
+        case IWDT_CMD_GET_STATUS:
+        {
+            /* Get value 16 bits IWDTSR register */
+            *p_status = IWDT.IWDTSR.WORD;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    release_hw_lock();
+    return IWDT_SUCCESS;
+}
+/******************************************************************************
+End of function R_IWDT_Control
+******************************************************************************/
+
+/***********************************************************************************************************************
+* Function Name: R_IWDT_GetVersion
+********************************************************************************************************************//**
+* @brief This function returns the driver version number at runtime.
+* @return Version number.
+* @details Returns the version of this module. The version number is encoded such that the top 2 bytes are the major
+* version number and the bottom 2 bytes are the minor version number.
+* @note None.
+*/
+uint32_t  R_IWDT_GetVersion(void)
+{
+    uint32_t  version = (IWDT_RX_VERSION_MAJOR << 16) | IWDT_RX_VERSION_MINOR;
+
+    return version;
+}
+/******************************************************************************
+End of function R_IWDT_GetVersion
+******************************************************************************/
+
+/*****************************************************************************
+* Function Name: acquire_hw_lock
+* Description  : get the hardware lock BSP_LOCK_IWDT.
+* Arguments    : None.
+* Return Value : true -
+*                  the lock is acquired successfully
+*                false -
+*                   fail to get the lock
+******************************************************************************/
+static inline bool acquire_hw_lock(void)
+{
+    return R_BSP_HardwareLock(BSP_LOCK_IWDT);
+}
+/******************************************************************************
+End of function acquire_hw_lock
+******************************************************************************/
+
+/*****************************************************************************
+* Function Name: release_hw_lock
+* Description  : release hardware lock BSP_LOCK_IWDT.
+* Arguments    : None.
+* Return Value : None.
+******************************************************************************/
+static inline void release_hw_lock(void)
+{
+    R_BSP_HardwareUnlock(BSP_LOCK_IWDT);
+}
+/******************************************************************************
+End of function release_hw_lock
+******************************************************************************/

--- a/drivers/rx/rdp/src/r_iwdt_rx/src/r_iwdt_rx.c
+++ b/drivers/rx/rdp/src/r_iwdt_rx/src/r_iwdt_rx.c
@@ -37,6 +37,7 @@ Includes   <System Includes> , "Project Includes"
 /* Defines for IWDT support */
 #include "r_iwdt_rx_config.h"
 #include "r_iwdt_rx_if.h"
+#include "r_bsp_locking.h"
 
 /***********************************************************************************************************************
 Macro definitions

--- a/zephyr/rx/rdp_cfg/r_config/r_iwdt_rx_config.h
+++ b/zephyr/rx/rdp_cfg/r_config/r_iwdt_rx_config.h
@@ -1,0 +1,36 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 - 2025 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name     : r_iwdt_rx_config.h
+* Description   : Configures the IWDT drivers
+************************************************************************************************************************
+* History : DD.MM.YYYY Version Description           
+*           07.06.2013 1.00    First Release     
+*           06.09.2013 1.10    Move internal macro checking to private header file
+*           19.03.2014 1.20    Removed equates relative to OFS0 settings.
+*           21.07.2017 1.80    Update the 'Copyright' year           
+*           15.03.2025 4.51    Updated disclaimer
+***********************************************************************************************************************/
+#ifndef IWDT_RX_CONFIG_H
+#define IWDT_RX_CONFIG_H
+
+/***********************************************************************************************************************
+Configuration Options
+***********************************************************************************************************************/
+
+/* SPECIFY WHETHER TO INCLUDE CODE FOR API PARAMETER CHECKING 
+   Setting to BSP_CFG_PARAM_CHECKING_ENABLE utilizes the system default setting (default)
+   Setting to 1 includes parameter checking; 0 compiles out parameter checking */
+#define IWDT_CFG_PARAM_CHECKING_ENABLE   (BSP_CFG_PARAM_CHECKING_ENABLE)
+
+
+/* NOTE:
+ * To have the IWDT start automatically at powerup instead of using an Open() call,
+ * change the BSP_CFG_OFS0_REG_VALUE mask to the desired settings in r_bsp_config.h.
+ */
+
+
+#endif /* IWDT_RX_CONFIG_H */


### PR DESCRIPTION
- Add bsp_locking file for RX HAL
- Add IWDT HAL support for Renesas RX with r_iwdt_rx on RDP (based on v1.37)