### PR TITLE
hal: renesas: rx: Add ADC support on Renesas RX

### DIFF
--- a/drivers/rx/CMakeLists.txt
+++ b/drivers/rx/CMakeLists.txt
@@ -103,3 +103,15 @@ if(CONFIG_USE_RX_RDP_I2C)
 		rdp/src/r_riic_rx/src/targets/${CONFIG_SOC_SERIES}/r_riic_${CONFIG_SOC_SERIES}.c
 	)
 endif()
+
+if(CONFIG_USE_RX_RDP_ADC)
+	zephyr_include_directories(
+		rdp/src/r_s12ad_rx
+		rdp/src/r_s12ad_rx/src
+		rdp/src/r_s12ad_rx/src/targets/${CONFIG_SOC_SERIES}
+	)
+	zephyr_library_sources(
+		rdp/src/r_s12ad_rx/src/r_s12ad_rx.c
+		rdp/src/r_s12ad_rx/src/targets/${CONFIG_SOC_SERIES}/r_s12ad_${CONFIG_SOC_SERIES}.c
+	)
+endif()

--- a/drivers/rx/rdp/src/r_s12ad_rx/r_s12ad_rx_if.h
+++ b/drivers/rx/rdp/src/r_s12ad_rx/r_s12ad_rx_if.h
@@ -1,0 +1,326 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/**********************************************************************************************************************
+* File Name    : r_s12ad_rx_if.h
+* Description  : 12-bit A/D Converter driver interface file.
+***********************************************************************************************************************
+* History : DD.MM.YYYY Version Description
+*           22.07.2013 1.00    Initial Release.
+*           21.04.2014 1.20    Updated for RX210 advanced features; RX110/63x support.
+*           05.06.2014 1.30    Fixed channel mask bug in adc_enable_chans()
+*           06.11.2014 1.40    Added RX113 support.
+*           25.03.2015 2.00    Merged in r_s12ad_rx64m and added support for rx71m.
+*           25.03.2015 2.10    Added rx231 support and updated the minor version information
+*           01.03.2016 2.11    Added RX130 and RX230 support.
+*           01.10.2016 2.20    Added RX65x support.
+*           03.04.2017 2.30    Added RX65N-2MB and RX130-512KB support.
+*           03.09.2018 3.00    Added RX66T support.
+*           03.12.2018 3.01    Changed Minor version to '01' for update of xml file.
+*           28.12.2018 3.10    Added RX72T support.
+*           05.04.2019 4.00    Changed Major/Minor version to 4.00 for update below.
+*                              - Added support of GNUC and ICCRX.
+*                              - End of Update for RX210, RX631, and RX63N.
+*                              Deleted include of RX210, RX631, and RX63N.
+*                              Modified include pass of RX65N.
+*           06.28.2019 4.10    Added RX23W support.
+*           07.31.2019 4.20    Added RX72M support.
+*           08.30.2019 4.30    Added RX13T support.
+*           22.11.2019 4.40    Added RX66N and RX72N support.
+*           31.01.2020 4.41    Added support for RX13T with IAR Compiler.
+*           28.02.2020 4.50    Added RX23E-A support.
+*           10.06.2020 4.60    Added RX23T and RX24T and RX24U support.
+*           30.11.2020 4.61    Changed minor version for e2studio 2020-10 support.
+*           01.03.2021 4.70    Added RX72M 144pins and 100pins support.
+*                              Added RX23W 83pins support.
+*           31.05.2021 4.80    Added RX671 support.
+*           30.07.2021 4.90    Added RX140 support.
+*           01.11.2021 4.91    Fixed MDF file.
+*           19.11.2021 4.92    Added RX140 80pins support.
+*           30.11.2021 4.93    Added RX66T 48pins support.
+*           29.12.2021 5.00    Added RX660 support.
+*           01.08.2022 5.10    Added RX26T support.
+*           14.10.2022 5.20    Added RX23E-B support.
+*           03.04.2023 5.30    Added RX26T 48k support.
+*           13.02.2024 5.40    Added RX260 and RX261 support.
+*           20.03.2025 5.41    Changed the disclaimer in program sources.
+***********************************************************************************************************************/
+
+#ifndef S12AD_PRV_IF_H
+#define S12AD_PRV_IF_H
+
+/******************************************************************************
+Includes   <System Includes> , "Project Includes"
+*******************************************************************************/
+#include "platform.h"
+
+/* MCU SPECIFIC USER INTERFACE FILES */
+
+#if defined(BSP_MCU_RX110)
+#include "./src/targets/rx110/r_s12ad_rx110_if.h"
+#elif defined(BSP_MCU_RX111)
+#include "./src/targets/rx111/r_s12ad_rx111_if.h"
+#elif defined(BSP_MCU_RX113)
+#include "./src/targets/rx113/r_s12ad_rx113_if.h"
+#elif defined(BSP_MCU_RX130)
+#include "./src/targets/rx130/r_s12ad_rx130_if.h"
+#elif defined(BSP_MCU_RX13T)
+#include "./src/targets/rx13T/r_s12ad_rx13t_if.h"
+#elif defined(BSP_MCU_RX140)
+#include "./src/targets/rx140/r_s12ad_rx140_if.h"
+#elif defined(BSP_MCU_RX230)
+#include "./src/targets/rx230/r_s12ad_rx230_if.h"
+#elif defined(BSP_MCU_RX231)
+#include "./src/targets/rx231/r_s12ad_rx231_if.h"
+#elif defined(BSP_MCU_RX23E_A)
+#include "./src/targets/rx23e-a/r_s12ad_rx23e-a_if.h"
+#elif defined(BSP_MCU_RX23E_B)
+#include "./src/targets/rx23e-b/r_s12ad_rx23e-b_if.h"
+#elif defined(BSP_MCU_RX23W)
+#include "./src/targets/rx23w/r_s12ad_rx23w_if.h"
+#elif defined(BSP_MCU_RX64M)
+#include "./src/targets/rx64m/r_s12ad_rx64m_if.h"
+#elif defined(BSP_MCU_RX65_ALL)
+#include "./src/targets/rx65n/r_s12ad_rx65n_if.h"
+#elif defined(BSP_MCU_RX660)
+#include "./src/targets/rx660/r_s12ad_rx660_if.h"
+#elif defined(BSP_MCU_RX66N)
+#include "./src/targets/rx66n/r_s12ad_rx66n_if.h"
+#elif defined(BSP_MCU_RX66T)
+#include "./src/targets/rx66t/r_s12ad_rx66t_if.h"
+#elif defined(BSP_MCU_RX671)
+#include "./src/targets/rx671/r_s12ad_rx671_if.h"
+#elif defined(BSP_MCU_RX71M)
+#include "./src/targets/rx71m/r_s12ad_rx71m_if.h"
+#elif defined(BSP_MCU_RX72T)
+#include "./src/targets/rx72t/r_s12ad_rx72t_if.h"
+#elif defined(BSP_MCU_RX72M)
+#include "./src/targets/rx72m/r_s12ad_rx72m_if.h"
+#elif defined(BSP_MCU_RX72N)
+#include "./src/targets/rx72n/r_s12ad_rx72n_if.h"
+#elif defined(BSP_MCU_RX23T)
+#include "./src/targets/rx23t/r_s12ad_rx23t_if.h"
+#elif defined(BSP_MCU_RX24T)
+#include "./src/targets/rx24t/r_s12ad_rx24t_if.h"
+#elif defined(BSP_MCU_RX24U)
+#include "./src/targets/rx24u/r_s12ad_rx24u_if.h"
+#elif defined(BSP_MCU_RX26T)
+#include "./src/targets/rx26t/r_s12ad_rx26t_if.h"
+#elif defined(BSP_MCU_RX260)
+#include "./src/targets/rx260/r_s12ad_rx260_if.h"
+#elif defined(BSP_MCU_RX261)
+#include "./src/targets/rx261/r_s12ad_rx261_if.h"
+#endif
+
+/******************************************************************************
+Macro definitions
+*******************************************************************************/
+/* Version Number of API. */
+#define ADC_VERSION_MAJOR       (5)
+#define ADC_VERSION_MINOR       (41)
+
+/*****************************************************************************
+Typedef definitions
+******************************************************************************/
+
+typedef enum e_adc_err      // ADC API error codes
+{
+    ADC_SUCCESS = 0,
+    ADC_ERR_AD_LOCKED,          // Open() call is in progress elsewhere
+    ADC_ERR_AD_NOT_CLOSED,      // peripheral still running in another mode
+    ADC_ERR_MISSING_PTR,        // missing required pointer argument
+    ADC_ERR_INVALID_ARG,        // argument is not valid for parameter
+    ADC_ERR_ILLEGAL_ARG,        // argument is illegal for mode
+    ADC_ERR_SCAN_NOT_DONE,      // default, Group A, or Group B scan not done
+    ADC_ERR_TRIG_ENABLED,       // scan running, cannot configure comparator
+    ADC_ERR_CONDITION_NOT_MET,  // no chans/sensors passed comparator condition
+    ADC_ERR_CONFIGURABLE_INT,   // vector number of software configurable interrupt B is out of range
+    ADC_ERR_UNKNOWN             // unknown hardware error
+} adc_err_t;
+
+
+/* CALLBACK FUNCTION ARGUMENT DEFINITIONS */
+
+typedef enum e_adc_cb_evt           // callback function events
+{
+    ADC_EVT_SCAN_COMPLETE,          // normal/Group A scan complete
+    ADC_EVT_SCAN_COMPLETE_GROUPB,   // Group B scan complete
+#if (defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) || defined(BSP_MCU_RX72T) \
+    || defined(BSP_MCU_RX72M)  || defined(BSP_MCU_RX13T) || defined(BSP_MCU_RX66N) \
+    || defined(BSP_MCU_RX72N)  || defined(BSP_MCU_RX24T) || defined(BSP_MCU_RX24U) \
+    || defined(BSP_MCU_RX671)  || defined(BSP_MCU_RX660) || defined(BSP_MCU_RX26T))
+    ADC_EVT_SCAN_COMPLETE_GROUPC,   // Group C scan complete
+#endif    
+#if (defined(BSP_MCU_RX64M) || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72T) || defined(BSP_MCU_RX72M) \
+    || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N) || defined(BSP_MCU_RX671) \
+    || defined(BSP_MCU_RX660) || defined(BSP_MCU_RX26T))
+    ADC_EVT_CONDITION_MET,          // chans/sensors met comparator condition
+#endif
+#if (defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) || defined(BSP_MCU_RX72T) \
+    || defined(BSP_MCU_RX72M)  || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N) \
+    || defined(BSP_MCU_RX671)  || defined(BSP_MCU_RX660) || defined(BSP_MCU_RX26T))
+    ADC_EVT_CONDITION_METB          // chans/sensors met comparator condition
+#endif
+} adc_cb_evt_t;
+
+typedef struct st_adc_cb_args       // callback arguments
+{
+    adc_cb_evt_t   event;
+#if (defined(BSP_MCU_RX64M) || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72T) || defined(BSP_MCU_RX72M) \
+    || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N) || defined(BSP_MCU_RX671) \
+    || defined(BSP_MCU_RX660) || defined(BSP_MCU_RX26T))
+    uint32_t       compare_flags;   // valid only for compare event in Window A
+#endif
+#if (defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) || defined(BSP_MCU_RX72T) \
+    || defined(BSP_MCU_RX72M)  || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N) \
+    || defined(BSP_MCU_RX671)  || defined(BSP_MCU_RX660) || defined(BSP_MCU_RX26T))
+    uint32_t       compare_flagsb;  // valid only for compare event in Window B
+#endif
+#if (defined(BSP_MCU_RX64M) || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72T) || defined(BSP_MCU_RX72M) \
+    || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N) || defined(BSP_MCU_RX24T) \
+    || defined(BSP_MCU_RX24U) || defined(BSP_MCU_RX671) || defined(BSP_MCU_RX26T))
+    uint8_t        unit;
+#endif
+} adc_cb_args_t;
+
+
+/*****************************************************************************
+Public Functions
+******************************************************************************/
+/******************************************************************************
+* Function Name: R_ADC_Open
+* Description  : This function applies power to the A/D peripheral, sets the
+*                operational mode, trigger sources, interrupt priority, and
+*                configurations common to all channels and sensors. If interrupt
+*                priority is non-zero, the function takes a callback function
+*                pointer for notifying the user at interrupt level whenever a
+*                scan has completed.
+*
+* Arguments    : unit -
+*                    Unit number
+*                mode-
+*                    Operational mode (see enumeration below)
+*                p_cfg-
+*                    Pointer to configuration structure (see below)
+*                p_callback-
+*                    Optional pointer to function called from interrupt when
+*                    a scan completes
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*                ADC_ERR_AD_LOCKED-
+*                    Open() call is in progress elsewhere
+*                ADC_ERR_AD_NOT_CLOSED-
+*                    Peripheral is still running in another mode; Perform
+*                    R_ADC_Close() first
+*                ADC_ERR_INVALID_ARG-
+*                    mode or element of p_cfg structure has invalid value.
+*                ADC_ERR_ILLEGAL_ARG-
+*                    an argument is illegal based upon mode
+*                ADC_ERR_MISSING_PTR-
+*                    p_cfg pointer is FIT_NO_PTR/NULL
+*******************************************************************************/
+adc_err_t R_ADC_Open(uint8_t const      unit,
+                    adc_mode_t const   mode,
+                    adc_cfg_t * const  p_cfg,
+                    void               (* const p_callback)(void *p_args));
+
+/******************************************************************************
+* Function Name: R_ADC_Control
+* Description  : This function provides commands for enabling channels and
+*                sensors and for runtime operations. These include enabling/
+*                disabling trigger sources and interrupts, initiating a
+*                software trigger, and checking for scan completion.
+*
+* NOTE: Enabling a channel or a sensor, or setting the sample state count reg
+*       cannot be done while the ADCSR.ADST bit is set (conversion in progress).
+*       Because these commands should only be called once during initialization
+*       before triggers are enabled, this should not be an issue. Registers
+*       with this restriction include ADANSA, ADANSB, ADADS, ADADC, ADSSTR,
+*       ADEXICR, and some bits in ADCSR and TSCR.
+*       No runtime operational sequence checking of any kind is performed.
+*
+* Arguments    : unit -
+*                    Unit number
+*                cmd-
+*                    Command to run
+*                p_args-
+*                    Pointer to optional configuration structure
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*                ADC_ERR_MISSING_PTR-
+*                    p_args pointer is FIT_NO_PTR/NULL when required as an argument
+*                ADC_ERR_INVALID_ARG-
+*                    cmd or element of p_args structure has invalid value.
+*                ADC_ERR_ILLEGAL_CMD-
+*                    cmd is illegal based upon mode
+*                ADC_ERR_SCAN_NOT_DONE-
+*                    The requested scan has not completed
+*                ADC_ERR_UNKNOWN
+*                    Did not receive expected hardware response
+*******************************************************************************/
+adc_err_t R_ADC_Control(uint8_t const   unit,
+                        adc_cmd_t const cmd,
+                        void * const    p_args);
+
+/******************************************************************************
+* Function Name: R_ADC_Read
+* Description  : This function reads conversion results from a single channel,
+*                sensor, or the double trigger register.
+* Arguments    : unit -
+*                    Unit number
+*                reg_id-
+*                    Id for the register to read (see enum below)
+*                p_data-
+*                    Pointer to variable to load value into.
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*                ADC_ERR_INVALID_ARG-
+*                    reg_id contains an invalid value.
+*                ADC_ERR_MISSING _PTR-
+*                    p_data is FIT_NO_PTR/NULL
+*******************************************************************************/
+adc_err_t R_ADC_Read(uint8_t const      unit,
+                    adc_reg_t const    reg_id,
+                    uint16_t * const   p_data);
+
+
+/******************************************************************************
+* Function Name: R_ADC_ReadAll
+* Description  : This function reads conversion results from all potential
+*                sources, enabled or not.
+* Arguments    : p_all_data-
+*                    Pointer to structure to load register values into.
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*                ADC_ERR_MISSING _PTR-
+*                    p_data is FIT_NO_PTR/NULL
+*******************************************************************************/
+adc_err_t R_ADC_ReadAll(adc_data_t * const  p_all_data);
+
+/******************************************************************************
+* Function Name: R_ADC_Close
+* Description  : This function ends any scan in progress, disables interrupts,
+*                and removes power to the A/D peripheral.
+* Arguments    : unit - Unit number
+* Return Value : ADC_SUCCESS - Successful
+*                ADC_ERR_INVALID_ARG - unit contains an invalid value.
+*******************************************************************************/
+adc_err_t R_ADC_Close(uint8_t const unit);
+
+/*****************************************************************************
+* Function Name: R_ADC_GetVersion
+* Description  : Returns the version of this module. The version number is
+*                encoded such that the top two bytes are the major version
+*                number and the bottom two bytes are the minor version number.
+* Arguments    : none
+* Return Value : version number
+******************************************************************************/
+uint32_t  R_ADC_GetVersion(void);
+
+                                    
+#endif /* S12AD_PRV_IF_H */

--- a/drivers/rx/rdp/src/r_s12ad_rx/src/r_s12ad_rx.c
+++ b/drivers/rx/rdp/src/r_s12ad_rx/src/r_s12ad_rx.c
@@ -1,0 +1,539 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_s12ad_rx.c
+* Description  : Primary source code for 12-bit A/D Converter driver.
+***********************************************************************************************************************/
+/**********************************************************************************************************************
+* History : DD.MM.YYYY Version Description
+*           22.07.2013 1.00    Initial Release.
+*           21.04.2014 1.20    Updated for RX210 advanced features; RX110/63x support.
+*           06.11.2014 1.40    Added RX113 support.
+*           01.03.2016 2.11    Added RX130 and RX230 support.
+*           01.10.2016 2.20    Added RX65x support.
+*                              Corresponding to the notice for A/D convert stop.(RX110/RX111/RX113/RX210/RX63x)
+*                              Corresponding to the notice for shift to Low power mode.(RX110/RX111/RX113/RX210/RX63x)
+*                              Delete parameter check by the enum value.
+*                              R_ADC_ReadAll() parameter change.(adjust the parameter structure to RX130/RX230/RX231)
+*                              Bug fix for callback function execute when pointer is NULL.(RX130/RX230/RX231)
+*                              TEMPS register can change only during temperature sensor mode.(RX63x/RX210)
+*           03.09.2018 3.00    Added RX66T support.
+*                              Added the comment to while statement.
+*           28.12.2018 3.10    Added RX72T support.
+*           05.04.2019 4.00    Added support for GNUC and ICCRX.
+*                              Deleted the process of RX210, RX631, and RX63N.
+*                              Deleted the function of adc_gbadi_isr.
+*           28.06.2019 4.10    Added RX23W support.
+*           31.07.2019 4.20    Added RX72M support.
+*           30.08.2019 4.30    Added RX13T support.
+*           22.11.2019 4.40    Added RX66N and RX72N support.
+*                              Added support for atomic control.
+*           28.02.2020 4.50    Added RX23E-A support.
+*                              Added the following processing to fix the bug.
+*                              - Added the process of read the A/D Data Duplication Register (ADDBLDR) to the 
+*                                R_ADC_ReadAll function.
+*                              - Added the interrupt function of A/D scan end interrupt for Group B.
+*           10.06.2020 4.60    Added RX23T and RX24T and RX24U support.
+*           01.09.2020 4.80    Added RX671 support.
+*           30.07.2021 4.90    Added RX140 support.
+*           29.12.2021 5.00    Added RX660 support.
+*           01.08.2022 5.10    Added RX26T support.
+*           14.10.2022 5.20    Added RX23E-B support.
+*           03.04.2023 5.30    Added RX26T 48k support.
+*           13.02.2024 5.40    Added RX260 and RX261 support.
+*           20.03.2025 5.41    Changed the disclaimer in program sources.
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Includes   <System Includes> , "Project Includes"
+***********************************************************************************************************************/
+/* Includes board and MCU related header files. */
+#include "platform.h"
+/* Configuration for this package. */
+#include "r_s12ad_rx_config.h"
+/* Public interface header file for this package. */
+#include "r_s12ad_rx_if.h"
+/* Private header file for this package. */
+#include "r_s12ad_rx_private.h"
+
+/***********************************************************************************************************************
+Macro definitions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Typedef definitions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Private global variables and functions
+***********************************************************************************************************************/
+#if (defined(BSP_MCU_RX64M)   || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72T)    || defined(BSP_MCU_RX72M) \
+    || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N)    || defined(BSP_MCU_RX24T) \
+    || defined(BSP_MCU_RX24U) || defined(BSP_MCU_RX671)    || defined(BSP_MCU_RX26T))
+
+/* In ROM */
+extern R_BSP_VOLATILE_EVENACCESS uint16_t * const  gp_dreg0_ptrs[];
+extern R_BSP_VOLATILE_EVENACCESS uint16_t * const  gp_dreg1_ptrs[];
+#if (defined(BSP_MCU_RX66T)   || defined(BSP_MCU_RX72T) || defined(BSP_MCU_RX24T) \
+    || defined(BSP_MCU_RX24U) || defined(BSP_MCU_RX26T))
+extern R_BSP_VOLATILE_EVENACCESS uint16_t * const  gp_dreg2_ptrs[];
+#endif
+
+#elif defined(BSP_MCU_RX660)
+
+extern R_BSP_VOLATILE_EVENACCESS uint16_t * const  gp_dreg_ptrs[];
+
+#else  /* rx110/rx111/rx113/rx130/rx13t/rx140/rx230/rx231/rx23w/rx23e-a/rx23e-b/rx23t/rx260/rx261 */
+
+extern R_BSP_VOLATILE_EVENACCESS uint16_t * const  gp_dreg_ptrs[]; // In ROM
+adc_ctrl_t g_dcb = { ADC_MODE_MAX, false, NULL};  // In RAM
+
+#endif /* #if (defined(BSP_MCU_RX64M) || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72T)    || defined(BSP_MCU_RX72M) \
+    || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N)    || defined(BSP_MCU_RX24T) \
+    || defined(BSP_MCU_RX24U) || defined(BSP_MCU_RX671)    || defined(BSP_MCU_RX26T)) */
+
+#if (!defined(BSP_MCU_RX64M) && !defined(BSP_MCU_RX65_ALL) && !defined(BSP_MCU_RX66T) \
+    && !defined(BSP_MCU_RX71M) && !defined(BSP_MCU_RX72T) && !defined(BSP_MCU_RX72M) \
+    && !defined(BSP_MCU_RX13T) && !defined(BSP_MCU_RX66N) && !defined(BSP_MCU_RX72N) \
+    && !defined(BSP_MCU_RX23T) && !defined(BSP_MCU_RX24T) && !defined(BSP_MCU_RX24U) \
+    && !defined(BSP_MCU_RX671) && !defined(BSP_MCU_RX660) && !defined(BSP_MCU_RX26T))
+R_BSP_PRAGMA_STATIC_INTERRUPT(adc_s12adi0_isr, VECT(S12AD,S12ADI0))
+R_BSP_PRAGMA_STATIC_INTERRUPT(adc_gbadi_isr, VECT(S12AD,GBADI))
+
+#endif
+
+/**********************************************************************************************************************
+ * Function Name: R_ADC_Open
+ ******************************************************************************************************************//**
+ * @brief This function initializes the 12-bit A/D converter. This function must be run before calling any other API
+ * function.
+ * @param[in] unit Unit number. Set this to 0 if your MCU supports only one unit.
+ * @param[in] mode Operating mode.
+ * @param[in] p_cfg Pointer to the configuration structure of the 12-bit A/D converter function.
+ * @param[in] p_callback Optional pointer to function called from interrupt when a scan completes or a comparator
+ * condition is met. When not using this parameter, set FIT_NO_PTR.
+ * @retval ADC_SUCCESS Successful
+ * @retval ADC_ERR_AD_LOCKED Open() call is in progress elsewhere
+ * @retval ADC_ERR_AD_NOT_CLOSED Peripheral is still running in another mode; Perform R_ADC_Close() first
+ * @retval ADC_ERR_INVALID_ARG Element of p_cfg structure has invalid value
+ * @retval ADC_ERR_ILLEGAL_ARG an argument is illegal based upon mode
+ * @retval ADC_ERR_MISSING_PTR p_cfg pointer is FIT_NO_PTR/NULL
+ * @retval ADC_ERR_CONFIGURABLE_INT vector number of software configurable interrupt B is out of range
+ * @details Applies power to the A/D peripheral, sets the operational mode, trigger sources, interrupt priority, and
+ * configurations common to all channels and sensors. With a non-zero interrupt priority (interrupt usage), a callback
+ * function is called by the interrupts whenever a scan has completed or a comparator condition is met. When setting
+ * the interrupt priority to 0, a callback function is not called. In this case, poll for scan completion with the
+ * R_ADC_Control() function when necessary. To set values of parameters used in this function, first clear all members
+ * of parameters to 0, and then set values.
+ * @note (RX Family Common):\n
+ * Before calling the R_ADC_Open() function, set the vector number for the software configurable interrupt B
+ * assigned to the unit to be used.
+ * Refer to the User's Manual: Hardware about limitations of using output pins on the same port as analog pins.\n
+ * The application must set the A/D conversion clock prior to calling R_ADC_Open() function.\n
+ * To stop A/D conversion which is started in continuous scan mode, call the R_ADC_Close function.\n
+ * If continuous scan mode is selected, it is recommended not to use the S12ADI interrupt since scan completion occurs
+ * continuously. That causes the majority of the processing time to be spent at the interrupt level.\n
+ * If interrupts are in use, a callback function is required which takes a single argument. This is a pointer to a
+ * which is cast to a void pointer (provides consistency with other FIT module callback functions). Cast to the
+ * structure adc_cb_args_t pointer in the interrupt handling.\n\n
+ * (S12ADb, A12ADC, S12ADE, S12ADF, S12ADFa, S12ADH):\n
+ *    After the R_ADC_Open() function is executed, wait at least 1 us before executing A/D conversion.
+ */
+adc_err_t R_ADC_Open( uint8_t const          unit,
+                    adc_mode_t const        mode,
+                    adc_cfg_t * const       p_cfg,
+                    void         (* const  p_callback)(void *p_args))
+{
+    return adc_open(unit, mode, p_cfg, p_callback);
+} /* End of function R_ADC_Open() */
+
+
+/**********************************************************************************************************************
+ * Function Name: R_ADC_Control
+ ******************************************************************************************************************//**
+ * @brief This function makes 12-bit A/D converter function settings and acquires the interrupt control and A/D
+ * converter start/stop state.
+ * @param[in] unit Unit number. Set this to 0 if your MCU supports only one unit.
+ * @param[in] cmd Command to run.
+ * @param[in] p_args Pointer to optional configuration structure. Clear all members of the argument to 0 before setting
+ * values to them. If the command requires no argument, set FIT_NO_PTR.
+ * @retval ADC_SUCCESS Successful
+ * @retval ADC_ERR_MISSING_PTR p_args pointer is FIT_NO_PTR/NULL when required as an argument
+ * @retval ADC_ERR_INVALID_ARG Invalid value is specified to p_args structure
+ * @retval ADC_ERR_ILLEGAL_ARG cmd is illegal based upon mode
+ * @retval ADC_ERR_SCAN_NOT_DONE The requested scan has not completed
+ * @retval ADC_ERR_TRIG_ENABLED Cannot configure comparator because scan still running
+ * @retval ADC_ERR_CONDITION_NOT_MET No channels/sensors met the comparison condition
+ * @details Provides commands for enabling channels and sensors and for runtime operations. These include
+ * enabling/disabling trigger sources and interrupts, initiating a software trigger, and checking for scan completion.
+ * After the R_ADC_Open function is called, the commands can be issued by using the R_ADC_Control function.
+ * See Section 3.2 in the application note for details.
+ * @note (RX Family Common) \n
+ * When the A/D conversion start (ADST) bit is 1, settings such as mode must not be changed
+ * using this function. However, the conversion status or the comparison result can be obtained.\n
+ * When switching channels used for A/D conversion or settings, call the R_ADC_Close() function once and then call the
+ * R_ADC_Open() function again to start.\n
+ * When waiting completion of A/D conversion using the R_ADC_Control function, use the commands.See Section
+ * 3.2 in the application note for details.\n
+ * When A/D conversion interrupts are enabled, the R_ADC_Control() function cannot be used to wait completion of
+ * A/D conversion except when using single scan mode with software trigger. In this case, use the callback function for
+ * the A/D conversion interrupt to wait completion of A/D conversion.\n\n
+ * (S12ADF)\n
+ * If Group A Priority is selected such that Group B operates in continuous scan mode, it is recommended not
+ * to use the GBADI interrupt since the interrupt handling will be processed so often. That causes the majority of
+ * the processing time to be spent at the interrupt level.\n\n
+ * (S12ADC, S12ADFa)\n
+ * Channels and sensors can be combined in the same unit.\n
+ * ELC is only for S12ADI, not S12GBADI or S12CMPI. (S12ADC)\n
+ * ELC is only for S12ADI, not GBADI, GCADI, S12CMPAI or S12CMPBI. (S12ADFa)\n
+ * The application should wait 30 us after configuring the scan before enabling the trigger for Temperature Sensor
+ * for best results.\n
+ * If Group A Priority is selected such that Group B operates in continuous scan mode, it is recommended not to
+ * use the S12GBADI interrupt (S12ADC) and GBADI interrupt (S12ADFa) since the interrupt handling will be processed
+ * so often. That causes the majority of the processing time to be spent at the interrupt level.\n
+ * Enabling the comparator should be done prior to enabling the triggers. Some features may not be used with others.
+ * See Section 3.2 in the application note for details.\n\n
+ * (S12ADE)\n
+ * This function does not support following features.\n
+ * Compare function window B\n
+ * Compare function window A/B composite condition setting\n\n
+ * (S12ADC, S12ADE, S12ADFa)\n
+ * When using the comparison, configure the comparison after the channel configuration.\n\n
+ * (S12ADb, S12ADFa, A12ADH)\n
+ * For temperature sensor output and internal reference voltage, the number of
+ * sampling states must be set as indicated below, at a minimum:\n
+ * S12ADb, S12ADFa: 5 us\n
+ * S12ADH: 4 us\n
+ */
+adc_err_t R_ADC_Control(uint8_t const       unit,
+                        adc_cmd_t const     cmd,
+                        void * const        p_args)
+{
+    return adc_control(unit, cmd, p_args);
+} /* End of function R_ADC_Control() */
+
+
+/**********************************************************************************************************************
+ * Function Name: R_ADC_Read
+ ******************************************************************************************************************//**
+ * @brief This function reads conversion results from a single channel, sensor, double trigger, or self-diagnosis
+ * register.
+ * @param[in] unit Unit number. Set this to 0 if your MCU supports only one unit.
+ * @param[in] reg_id ID of the register to read.
+ * @param[in] p_data Pointer to variable to load value into.
+ * @retval ADC_SUCCESS Success
+ * @retval ADC_ERR_INVALID_ARG unit or reg_id contains an invalid value
+ * @retval ADC_ERR_MISSING _PTR p_data is FIT_NO_PTR/NULL
+ * @details Reads conversion results from a single channel, sensor, double trigger, or self-diagnosis register.
+ * @note (S12ADb)\n
+ * For temperature sensor output and internal reference voltage, discard the first A/D conversion
+ * result after the open, and use the second and the subsequent A/D conversion results.
+ */
+adc_err_t R_ADC_Read(uint8_t            unit,
+                    adc_reg_t const    reg_id,
+                    uint16_t * const   p_data)
+{
+    dregs_t *p_dregs;
+
+#if (defined(BSP_MCU_RX64M)   || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72T)    || defined(BSP_MCU_RX72M) \
+    || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N)    || defined(BSP_MCU_RX24T) \
+    || defined(BSP_MCU_RX24U) || defined(BSP_MCU_RX671)    || defined(BSP_MCU_RX26T))
+    p_dregs = ADC_PRV_GET_DATA_ARR(unit);
+#else
+    p_dregs = gp_dreg_ptrs;
+#endif /* #if (defined(BSP_MCU_RX64M)   || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72T)    || defined(BSP_MCU_RX72M) \
+    || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N)    || defined(BSP_MCU_RX24T) \
+    || defined(BSP_MCU_RX24U) || defined(BSP_MCU_RX671)    || defined(BSP_MCU_RX26T)) */
+
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+    #if (defined(BSP_MCU_RX64M) || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72M) \
+        || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N)  || defined(BSP_MCU_RX671))
+    if (unit > 1)
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+    #elif (defined(BSP_MCU_RX66T) || defined(BSP_MCU_RX72T) || defined(BSP_MCU_RX24T) \
+        || defined(BSP_MCU_RX24U) || defined(BSP_MCU_RX26T))
+    if (unit > 2)
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+    #endif
+
+    /* Casting is valid because it matches the type to the right side or argument. */
+    if ((NULL == p_data) || (FIT_NO_PTR == p_data))
+    {
+        return ADC_ERR_MISSING_PTR;
+    }
+
+    if (NULL == p_dregs[reg_id])
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+
+    /* Do not check if corresponding channel/sensor is enabled */
+#endif
+
+    *p_data = *p_dregs[reg_id];
+
+    return ADC_SUCCESS;
+} /* End of function R_ADC_Read() */
+
+/**********************************************************************************************************************
+ * Function Name: R_ADC_ReadAll
+ ******************************************************************************************************************//**
+ * @brief This function reads conversion results from all storage registers supported by the MCU.
+ * @param[in] p_all_data Pointer to structure in which register values are loaded.
+ * @retval ADC_SUCCESS Success
+ * @retval ADC_ERR_MISSING_PTR p_data is FIT_NO_PTR/NULL
+ * @details Reads conversion results from all potential sources, enabled or not.
+ * @note None.
+ */
+adc_err_t R_ADC_ReadAll(adc_data_t * const  p_all_data)
+{
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+    /* Casting is valid because it matches the type to the right side or argument. */
+    if ((NULL == p_all_data) || (FIT_NO_PTR == p_all_data))
+    {
+        return ADC_ERR_MISSING_PTR;
+    }
+#endif
+
+#if (defined(BSP_MCU_RX64M)   || defined(BSP_MCU_RX65_ALL)|| defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72M)   || defined(BSP_MCU_RX72T) \
+    || defined(BSP_MCU_RX231) || defined(BSP_MCU_RX230)   || defined(BSP_MCU_RX23W) \
+    || defined(BSP_MCU_RX130) || defined(BSP_MCU_RX13T)   || defined(BSP_MCU_RX66N) \
+    || defined(BSP_MCU_RX72N) || defined(BSP_MCU_RX23E_A) || defined(BSP_MCU_RX23E_B) \
+    || defined(BSP_MCU_RX23T) || defined(BSP_MCU_RX24T)   || defined(BSP_MCU_RX24U) \
+    || defined(BSP_MCU_RX671) || defined(BSP_MCU_RX140)   || defined(BSP_MCU_RX660) \
+    || defined(BSP_MCU_RX26T) || defined(BSP_MCU_RX260)   || defined(BSP_MCU_RX261))
+    
+    return adc_read_all(p_all_data);
+
+#else /* rx110/rx111/rx113 */
+
+    p_all_data->chan[ADC_REG_CH0] = S12AD.ADDR0;
+    p_all_data->chan[ADC_REG_CH1] = S12AD.ADDR1;
+    p_all_data->chan[ADC_REG_CH2] = S12AD.ADDR2;
+    p_all_data->chan[ADC_REG_CH3] = S12AD.ADDR3;
+    p_all_data->chan[ADC_REG_CH4] = S12AD.ADDR4;
+    p_all_data->chan[ADC_REG_CH6] = S12AD.ADDR6;
+    p_all_data->chan[ADC_REG_CH8] = S12AD.ADDR8;
+    p_all_data->chan[ADC_REG_CH9] = S12AD.ADDR9;
+    p_all_data->chan[ADC_REG_CH10] = S12AD.ADDR10;
+    p_all_data->chan[ADC_REG_CH11] = S12AD.ADDR11;
+    p_all_data->chan[ADC_REG_CH12] = S12AD.ADDR12;
+    p_all_data->chan[ADC_REG_CH13] = S12AD.ADDR13;
+    p_all_data->chan[ADC_REG_CH14] = S12AD.ADDR14;
+    p_all_data->chan[ADC_REG_CH15] = S12AD.ADDR15;
+
+#if (!defined(BSP_MCU_RX110) && !defined(BSP_MCU_RX111))
+    p_all_data->chan[ADC_REG_CH5] = S12AD.ADDR5;
+    p_all_data->chan[ADC_REG_CH7] = S12AD.ADDR7;
+#endif
+#ifdef BSP_MCU_RX113
+    p_all_data->chan[ADC_REG_CH21] = S12AD.ADDR21;
+#endif
+    p_all_data->temp = S12AD.ADTSDR;
+    p_all_data->volt = S12AD.ADOCDR;
+    p_all_data->dbltrig = S12AD.ADDBLDR;
+
+    return ADC_SUCCESS;
+
+#endif /* #if (definedBSP_MCU_RX64M || definedBSP_MCU_RX65_ALL || definedBSP_MCU_RX66T \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72M)   || defined(BSP_MCU_RX72T) \
+    || defined(BSP_MCU_RX231) || defined(BSP_MCU_RX230)   || defined(BSP_MCU_RX23W) \
+    || defined(BSP_MCU_RX130) || defined(BSP_MCU_RX13T)   || defined(BSP_MCU_RX66N) \
+    || defined(BSP_MCU_RX72N) || defined(BSP_MCU_RX23E_A) || defined(BSP_MCU_RX23E_B) \
+    || defined(BSP_MCU_RX23T) || defined(BSP_MCU_RX24T)   || defined(BSP_MCU_RX24U) \
+    || defined(BSP_MCU_RX671) || defined(BSP_MCU_RX140)   || defined(BSP_MCU_RX660) \
+    || defined(BSP_MCU_RX26T) || defined(BSP_MCU_RX260)   || defined(BSP_MCU_RX261)) */
+    
+} /* End of function R_ADC_ReadAll() */
+
+/**********************************************************************************************************************
+* Function Name: R_ADC_Close
+ ******************************************************************************************************************//**
+ * @brief This function ends any scan in progress, disables interrupts, and removes power to the A/D peripheral.
+ * @param[in] unit Unit number. Set this to 0 if your MCU supports only one unit.
+ * @retval ADC_SUCCESS Success
+ * @retval ADC_ERR_INVALID_ARG unit contains an invalid value.
+ * @details Ends the A/D conversion in progress, disables interrupts, and ends A/D converter operation. This function
+ * can be called once per unit after the R_ADC_Open function is called.\n
+ * When changing A/D conversion settings, call the R_ADC_Open() function again after this function is called.
+ * @note This function will abort any scan that may be in progress.
+ */
+adc_err_t   R_ADC_Close(uint8_t const unit)
+{
+#if (defined(BSP_MCU_RX64M)   || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72M)    || defined(BSP_MCU_RX72T) \
+    || defined(BSP_MCU_RX231) || defined(BSP_MCU_RX230)    || defined(BSP_MCU_RX23W) \
+    || defined(BSP_MCU_RX130) || defined(BSP_MCU_RX13T)    || defined(BSP_MCU_RX66N) \
+    || defined(BSP_MCU_RX72N) || defined(BSP_MCU_RX23E_A)  || defined(BSP_MCU_RX23E_B) \
+    || defined(BSP_MCU_RX23T) || defined(BSP_MCU_RX24T)    || defined(BSP_MCU_RX24U) \
+    || defined(BSP_MCU_RX671) || defined(BSP_MCU_RX140)    || defined(BSP_MCU_RX660) \
+    || defined(BSP_MCU_RX26T) || defined(BSP_MCU_RX260)    || defined(BSP_MCU_RX261))
+
+    return adc_close(unit);
+
+#else /* rx110/rx111/rx113 */
+    volatile uint16_t i;
+
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    bsp_int_ctrl_t int_ctrl;
+#endif
+
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+    if (unit > 0)
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+#endif
+
+    /* Stop triggers & conversions, and disable peripheral interrupts */
+    R_BSP_InterruptRequestDisable(VECT(S12AD,S12ADI0));         // disable interrupts in ICU
+    IR(S12AD,S12ADI0) = 0;          // clear interrupt flag
+    R_BSP_InterruptRequestDisable(VECT(S12AD,GBADI));           // disable interrupts in ICU
+    IR(S12AD,GBADI) = 0;            // clear interrupt flag
+    S12AD.ADCSR.BIT.TRGE = 0;
+    S12AD.ADCSR.WORD = 0;
+
+    /* Wait for 2 ADCLK cycles (MAX: 128 ICLK cycles) */
+    /* WAIT_LOOP */
+    for (i = 0; i < 128; i++)
+    {
+        R_BSP_NOP();
+    }
+
+    /* Power down peripheral */
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_LPC_CGC_SWR);
+#ifndef BSP_MCU_RX11_ALL             // RX63x
+    if (g_dcb.mode == ADC_MODE_SS_TEMPERATURE)
+    {
+        TEMPS.TSCR.BYTE = 0;
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_DISABLE, &int_ctrl);
+#endif
+        MSTP(TEMPS) = 1;
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_ENABLE, &int_ctrl);
+#endif
+    }
+#endif
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_DISABLE, &int_ctrl);
+#endif
+    MSTP(S12AD) = 1;
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_ENABLE, &int_ctrl);
+#endif
+
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_CGC_SWR);
+
+    /* Show driver as closed */
+    g_dcb.opened = false;
+
+    return ADC_SUCCESS;
+
+#endif /* #if (definedBSP_MCU_RX64M || definedBSP_MCU_RX65_ALL || definedBSP_MCU_RX66T \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72M)    || defined(BSP_MCU_RX72T) \
+    || defined(BSP_MCU_RX231) || defined(BSP_MCU_RX230)    || defined(BSP_MCU_RX23W) \
+    || defined(BSP_MCU_RX130) || defined(BSP_MCU_RX13T)    || defined(BSP_MCU_RX66N) \
+    || defined(BSP_MCU_RX72N) || defined(BSP_MCU_RX23E_A)  || defined(BSP_MCU_RX23E_B) \
+    || defined(BSP_MCU_RX23T) || defined(BSP_MCU_RX24T)    || defined(BSP_MCU_RX24U) \
+    || defined(BSP_MCU_RX671) || defined(BSP_MCU_RX140)    || defined(BSP_MCU_RX660) \
+    || defined(BSP_MCU_RX26T) || defined(BSP_MCU_RX260)    || defined(BSP_MCU_RX261)) */
+} /* End of function R_ADC_Close() */
+
+
+/**********************************************************************************************************************
+* Function Name: R_ADC_GetVersion
+ ******************************************************************************************************************//**
+ * @brief This function returns the driver version number at runtime.
+ * @retval Version number.
+ * @details Returns the version of this module. The version number is encoded such that the top 2 bytes are the major
+ * version number and the bottom 2 bytes are the minor version number.
+ * @note None.
+ */
+uint32_t  R_ADC_GetVersion(void)
+{
+    uint32_t const version = (ADC_VERSION_MAJOR << 16) | ADC_VERSION_MINOR;
+
+    return version;
+} /* End of function R_ADC_GetVersion() */
+
+
+#if (!defined(BSP_MCU_RX64M) && !defined(BSP_MCU_RX65_ALL) && !defined(BSP_MCU_RX66T) \
+    && !defined(BSP_MCU_RX71M) && !defined(BSP_MCU_RX72T) && !defined(BSP_MCU_RX72M) \
+    && !defined(BSP_MCU_RX13T) && !defined(BSP_MCU_RX66N) && !defined(BSP_MCU_RX72N) \
+    && !defined(BSP_MCU_RX23T) && !defined(BSP_MCU_RX24T) && !defined(BSP_MCU_RX24U) \
+    && !defined(BSP_MCU_RX671) && !defined(BSP_MCU_RX660) && !defined(BSP_MCU_RX26T))
+
+/******************************************************************************
+* Function Name: adc_enable_s12adi0
+* Description  : This function clears the S12ADI0 interrupt flag and enables
+*                interrupts in the peripheral (for IR flag usage). If priority
+*                is not 0, interrupts are enabled in the ICU.
+*                NOTE: This has nothing to do with enabling triggers.
+* Arguments    : none
+* Return Value : none
+*******************************************************************************/
+void adc_enable_s12adi0(void)
+{
+
+    IR(S12AD,S12ADI0) = 0;                  // clear flag
+    S12AD.ADCSR.BIT.ADIE = 1;               // enable in peripheral
+    if (0 != ICU.IPR[IPR_S12AD_S12ADI0].BYTE)
+    {
+        R_BSP_InterruptRequestEnable(VECT(S12AD,S12ADI0));             // enable in ICU
+    }
+} /* End of function adc_enable_s12adi0() */
+
+
+/*****************************************************************************
+* Function Name: adc_s12adi0_isr
+* Description  : Interrupt handler for normal/Group A/double trigger
+*                scan complete.
+* Arguments    : none
+* Return Value : none
+******************************************************************************/
+R_BSP_ATTRIB_STATIC_INTERRUPT void adc_s12adi0_isr(void)
+{
+    adc_cb_evt_t    event = ADC_EVT_SCAN_COMPLETE;
+
+    /* presence of callback function verified in Open() */
+    if ((NULL != g_dcb.p_callback) && (FIT_NO_FUNC != g_dcb.p_callback))
+    {
+        g_dcb.p_callback(&event);
+    }
+} /* End of function adc_s12adi0_isr() */
+
+/*****************************************************************************
+* Function Name: adc_gbadi_isr
+* Description  : Interrupt handler for Group B scan complete.
+* Arguments    : none
+* Return Value : none
+******************************************************************************/
+R_BSP_ATTRIB_STATIC_INTERRUPT void adc_gbadi_isr(void)
+{
+    adc_cb_evt_t    event = ADC_EVT_SCAN_COMPLETE_GROUPB;
+
+    /* presence of callback function verified in Open() */
+    if ((NULL != g_dcb.p_callback) && (FIT_NO_FUNC != g_dcb.p_callback))
+    {
+        g_dcb.p_callback(&event);
+    }
+} /* End of function adc_gbadi_isr() */
+
+#endif /* #if (!definedBSP_MCU_RX64M && !definedBSP_MCU_RX65_ALL && !definedBSP_MCU_RX66T \
+    && !definedBSP_MCU_RX71M && !definedBSP_MCU_RX72T && !definedBSP_MCU_RX72M \
+    && !definedBSP_MCU_RX13T && !definedBSP_MCU_RX66N && !definedBSP_MCU_RX72N \
+    && !definedBSP_MCU_RX23T && !definedBSP_MCU_RX24T && !definedBSP_MCU_RX24U \
+    && !definedBSP_MCU_RX671 && !definedBSP_MCU_RX660 && !definedBSP_MCU_RX26T */

--- a/drivers/rx/rdp/src/r_s12ad_rx/src/r_s12ad_rx_private.h
+++ b/drivers/rx/rdp/src/r_s12ad_rx/src/r_s12ad_rx_private.h
@@ -1,0 +1,705 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/******************************************************************************
+* File Name    : r_s12ad_rx_private.h
+* Description  : Definitions and structures used internally by the driver.
+*******************************************************************************/
+/******************************************************************************
+* History : DD.MM.YYYY Version Description
+*           22.07.2013 1.00    Initial Release.
+*           21.04.2014 1.20    Updated for RX210 advanced features; RX110/63x support.
+*           06.11.2014 1.40    Added RX113 support.
+*           20.05.2015 1.50    Added RX231 support.
+*           01.03.2016 2.11    Added RX130 and RX230 support.
+*           01.10.2016 2.20    Added RX65x support.
+*           03.04.2017 2.30    Added RX65N-2MB and RX130-512KB support.
+*           03.09.2018 3.00    Added RX66T support.
+*           28.12.2018 3.10    Added RX72T support.
+*                              Added RX65N 64pins support.
+*           05.04.2019 4.00    Deleted the bellow macro definition of RX210, RX631, and RX63N.
+*                              - ADC_PRV_INVALID_CH_MASK
+*                              Added support for GNUC and ICCRX.
+*           28.06.2019 4.10    Added RX23W support.
+*           31.07.2019 4.20    Added RX72M support.
+*           30.08.2019 4.30    Added RX13T support.
+*           22.11.2019 4.40    Added RX66N and RX72N support.
+*           28.02.2020 4.50    Added RX23E-A support.
+*           10.06.2020 4.60    Added RX23T and RX24T and RX24U support.
+*           01.03.2021 4.70    Added RX72M 144pins and 100pins support.
+*                              Added RX23W 83pins support.
+*           31.05.2021 4.80    Added RX671 support.
+*           30.07.2021 4.90    Added RX140 support.
+*           30.11.2021 4.93    Added RX66T 48pins support.
+*           29.12.2021 5.00    Added RX660 support.
+*           01.08.2022 5.10    Added RX26T support.
+*           14.10.2022 5.20    Added RX23E-B support.
+*           03.04.2023 5.30    Added RX26T 48k support.
+*           13.02.2024 5.40    Added RX260 and RX261 support.
+*           20.03.2025 5.41    Changed the disclaimer in program sources.
+*******************************************************************************/
+
+#ifndef S12AD_PRV_PRIVATE_H
+#define S12AD_PRV_PRIVATE_H
+
+/******************************************************************************
+Includes   <System Includes> , "Project Includes"
+*******************************************************************************/
+#include "platform.h"
+#include "r_s12ad_rx_if.h"
+
+/******************************************************************************
+Macro definitions
+*******************************************************************************/
+
+#if R_BSP_VERSION_MAJOR < 5
+    #error "This module must use BSP module of Rev.5.00 or higher. Please use the BSP module of Rev.5.00 or higher."
+#endif
+
+/* Macro for accessing RX64M/RX65x/RX66T/RX71M/RX72T/RX24T/RX24U/RX671 data register pointers for 
+ a given unit (0, 1 or 2) */
+#if (defined(BSP_MCU_RX66T)   || defined(BSP_MCU_RX72T) || defined(BSP_MCU_RX24T) \
+    || defined(BSP_MCU_RX24U) || defined(BSP_MCU_RX26T))
+#define ADC_PRV_GET_DATA_ARR(x)     (((x)==0) ? gp_dreg0_ptrs : \
+                                    ((x)==1) ? gp_dreg1_ptrs : \
+                                                gp_dreg2_ptrs)
+#else
+#define ADC_PRV_GET_DATA_ARR(x)         (((x)==0) ? gp_dreg0_ptrs : gp_dreg1_ptrs)
+#endif /* #if (defined(BSP_MCU_RX66T) || defined(BSP_MCU_RX72T) || defined(BSP_MCU_RX671)) */
+
+#if (defined(BSP_MCU_RX110) || defined(BSP_MCU_RX111))
+
+#if BSP_PACKAGE_PINS == 64
+
+/* valid: 1111 1111 0101 1111; invalid 0000 0000 1010 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFF00A0)
+
+#elif BSP_PACKAGE_PINS == 48
+
+/* valid: 1001 1111 0100 0111; invalid 0110 0000 1011 1000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFF60B8)
+
+#elif BSP_PACKAGE_PINS == 40
+
+/* valid: 0001 1111 0100 0110; invalid 1110 0000 1011 1001 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFFE0B9)
+
+#elif BSP_PACKAGE_PINS == 36
+
+/* valid: 0001 1111 0000 0110; invalid 1110 0000 1111 1001 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFFE0F9)
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /*  */
+
+#endif
+
+
+#ifdef BSP_MCU_RX113
+
+#if BSP_PACKAGE_PINS == 100
+
+/* valid: 0010 0000 1111 1111 1111 1111; invalid 1101 1111 0000 0000 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFDF0000)
+
+#elif BSP_PACKAGE_PINS == 64
+
+/* valid: 1111 1111 0000 0111; invalid 0000 0000 1111 1000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFF00F8)
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* #if BSP_PACKAGE_PINS == 100 */
+
+#endif
+
+
+#ifdef BSP_MCU_RX130
+
+/* Temp sensor and internal v ref are in bit locations 8 and 9 in each mask for rx130 */
+#if BSP_PACKAGE_PINS == 100
+
+/* valid: 1111 1111 1111 1111 0000 0011 1111 1111; invalid 0000 0000 0000 0000 1111 1100 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0x0000FC00)
+
+#elif BSP_PACKAGE_PINS == 80
+
+/* valid: 0000 0111 0011 1111 0000 0011 1111 1111; invalid 1111 1000 1100 0000 1111 1100 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xF8C0FC00)
+
+#elif BSP_PACKAGE_PINS == 64
+
+/* valid: 0000 0000 0011 1111 0000 0011 1111 1111; invalid 1111 1111 1100 0000 1111 1100 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFC0FC00)
+
+#elif BSP_PACKAGE_PINS == 48
+
+/* valid: 0000 0000 0001 1110 0000 0011 1110 0111; invalid 1111 1111 1110 0001 1111 1100 0001 1000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFE1FC18)
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* #if BSP_PACKAGE_PINS == 100 */
+
+#endif
+
+
+#ifdef BSP_MCU_RX13T
+
+/* Internal v ref are in bit location 8 in each mask for rx130 */
+#if BSP_PACKAGE_PINS == 48
+
+/* valid: 0000 0000 0000 0000 0000 0001 1111 1111; invalid 1111 1111 1111 1111 1111 1110 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFFFE00)
+
+#elif BSP_PACKAGE_PINS == 32
+
+/* valid: 0000 0000 0000 0000 0000 0001 0001 1111; invalid 1111 1111 1111 1111 1111 1110 1110 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFFFEE0)
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 48 */
+
+#endif
+
+
+#ifdef BSP_MCU_RX140
+
+/* Temp sensor and internal v ref are in bit locations 9 and 10 in each mask for rx140 */
+#if BSP_PACKAGE_PINS == 80
+
+/* valid: 0000 0111 0011 1111 0000 0111 1111 1111; invalid 1111 1000 1100 0000 1111 1000 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xF8C0F800)
+
+#elif BSP_PACKAGE_PINS == 64
+
+/* valid: 0000 0000 0011 1111 0000 0111 1111 1111; invalid 1111 1111 1100 0000 1111 1000 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFC0F800)
+
+#elif BSP_PACKAGE_PINS == 48
+
+/* valid: 0000 0000 0001 1110 0000 0111 1110 0111; invalid 1111 1111 1110 0001 1111 1000 0001 1000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFE1F818)
+
+#elif BSP_PACKAGE_PINS == 32
+
+/* valid: 0000 0000 0001 1110 0000 0111 1110 0111; invalid 1111 1111 1110 0001 1111 1000 1111 1000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFE1F8F8)
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* #if BSP_PACKAGE_PINS == 80 */
+
+#endif
+
+
+#ifdef BSP_MCU_RX230
+
+/* Temp sensor and internal v ref are in bit locations 8 and 9 in each mask for rx230 */
+#if BSP_PACKAGE_PINS == 100
+
+/* valid: 1111 1111 1111 1111 0000 0011 1111 1111; invalid 0000 0000 0000 0000 1111 1100 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0x0000FC00)
+
+#elif BSP_PACKAGE_PINS == 64
+
+/* valid: 0000 0000 0011 1111 0000 0011 0101 1111; invalid 1111 1111 1100 0000 1111 1100 1010 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFC0FCA0)
+
+#elif BSP_PACKAGE_PINS == 48
+
+/* valid: 0000 0000 0001 1110 0000 0011 0100 0111; invalid 1111 1111 1110 0001 1111 1100 1011 1000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFE1FCB8)
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 100 */
+
+#endif
+
+
+#ifdef BSP_MCU_RX231
+
+/* Temp sensor and internal v ref are in bit locations 8 and 9 in each mask for rx231 */
+#if BSP_PACKAGE_PINS == 100
+
+/* valid: 1111 1111 1111 1111 0000 0011 1111 1111; invalid 0000 0000 0000 0000 1111 1100 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0x0000FC00)
+
+#elif BSP_PACKAGE_PINS == 64
+
+/* valid: 0000 0000 0011 1111 0000 0011 0101 1111; invalid 1111 1111 1100 0000 1111 1100 1010 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFC0FCA0)
+
+#elif BSP_PACKAGE_PINS == 48
+
+/* valid: 0000 0000 0001 1110 0000 0011 0100 0111; invalid 1111 1111 1110 0001 1111 1100 1011 1000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFE1FCB8)
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* BSP_PACKAGE_PINS == 100 */
+
+#endif
+
+
+#ifdef BSP_MCU_RX23T
+
+/* Internal v ref are in bit location 8 in each mask for rx23t */
+#if BSP_PACKAGE_PINS == 64
+
+/* valid: 0000 0000 0000 0011 0000 0001 1111 1111; invalid 1111 1111 1111 1100 1111 1110 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFCFE00)
+
+#elif BSP_PACKAGE_PINS == 52
+
+/* valid: 0000 0000 0000 0011 0000 0001 1111 1111; invalid 1111 1111 1111 1100 1111 1110 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFCFE00)
+
+#elif BSP_PACKAGE_PINS == 48
+
+/* valid: 0000 0000 0000 0011 0000 0001 1111 1111; invalid 1111 1111 1111 1100 1111 1110 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFCFE00)
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* BSP_PACKAGE_PINS == 64 */
+
+#endif
+
+
+#ifdef BSP_MCU_RX23E_A
+
+#if BSP_PACKAGE_PINS == 48
+/* valid: 0000 0000 0000 0000 0000 0011 1111 1111; invalid 1111 1111 1111 1111 1111 1111 1100 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFFFFC0)
+
+#elif BSP_PACKAGE_PINS == 40
+
+/* valid: 0000 1000 0001 1100 0000 0011 1110 0010; invalid 1111 1111 1110 1111 1111 1111 1111 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xFFFFFFF0)
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 48 */
+
+#endif
+
+#ifdef BSP_MCU_RX23W
+
+/* Temp sensor and internal v ref are in bit locations 8 and 9 in each mask for rx23w */
+#if BSP_PACKAGE_PINS == 85
+/* valid: 0000 1000 0001 1111 0000 0011 1111 1111; invalid 1111 0111 1110 0000 1111 1100 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xF7E0FC00)
+
+#elif BSP_PACKAGE_PINS == 83
+/* valid: 0000 1000 0001 1111 0000 0011 1111 1111; invalid 1111 0111 1110 0000 1111 1100 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK     (0xF7E0FC00)
+
+#elif BSP_PACKAGE_PINS == 56
+
+/* valid: 0000 1000 0001 1100 0000 0011 1110 0010; invalid 1111 0111 1110 0011 1111 1100 0001 1101 */
+#define ADC_PRV_INVALID_CH_MASK     (0xF7E3FC1D)
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 85 */
+
+#endif
+
+#ifdef BSP_MCU_RX24T
+
+/* Internal v ref are in bit location 12 in mask2 for rx24t */
+#if BSP_PACKAGE_PINS == 100
+
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFEFFF0)    /* all channels valid (0-3,16) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFEFFF0)    /* all channels valid (0-3,16) */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFFFE000)    /* all channels valid (0-11, sensors) */
+
+#elif BSP_PACKAGE_PINS == 80
+
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFEFFF0)    /* all channels valid (0-3,16) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFEFFF0)    /* all channels valid (0-3,16) */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFFFE0C4)    /* all channels valid (2,6-11, sensors) */
+
+#elif BSP_PACKAGE_PINS == 64
+
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFF8)    /* all channels valid (0-2) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFEFFF8)    /* all channels valid (0-2,16) */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFFFE83F)    /* all channels valid (6-10, sensors) */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 100 */
+
+#endif
+
+#ifdef BSP_MCU_RX24U
+
+/* Internal v ref are in bit location 12 in mask2 for rx24u */
+#if BSP_PACKAGE_PINS == 144
+
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFEFFF0)    /* all channels valid (0-3,16) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFEFFF0)    /* all channels valid (0-3,16) */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFFFE000)    /* all channels valid (0-11, sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFEFFF0)    /* all channels valid (0-3,16) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFEFFF0)    /* all channels valid (0-3,16) */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFFFE0C0)    /* all channels valid (0-5,8-11, sensors) */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 144 */
+
+#endif
+
+#if (defined(BSP_MCU_RX64M) || defined(BSP_MCU_RX71M))
+
+#if BSP_PACKAGE_PINS == 177
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 176
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 145
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+
+/* valid: 0110 0000 0011 1111 1111 1111; invalid 1001 1111 1100 0000 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF9FC000)    /* chans 0-13, sensors valid */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 177 */
+
+#endif
+
+#if (defined(BSP_MCU_RX65_ALL))
+
+#if BSP_PACKAGE_PINS == 177
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 176
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 145
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+
+/* valid: 0110 0000 0011 1111 1111 1111; invalid 1001 1111 1100 0000 0000 0000 */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF9FC000)    /* chans 0-13, sensors valid */
+
+#elif BSP_PACKAGE_PINS == 64
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFF0)    /* channels 0-3 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF9FC33F)    /* chans 6, 7 10-13, sensors valid */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* BSP_PACKAGE_PINS == 177 */
+
+#endif /* definedBSP_MCU_RX65_ALL */
+
+#if (defined(BSP_MCU_RX660))
+
+#if BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFC000000)    /* all channels valid (0-23 sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+#define ADC_PRV_INVALID_CH_MASK0    (0xFC000000)    /* all channels valid (0-23 sensors) */
+
+#elif BSP_PACKAGE_PINS == 80
+#define ADC_PRV_INVALID_CH_MASK0    (0xFCF8C000)    /* channels 0-13 16-18 sensors valid */
+
+#elif BSP_PACKAGE_PINS == 64
+#define ADC_PRV_INVALID_CH_MASK0    (0xFCFFC000)    /* channels 0-13 sensors valid */
+
+#elif BSP_PACKAGE_PINS == 48
+#define ADC_PRV_INVALID_CH_MASK0    (0xFCFFE118)    /* channels 0-2 5-7 9-12 sensors valid */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* BSP_PACKAGE_PINS == 177 */
+
+#endif /* definedBSP_MCU_RX65_ALL */
+
+#if (defined(BSP_MCU_RX66T))
+
+#if BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F000)    /* all channels valid (0-11, 16, 17 sensors) */
+
+#elif BSP_PACKAGE_PINS == 112
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF70)    /* channels 0-3, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFF70)    /* channels 0-3, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F030)    /* channels 0-3, 6-11, 16, 17 sensors valid */
+
+#elif BSP_PACKAGE_PINS == 100
+
+#if ((BSP_CFG_MCU_PART_FUNCTION == 0xA) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0xC) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0xE) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0x10))
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF70)    /* channels 0-3, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFF70)    /* channels 0-3, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F030)    /* channels 0-3, 6-11, 16, 17 sensors valid */
+#else
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFF0)    /* channels 0-3 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFFF0)    /* channels 0-3 valid */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F000)    /* all channels valid (0-11, 16, 17 sensors) */
+#endif /* #if ((BSP_CFG_MCU_PART_FUNCTION == 0xA) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0xC) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0xE) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0x10)) */
+
+#elif BSP_PACKAGE_PINS == 80
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF70)    /* channels 0-3, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFF70)    /* channels 0-3, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F2F0)    /* channels 0-3, 8, 10, 11, 16, 17, sensors valid */
+
+#elif BSP_PACKAGE_PINS == 64
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF78)    /* channels 0-2, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFF78)    /* channels 0-2, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F3F8)    /* channels 0-2, 10, 11, 16, 17, sensors valid */
+
+#elif BSP_PACKAGE_PINS == 48
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFF0)    /* channels 0-3 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFFFE)    /* channels 0 valid */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF3F2FF)    /* channels 8, 10, 11, sensors valid */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* BSP_PACKAGE_PINS == 144 */
+
+#endif /* definedBSP_MCU_RX66T */
+
+#if (defined(BSP_MCU_RX671))
+
+#if BSP_PACKAGE_PINS == 145
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFC000)    /* all channels valid (0-11, sensors) */
+
+#elif BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFC000)    /* all channels valid (0-11, sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFCF00)    /* channels 0-7, sensors valid */
+
+#elif BSP_PACKAGE_PINS == 64
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFF0)    /* channels 0-3 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFCFC0)    /* channels 0-5, sensors valid */
+
+#elif BSP_PACKAGE_PINS == 48
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFF0)    /* channels 0-3 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFCFC3)    /* channels 2-5, sensors valid */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* BSP_PACKAGE_PINS == 145 */
+
+#endif /* definedBSP_MCU_RX671 */
+
+#if (defined(BSP_MCU_RX72T))
+
+#if BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F000)    /* all channels valid (0-11, 16, 17 sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+
+#if ((BSP_CFG_MCU_PART_FUNCTION == 0xA) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0xC) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0xE) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0x10))
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF70)    /* channels 0-3, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFF70)    /* channels 0-3, 7 valid */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F030)    /* channels 0-3, 6-11, 16, 17 sensors valid */
+#else
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFF0)    /* channels 0-3 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFFFFFFF0)    /* channels 0-3 valid */
+#define ADC_PRV_INVALID_CH_MASK2    (0xFFF0F000)    /* all channels valid (0-11, 16, 17 sensors) */
+#endif /* #if ((BSP_CFG_MCU_PART_FUNCTION == 0xA) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0xC) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0xE) || \
+    (BSP_CFG_MCU_PART_FUNCTION == 0x10)) */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 144 */
+#endif
+
+#if (defined(BSP_MCU_RX72M))
+
+#if BSP_PACKAGE_PINS == 224
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 176
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFE0)    /* channels 0-4 valid */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFFF8)    /* channels 0-2  */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF983931)    /* channels 1-3, 6, 7, 9, 10, 14-18, sensors valid */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif /* BSP_PACKAGE_PINS == 224 */
+#endif
+
+#if (defined(BSP_MCU_RX66N))
+
+#if BSP_PACKAGE_PINS == 224
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 176
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 145
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF9FC000)    /* chans 0-13, sensors valid */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /* BSP_PACKAGE_PINS == 224 */
+#endif
+
+#if (defined(BSP_MCU_RX72N))
+
+#if BSP_PACKAGE_PINS == 224
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 176
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 145
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 144
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF800000)    /* all channels valid (0-20, sensors) */
+
+#elif BSP_PACKAGE_PINS == 100
+#define ADC_PRV_INVALID_CH_MASK0    (0xFFFFFF00)    /* all channels valid (0-7) */
+#define ADC_PRV_INVALID_CH_MASK1    (0xFF9FC000)    /* chans 0-13, sensors valid */
+
+#else
+    #error "ERROR - BSP_CFG_MCU_PART_PACKAGE - Unknown package chosen in r_bsp_config.h"
+#endif  /*  */
+#endif
+
+
+/******************************************************************************
+Typedef definitions
+*******************************************************************************/
+typedef R_BSP_VOLATILE_EVENACCESS uint16_t * const  dregs_t;
+
+typedef struct st_adc_ctrl          // ADC Control Block
+{
+    adc_mode_t      mode;           // operational mode
+    bool            opened;
+    void          (*p_callback)(void *p_args);
+
+#if (defined(BSP_MCU_RX64M) || defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) \
+    || defined(BSP_MCU_RX71M) || defined(BSP_MCU_RX72T) || defined(BSP_MCU_RX72M) \
+    || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N) || defined(BSP_MCU_RX671) \
+    || defined(BSP_MCU_RX660) || defined(BSP_MCU_RX26T))
+    uint32_t        cmpi_mask;      // for GRPBL1
+#endif    
+#if (defined(BSP_MCU_RX65_ALL) || defined(BSP_MCU_RX66T) || defined(BSP_MCU_RX72T) \
+    || defined(BSP_MCU_RX72M)  || defined(BSP_MCU_RX66N) || defined(BSP_MCU_RX72N) \
+    || defined(BSP_MCU_RX671)  || defined(BSP_MCU_RX660) || defined(BSP_MCU_RX26T))
+    uint32_t        cmpi_maskb;     // for GRPBL1 WINDOWB
+#endif
+} adc_ctrl_t;
+
+/* ADCSR register ADCS field (non-63x) */
+typedef enum e_adc_adcs
+{
+    ADC_ADCS_SINGLE_SCAN =0,
+    ADC_ADCS_GROUP_SCAN  =1,
+    ADC_ADCS_CONT_SCAN   =2,
+    ADC_ADCS_MAX
+} e_adc_adcs_t;
+
+/******************************************************************************
+Exported global variables
+*******************************************************************************/
+
+/******************************************************************************
+Exported global functions (to be accessed by other files)
+*******************************************************************************/
+extern adc_err_t adc_open(uint8_t const          unit,
+                        adc_mode_t const       mode,
+                        adc_cfg_t * const      p_cfg,
+                        void         (* const  p_callback)(void *p_args));
+extern adc_err_t adc_close(uint8_t const  unit);
+extern adc_err_t adc_read_all(adc_data_t * const  p_all_data);
+extern adc_err_t adc_control(uint8_t const       unit,
+                            adc_cmd_t const     cmd,
+                            void * const        p_args);
+
+#if (!defined(BSP_MCU_RX64M) && !defined(BSP_MCU_RX65_ALL) && !defined(BSP_MCU_RX66T) \
+    && !defined(BSP_MCU_RX71M) && !defined(BSP_MCU_RX72T) && !defined(BSP_MCU_RX72M) \
+    && !defined(BSP_MCU_RX13T) && !defined(BSP_MCU_RX66N) && !defined(BSP_MCU_RX72N) \
+    && !defined(BSP_MCU_RX23T) && !defined(BSP_MCU_RX24T) && !defined(BSP_MCU_RX24U) \
+    && !defined(BSP_MCU_RX671) && !defined(BSP_MCU_RX26T))
+/******************************************************************************
+* Function Name: adc_enable_s12adi0
+* Description  : This function clears the S12ADI0 interrupt flag and enables
+*                interrupts in the peripheral (for IR flag usage). If priority
+*                is not 0, interrupts are enabled in the ICU.
+*                NOTE: This has nothing to do with enabling triggers.
+* Arguments    : none
+* Return Value : none
+*******************************************************************************/
+void adc_enable_s12adi0(void);
+#endif /* #if (!defined(BSP_MCU_RX64M) && !defined(BSP_MCU_RX65_ALL) && !defined(BSP_MCU_RX66T) \
+    && !defined(BSP_MCU_RX71M) && !defined(BSP_MCU_RX72T) && !defined(BSP_MCU_RX72M) \
+    && !defined(BSP_MCU_RX13T) && !defined(BSP_MCU_RX66N) && !defined(BSP_MCU_RX72N) \
+    && !defined(BSP_MCU_RX23T) && !defined(BSP_MCU_RX24T) && !defined(BSP_MCU_RX24U) \
+    && !defined(BSP_MCU_RX671) && !defined(BSP_MCU_RX26T)) */
+
+
+#endif /* S12AD_PRV_PRIVATE_H */
+

--- a/drivers/rx/rdp/src/r_s12ad_rx/src/targets/rx130/r_s12ad_rx130.c
+++ b/drivers/rx/rdp/src/r_s12ad_rx/src/targets/rx130/r_s12ad_rx130.c
@@ -1,0 +1,1207 @@
+/***********************************************************************************************************************
+* Copyright (c) 2016 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_s12ad_rx130.c
+* Description  : Primary source code for 12-bit A/D Converter driver.
+***********************************************************************************************************************/
+/**********************************************************************************************************************
+* History : DD.MM.YYYY Version Description
+*           01.03.2016 1.00    Initial Release.
+*           01.10.2016 2.20    Define name commoditize for the same meaning but different name define.
+*                              Delete parameter check by the enum value.
+*                              Initialize ADGSPCR register when mode without Group scan mode.
+*                              Comparison parameter change.(adjust the parameter structure to RX65N)
+*                              Bug fix for Comparison can not stop after start.
+*                              Bug fix for Can not choice both self-diag and dda.
+*                              Bug fix for self-diag can set during Single scan mode(double trigger).
+*                              adc_enable_s12gbadi() declaration change that same as prototype declaration.
+*           03.04.2017 2.30    R_ADC_Control function returns ADC_ERR_INVALID_ARG when set to group B or PGS bit
+*                               except for Group scan mode.
+*                              Corresponding to the notice when setting the PGS bit in the ADGSPCR register to 1.
+*                              Added RX130-512KB support.
+*           03.09.2018 3.00    Added the comment to while statement.
+*           28.12.2018 3.10    Fixed header comment of adc_close function.
+*           05.04.2019 4.00    Added support for GNUC and ICCRX.
+*           22.11.2019 4.40    Added support for atomic control.
+*           20.03.2025 5.41    Changed the disclaimer in program sources.
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Includes   <System Includes> , "Project Includes"
+***********************************************************************************************************************/
+/* Includes board and MCU related header files. */
+#include <stdio.h>
+#include "platform.h"
+#include "r_bsp_locking.h"
+
+#if defined (BSP_MCU_RX130)
+#include "r_s12ad_rx_config.h"
+#include "r_s12ad_rx_private.h"
+#include "r_s12ad_rx_if.h"
+
+/***********************************************************************************************************************
+Macro definitions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Typedef definitions
+***********************************************************************************************************************/
+typedef R_BSP_VOLATILE_EVENACCESS struct st_s12ad  aregs_t;
+
+/***********************************************************************************************************************
+Private global variables and functions
+***********************************************************************************************************************/
+
+/* In RAM */
+extern adc_ctrl_t g_dcb;
+
+/* In ROM. A/D Data Register pointers */
+volatile uint16_t R_BSP_EVENACCESS_SFR * const  gp_dreg_ptrs[ADC_REG_MAX+1] =
+                    {   &S12AD.ADDR0,     /* channel 0 */
+                        &S12AD.ADDR1,     /* channel 1 */
+                        &S12AD.ADDR2,     /* channel 2 */
+                        &S12AD.ADDR3,     /* channel 3 */
+                        &S12AD.ADDR4,     /* channel 4 */
+                        &S12AD.ADDR5,     /* channel 5 */
+                        &S12AD.ADDR6,     /* channel 6 */
+                        &S12AD.ADDR7,     /* channel 7 */
+                        &S12AD.ADDR16,    /* channel 16 */
+                        &S12AD.ADDR17,    /* channel 17 */
+                        &S12AD.ADDR18,    /* channel 18 */
+                        &S12AD.ADDR19,    /* channel 19 */
+                        &S12AD.ADDR20,    /* channel 20 */
+                        &S12AD.ADDR21,    /* channel 21 */
+                        &S12AD.ADDR22,    /* channel 22 */
+                        &S12AD.ADDR23,    /* channel 23 */
+                        &S12AD.ADDR24,    /* channel 24 */
+                        &S12AD.ADDR25,    /* channel 25 */
+                        &S12AD.ADDR26,    /* channel 26 */
+                        &S12AD.ADDR27,    /* channel 27 */
+                        &S12AD.ADDR28,    /* channel 28 */
+                        &S12AD.ADDR29,    /* channel 29 */
+                        &S12AD.ADDR30,    /* channel 30 */
+                        &S12AD.ADDR31,    /* channel 31 */
+                        &S12AD.ADTSDR,    /* temperature sensor */
+                        &S12AD.ADOCDR,    /* voltage sensor */
+                        &S12AD.ADDBLDR,   /* Data Duplication register */
+                        &S12AD.ADRD.WORD  /* self-diagnosis register */
+                    };
+
+
+/* In ROM. Sample State (SST) Register pointers */
+/* 8-bit register pointers */
+volatile uint8_t R_BSP_EVENACCESS_SFR * const  gp_sreg_ptrs[ADC_SST_REG_MAX+1] =
+                    {   &S12AD.ADSSTR0,     /* channel 0 */
+                        &S12AD.ADSSTR1,     /* channel 1 */
+                        &S12AD.ADSSTR2,     /* channel 2 */
+                        &S12AD.ADSSTR3,
+                        &S12AD.ADSSTR4,
+                        &S12AD.ADSSTR5,
+                        &S12AD.ADSSTR6,
+                        &S12AD.ADSSTR7,     /* channel 7 */
+                        &S12AD.ADSSTRL,     /* channels 16 to 21, 24 to 26 */
+                        &S12AD.ADSSTRT,     /* temperature sensor output */
+                        &S12AD.ADSSTRO      /* internal voltage reference */
+                    };
+
+
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+static adc_err_t adc_check_open_cfg(adc_mode_t  const  mode,
+                                    adc_cfg_t * const  p_cfg,
+                                    void     (* const  p_callback)(void *p_args));
+
+static adc_err_t adc_check_scan_config(adc_ch_cfg_t *p_config);
+#endif
+
+static adc_err_t adc_configure_scan(adc_ch_cfg_t *p_config);
+static void adc_enable_s12gbadi(void);
+static adc_err_t adc_en_comparator_level0(adc_cmpwin_t  *p_cmpwin);
+static uint32_t adc_get_and_clr_cmpi_flags(void);
+
+
+/******************************************************************************
+* Function Name: adc_open
+* Description  : This function applies power to the A/D peripheral, sets the
+*                operational mode, trigger sources, interrupt priority, and
+*                configurations common to all channels and sensors. If interrupt
+*                priority is non-zero, the function takes a callback function
+*                pointer for notifying the user at interrupt level whenever a
+*                scan has completed.
+*
+* Arguments    : unit -
+*                    Ignored for rx130. Pass 0 for this argument.
+*                mode -
+*                    Operational mode (see enumeration below)
+*                p_cfg-
+*                    Pointer to configuration structure (see below)
+*                p_callback-
+*                    Optional pointer to function called from interrupt when
+*                    a scan completes
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*                ADC_ERR_AD_LOCKED-
+*                    Open() call is in progress elsewhere
+*                ADC_ERR_AD_NOT_CLOSED-
+*                    Peripheral is still running in another mode; Perform
+*                    R_ADC_Close() first
+*                ADC_ERR_INVALID_ARG-
+*                    mode or element of p_cfg structure has invalid value.
+*                ADC_ERR_ILLEGAL_ARG-
+*                    an argument is illegal based upon mode
+*                ADC_ERR_MISSING_PTR-
+*                    p_cfg pointer is FIT_NO_PTR/NULL
+*******************************************************************************/
+adc_err_t adc_open(uint8_t     const   unit,
+                    adc_mode_t  const   mode,
+                    adc_cfg_t * const   p_cfg,
+                    void     (* const   p_callback)(void *p_args))
+{
+    aregs_t             *p_regs;
+    volatile uint16_t   u16_dummy;  /* Dummy read for "1" change to "0".(read first) */
+    volatile uint8_t    u8_dummy;   /* Dummy read for "1" change to "0".(read first) */
+
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    bsp_int_ctrl_t int_ctrl;
+#endif
+
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+    adc_err_t   err;
+
+    if ((NULL == p_cfg) || (FIT_NO_PTR == p_cfg))
+    {
+        return ADC_ERR_MISSING_PTR;
+    }
+
+    err = adc_check_open_cfg(mode, p_cfg, p_callback);
+    if (ADC_SUCCESS != err)
+    {
+        return err;
+    }
+#endif
+
+    /* ENSURE OPEN() NOT ALREADY IN PROGRESS */
+    if (true == g_dcb.opened)
+    {
+        return ADC_ERR_AD_NOT_CLOSED;
+    }
+    if (R_BSP_HardwareLock(BSP_LOCK_S12AD) == false)
+    {
+        return ADC_ERR_AD_LOCKED;
+    }
+
+    /* APPLY POWER TO PERIPHERAL */
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_LPC_CGC_SWR);
+
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_DISABLE, &int_ctrl);
+#endif
+    MSTP(S12AD) = 0;
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_ENABLE, &int_ctrl);
+#endif
+
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_CGC_SWR);
+
+    /* Get S12AD register address */
+    p_regs = (aregs_t *)&S12AD;
+    p_regs->ADCSR.WORD = p_regs->ADCSR.WORD & 0x0400;
+    p_regs->ADEXICR.WORD = 0;  //Don't convert Temp Sensor and Internal Reference
+
+    p_regs->ADANSA0.WORD = 0;
+    p_regs->ADANSA1.WORD = 0;
+    p_regs->ADANSB0.WORD = 0;
+    p_regs->ADANSB1.WORD = 0;
+
+    p_regs->ADADS0.WORD = 0;
+    p_regs->ADADS1.WORD = 0;
+    
+    p_regs->ADADC.BYTE = 0;
+    
+    p_regs->ADCER.WORD = 0;
+    p_regs->ADSTRGR.WORD = 0;
+
+    p_regs->ADSSTR0 = 0x0d;
+    p_regs->ADSSTR1 = 0x0d;
+    p_regs->ADSSTR2 = 0x0d;
+    p_regs->ADSSTR3 = 0x0d;
+    p_regs->ADSSTR4 = 0x0d;
+    p_regs->ADSSTR5 = 0x0d;
+    p_regs->ADSSTR6 = 0x0d;
+    p_regs->ADSSTR7 = 0x0d;
+    p_regs->ADSSTRL = 0x0d;
+    p_regs->ADSSTRT = 0x0d;
+    p_regs->ADSSTRO = 0x0d;
+
+    p_regs->ADDISCR.BYTE = 0;
+    p_regs->ADELCCR.BYTE = 0;
+    p_regs->ADGSPCR.WORD = 0;
+
+    p_regs->ADCMPCR.WORD = 0;
+    p_regs->ADCMPANSR0.WORD = 0;
+    p_regs->ADCMPANSR1.WORD = 0;
+    p_regs->ADCMPANSER.BYTE = 0;
+    p_regs->ADCMPLR0.WORD = 0;
+    p_regs->ADCMPLR1.WORD = 0;
+
+    p_regs->ADCMPLER.BYTE = 0;
+
+    p_regs->ADCMPDR0 = 0;
+    p_regs->ADCMPDR1 = 0;
+    u16_dummy = p_regs->ADCMPSR0.WORD;
+    p_regs->ADCMPSR0.WORD = 0;          /* target bit clear by read-modify-write */
+    u16_dummy = p_regs->ADCMPSR1.WORD;
+    p_regs->ADCMPSR1.WORD = 0;          /* target bit clear by read-modify-write */
+
+    u8_dummy = p_regs->ADCMPSER.BYTE;
+    p_regs->ADCMPSER.BYTE = 0;          /* target bit clear by read-modify-write */
+    p_regs->ADHVREFCNT.BYTE = 0;
+
+    p_regs->ADCMPBNSR.BYTE = 0;
+    p_regs->ADWINLLB = 0;
+    p_regs->ADWINULB = 0;
+    u8_dummy = p_regs->ADCMPBSR.BYTE;
+    p_regs->ADCMPBSR.BYTE = 0;          /* target bit clear by read-modify-write */
+    p_regs->ADBUFEN.BYTE = 0;
+    p_regs->ADBUFPTR.BYTE = 0;
+    
+    /* SET MODE RELATED REGISTER FIELDS */
+    g_dcb.mode = mode;
+
+    if ((ADC_MODE_SS_MULTI_CH_GROUPED == mode)
+    ||(ADC_MODE_SS_MULTI_CH_GROUPED_DBLTRIG_A == mode))
+    {
+        p_regs->ADCSR.BIT.ADCS = ADC_ADCS_GROUP_SCAN;
+    }
+    else
+    {
+        if ((ADC_MODE_CONT_ONE_CH == mode) || (ADC_MODE_CONT_MULTI_CH == mode))
+        {
+            p_regs->ADCSR.BIT.ADCS = ADC_ADCS_CONT_SCAN;
+        } // other modes have ADCS=0
+    }
+
+    if ((ADC_MODE_SS_ONE_CH_DBLTRIG == mode)
+    || (ADC_MODE_SS_MULTI_CH_GROUPED_DBLTRIG_A == mode))
+    {
+        p_regs->ADCSR.BIT.DBLE = 1;         // enable double trigger
+    }
+
+    /* SET TRIGGER AND INTERRUPT PRIORITY REGISTER FIELDS */
+    if (ADC_TRIG_SOFTWARE != p_cfg->trigger)
+    {
+        p_regs->ADSTRGR.BIT.TRSA = p_cfg->trigger;
+    }
+
+    if (ADC_TRIG_ASYNC_ADTRG == p_cfg->trigger)
+    {
+        p_regs->ADCSR.BIT.EXTRG = 1;        // set ext trigger for async trigger
+    }
+
+    if (ADC_ADCS_GROUP_SCAN == p_regs->ADCSR.BIT.ADCS)
+    {
+        p_regs->ADSTRGR.BIT.TRSB = p_cfg->trigger_groupb;
+        IPR(S12AD,GBADI) = p_cfg->priority_groupb;
+    }
+
+    IPR(S12AD,S12ADI0) = p_cfg->priority;
+
+    /* SET REGISTER FIELDS FOR REMAINING PARAMETERS */
+    p_regs->ADCER.BIT.ADRFMT = (ADC_ALIGN_LEFT == p_cfg->alignment) ? 1 : 0;
+    p_regs->ADCER.BIT.ACE = (ADC_CLEAR_AFTER_READ_ON == p_cfg->clearing) ? 1 : 0;
+    p_regs->ADADC.BYTE = p_cfg->add_cnt;
+
+    /* SET THE A/D CONVERSION OPERATING SPEED. */
+    p_regs->ADHVREFCNT.BIT.ADSLP = 1;             // Set the sleep bit to enter standby mode.
+    R_BSP_SoftwareDelay(1, BSP_DELAY_MICROSECS);  // Wait at least 0.2us
+
+    /* Set the A/D conversion speed select bit: 0=High Speed, 1=low current */
+    p_regs->ADCSR.BIT.ADHSC = (ADC_CONVERT_CURRENT_LOW == p_cfg->conv_speed) ? 1 : 0;
+    R_BSP_SoftwareDelay(5, BSP_DELAY_MICROSECS);  // Wait at least 4.8us
+    p_regs->ADHVREFCNT.BIT.ADSLP = 0;             // Clear sleep bit for normal operation
+    R_BSP_SoftwareDelay(1, BSP_DELAY_MICROSECS);  // Wait at least 1us
+
+    /* SAVE CALLBACK FUNCTION POINTER */
+    g_dcb.p_callback = p_callback;
+
+    /* MARK DRIVER AS OPENED */
+    g_dcb.opened = true;
+    R_BSP_HardwareUnlock(BSP_LOCK_S12AD);
+
+    return ADC_SUCCESS;
+} /* End of function adc_open() */
+
+
+/******************************************************************************
+* Function Name: adc_check_open_cfg
+* Description  : If Parameter Checking is enabled, this function will simply
+*                validate the parameters passed to the adc_open function.
+** Arguments    :mode -
+*                    Operational mode (see enumeration below)
+*                p_cfg-
+*                    Pointer to configuration structure (see below)
+*                p_callback-
+*                    Optional pointer to function called from interrupt when
+*                    a scan completes
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*                ADC_ERR_INVALID_ARG-
+*                    mode or element of p_cfg structure has invalid value.
+*                ADC_ERR_ILLEGAL_ARG-
+*                    an argument is illegal based upon mode
+*******************************************************************************/
+#if (ADC_CFG_PARAM_CHECKING_ENABLE == 1)
+static adc_err_t adc_check_open_cfg(adc_mode_t   const  mode,
+                                    adc_cfg_t  * const  p_cfg,
+                                    void      (* const  p_callback)(void *p_args))
+{
+
+    /* Check for valid argument values */
+    if (p_cfg->priority > BSP_MCU_IPL_MAX)  // priority is not enum value(can't check by a Compiler)
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+
+    /* If interrupt driven, must have callback function */
+    if ((0 != p_cfg->priority)
+    && ((NULL == p_callback) || (FIT_NO_FUNC == p_callback)))
+    {
+        return ADC_ERR_ILLEGAL_ARG;
+    }
+
+    /* In double trigger mode, SW and async triggers not allowed */
+    if ((ADC_MODE_SS_ONE_CH_DBLTRIG == mode)
+    && ((ADC_TRIG_SOFTWARE == p_cfg->trigger) || (ADC_TRIG_ASYNC_ADTRG == p_cfg->trigger)))
+    {
+        return ADC_ERR_ILLEGAL_ARG;
+    }
+
+    /* Group checking; only synchronous triggers allowed; must be unique */
+    if ((ADC_MODE_SS_MULTI_CH_GROUPED == mode) || (ADC_MODE_SS_MULTI_CH_GROUPED_DBLTRIG_A == mode))
+    {
+        if ((ADC_TRIG_ASYNC_ADTRG == p_cfg->trigger)
+        || (ADC_TRIG_ASYNC_ADTRG == p_cfg->trigger_groupb)
+        || (p_cfg->trigger == p_cfg->trigger_groupb)
+        || (ADC_TRIG_SOFTWARE == p_cfg->trigger)
+        || (ADC_TRIG_SOFTWARE == p_cfg->trigger_groupb))
+        {
+            return ADC_ERR_ILLEGAL_ARG;
+        }
+
+        if (p_cfg->priority_groupb > BSP_MCU_IPL_MAX)
+        {
+            return ADC_ERR_INVALID_ARG;
+        }
+
+        if ((0 != p_cfg->priority_groupb)   // Interrupt driven, must have callback function
+        && ((NULL == p_callback) || (FIT_NO_FUNC == p_callback)))
+        {
+            return ADC_ERR_ILLEGAL_ARG;
+        }
+    }
+
+    return ADC_SUCCESS;
+} /* End of function adc_check_open_cfg() */
+#endif /* ADC_CFG_PARAM_CHECKING_ENABLE == 1 */
+
+
+/******************************************************************************
+* Function Name: adc_control
+* Description  : This function provides commands for enabling channels and
+*                sensors and for runtime operations. These include enabling/
+*                disabling trigger sources and interrupts, initiating a
+*                software trigger, and checking for scan completion.
+*
+* NOTE: Enabling a channel or a sensor, or setting the sample state count reg
+*       cannot be done while the ADCSR.ADST bit is set (conversion in progress).
+*       Because these commands should only be called once during initialization
+*       before triggers are enabled, this should not be an issue. Registers
+*       with this restriction include ADANSA0, ADANSA1, ADANSB0, ADANSB1,
+*       ADADC, ADADS0, ADADS1, ADSSTRx, ADEXICR, ADCMPCR, ADCMPANSR0,
+*       ADCMPANSR1, ADCMPANSER, ADCMPLR0, ADCMPLR1, ADCMPLER, ADCMPDR0,
+*       ADCMPDR1, and some bits in ADCSR, ADCMPCR, ADGSPCR.
+*       No runtime operational sequence checking of any kind is performed.
+*
+* Arguments    : unit -
+*                    Ignored for rx130. Pass 0 for this argument.
+*                cmd-
+*                    Command to run
+*                p_args-
+*                    Pointer to optional configuration structure
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*                ADC_ERR_MISSING_PTR-
+*                    p_args pointer is FIT_NO_PTR/NULL when required as an argument
+*                ADC_ERR_INVALID_ARG-
+*                    cmd or element of p_args structure has invalid value.
+*                ADC_ERR_ILLEGAL_ARG-
+*                    argument is illegal based upon rest of configuration
+*                ADC_ERR_SCAN_NOT_DONE-
+*                    The requested scan has not completed
+*                ADC_ERR_TRIG_ENABLED -
+*                    Cannot configure comparator because a scan is running
+*                ADC_ERR_CONDITION_NOT_MET -
+*                    No chans/sensors passed comparator condition
+*                ADC_ERR_UNKNOWN
+*                    Did not receive expected hardware response
+*******************************************************************************/
+adc_err_t adc_control(uint8_t   const   unit,
+                        adc_cmd_t const   cmd,
+                        void *    const   p_args)
+{
+    adc_err_t       err=ADC_SUCCESS;
+    adc_sst_t       *p_sample;
+    adc_dda_t       *p_charge;
+    adc_cmpwin_t    *p_cmpwin;
+
+    /* Get S12AD register address */
+    aregs_t         *p_regs = (aregs_t *)&S12AD;
+    uint32_t        flags;
+
+    /* DO UNIVERSAL PARAMETER CHECKING */
+#if (ADC_CFG_PARAM_CHECKING_ENABLE == 1)
+    if ((NULL == p_args) || (FIT_NO_PTR == p_args))
+    {
+        if ((ADC_CMD_SET_DDA_STATE_CNT == cmd)
+        || (ADC_CMD_SET_SAMPLE_STATE_CNT == cmd)
+        || (ADC_CMD_ENABLE_CHANS == cmd)
+        || (ADC_CMD_EN_COMPARATOR_LEVEL == cmd)
+        || (ADC_CMD_EN_COMPARATOR_WINDOW == cmd)
+        || (ADC_CMD_CHECK_CONDITION_MET == cmd))
+        {
+            return ADC_ERR_MISSING_PTR;
+        }
+    }
+#endif
+
+    /* PROCESS INDIVIDUAL COMMANDS */
+    switch (cmd)
+    {
+    case ADC_CMD_USE_VREFH0:
+        S12AD.ADHVREFCNT.BIT.HVSEL = 1;
+        break;
+
+    case ADC_CMD_USE_VREFL0:
+        S12AD.ADHVREFCNT.BIT.LVSEL = 1;
+        break;
+
+    /* Set up Disconnect Detection Assist*/
+    case ADC_CMD_SET_DDA_STATE_CNT:
+
+        /* Disconnection Detection Assist (DDA) */
+        p_charge = (adc_dda_t *)p_args;            //Get the command arguments
+#if (ADC_CFG_PARAM_CHECKING_ENABLE == 1)
+        if (ADC_DDA_OFF != p_charge->method)
+        {
+
+            /* Cannot have temp sensor output or V-reference conversion enabled and Disconnect Detection enabled. */
+            if ((p_charge->num_states < ADC_DDA_STATE_CNT_MIN)
+            || (p_charge->num_states > ADC_DDA_STATE_CNT_MAX)
+            || ((p_regs->ADEXICR.WORD & 0x0300) != 0)) // Temp sensor or V-ref enabled
+            {
+                return ADC_ERR_ILLEGAL_ARG;
+            }
+        }
+#endif
+        if (ADC_DDA_OFF == p_charge->method)
+        {
+            p_regs->ADDISCR.BYTE = 0;              //Disable Disconnect Detection Assist
+        }
+        else
+        {
+
+            /* NOTE: Using Disconnect Detection Assist adds num_states x (#chans) ADCLKS to scan time */
+            p_regs->ADDISCR.BYTE = (uint8_t)((ADC_DDA_PRECHARGE == p_charge->method) ? 0x10 : 0);
+            p_regs->ADDISCR.BYTE |= p_charge->num_states;
+        }
+        break;
+
+    case ADC_CMD_SET_SAMPLE_STATE_CNT:
+        p_sample = (adc_sst_t *)p_args;            //Get the command arguments
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+        if (p_sample->num_states < ADC_SST_CNT_MIN)
+        {
+            return ADC_ERR_INVALID_ARG;
+        }
+#endif
+        *(gp_sreg_ptrs)[p_sample->reg_id] = p_sample->num_states;
+        break;
+
+    case ADC_CMD_ENABLE_CHANS:
+
+        /* Cast from void pointer to adc_ch_cfg_t */
+        err = adc_configure_scan((adc_ch_cfg_t *)p_args);
+        break;
+
+    case ADC_CMD_EN_COMPARATOR_LEVEL:
+
+        /* Cast from void pointer to adc_cmpwin_t */
+        p_cmpwin = (adc_cmpwin_t *)p_args;
+        p_regs->ADCMPCR.BIT.WCMPE = 0;          // Disable the window function. Compare level
+
+        err = adc_en_comparator_level0(p_cmpwin);
+        break;
+
+    case ADC_CMD_ENABLE_TEMP_SENSOR:
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+        if (ADC_MODE_SS_TEMPERATURE != g_dcb.mode)
+        {
+            return ADC_ERR_ILLEGAL_ARG;
+        }
+#endif
+        S12AD.ADEXICR.BIT.TSSA = 1;              // select temperature output on Single scan mode
+        if (ADC_ADD_OFF != S12AD.ADADC.BIT.ADC)
+        {
+            S12AD.ADEXICR.BIT.TSSAD = 1;         // enable addition
+        }
+        adc_enable_s12adi0();                    // setup interrupt handling
+        break;
+
+    case ADC_CMD_ENABLE_VOLT_SENSOR:
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+        if (ADC_MODE_SS_INT_REF_VOLT != g_dcb.mode)
+        {
+            return ADC_ERR_ILLEGAL_ARG;
+        }
+#endif
+        S12AD.ADEXICR.BIT.OCSA = 1;              // select internal reference voltage output on Single scan mode
+        if (ADC_ADD_OFF != S12AD.ADADC.BIT.ADC)
+        {
+            S12AD.ADEXICR.BIT.OCSAD = 1;         // enable addition
+        }
+        adc_enable_s12adi0();                    // setup interrupt handling
+        break;
+
+    case ADC_CMD_EN_COMPARATOR_WINDOW:
+
+        /* Cast from void pointer to adc_cmpwin_t */
+        p_cmpwin = (adc_cmpwin_t *)p_args;
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+        if (p_cmpwin->level_lo > p_cmpwin->level_hi)
+        {
+            return ADC_ERR_ILLEGAL_ARG;
+        }
+#endif
+        p_regs->ADCMPCR.BIT.WCMPE = 1;           // Enable window function
+
+        err = adc_en_comparator_level0(p_cmpwin);
+        break;
+
+    /* Enable A/D conversion to be started by synchronous or asynchronous trigger */
+    case ADC_CMD_ENABLE_TRIG:
+        p_regs->ADCSR.BIT.TRGE = 1;           // enable sync/async triggers
+        break;
+
+    /* Disable A/D conversion to be started by synchronous or asynchronous trigger */
+    case ADC_CMD_DISABLE_TRIG:
+        p_regs->ADCSR.BIT.TRGE = 0;           // disable sync/async triggers
+        break;
+
+    /* Start the A/D conversion process */
+    case ADC_CMD_SCAN_NOW:
+        if (0 == p_regs->ADCSR.BIT.ADST)
+        {
+            p_regs->ADCSR.BIT.ADST = 1;
+        }
+        else
+        {
+            err = ADC_ERR_SCAN_NOT_DONE;
+        }
+        break;
+
+    /* Check for completion of the current scan. */
+    case ADC_CMD_CHECK_SCAN_DONE:
+        if (1 == p_regs->ADCSR.BIT.ADST)
+        {
+            err = ADC_ERR_SCAN_NOT_DONE;
+        }
+        break;
+
+    /* Check for completion of the current scan. */
+    case ADC_CMD_CHECK_SCAN_DONE_GROUPA:
+        if (1 == IR(S12AD,S12ADI0))
+        {
+            IR(S12AD,S12ADI0) = 0;
+        }
+        else
+        {
+            err = ADC_ERR_SCAN_NOT_DONE;
+        }
+        break;
+
+    /* Check for completion of the current groupB scan. */
+    case ADC_CMD_CHECK_SCAN_DONE_GROUPB:
+        if (1 == IR(S12AD,GBADI))
+        {
+            IR(S12AD,GBADI) = 0;
+        }
+        else
+        {
+            err = ADC_ERR_SCAN_NOT_DONE;
+        }
+        break;
+
+    case ADC_CMD_CHECK_CONDITION_MET:
+        flags = adc_get_and_clr_cmpi_flags();
+        if (0 == flags)
+        {
+            err = ADC_ERR_CONDITION_NOT_MET;
+        }
+
+        /* Cast from void pointer to uint32_t */
+        *((uint32_t *)p_args) = flags;
+        break;
+
+    case ADC_CMD_ENABLE_INT:
+        p_regs->ADCSR.BIT.ADIE = 1;    // Enable Scan End Interrupt (S12ADI0)
+        break;
+
+    case ADC_CMD_DISABLE_INT:
+        p_regs->ADCSR.BIT.ADIE = 0;    // Disable Scan End Interrupt (S12ADI0)
+        break;
+
+    case ADC_CMD_ENABLE_INT_GROUPB:
+        p_regs->ADCSR.BIT.GBADIE = 1;  // Enable Group B Scan End Interrupt (GBADI)
+        break;
+
+    case ADC_CMD_DISABLE_INT_GROUPB:
+        p_regs->ADCSR.BIT.GBADIE = 0;  // Disable Group B Scan End Interrupt (GBADI)
+        break;
+
+    default:
+        err = ADC_ERR_INVALID_ARG;
+        break;
+    }
+
+    return err;
+} /* End of function adc_control() */
+
+/******************************************************************************
+* Function Name: adc_en_comparator_level0
+* Description  : This function sets up the comparator for level0 threshold
+*              : compare. The processing is identical for window except
+*              : for the setting of the window enable bit and the level1
+*              : value (ADCMPDR1).
+*              :
+* Arguments    : p_cmpwin -
+*              :     Pointer to comparator level/window compare structure
+*              :
+* Return Value :ADC_SUCCESS-
+*              :     Successful
+*              : ADC_ERR_INVALID_ARG-
+*              :     reg_id contains an invalid value.
+*              : ADC_ERR_ILLEGAL_ARG-
+*              :     an argument is illegal based upon rest of configuration
+*              : ADC_ERR_TRIG_ENABLED -
+*              :     Cannot configure comparator while scans are running
+*              :
+*******************************************************************************/
+static adc_err_t adc_en_comparator_level0(adc_cmpwin_t  *p_cmpwin)
+{
+
+    /* Get S12AD register address */
+    aregs_t *p_regs = (aregs_t *)&S12AD;
+
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+    if ((p_cmpwin->compare_mask & ADC_PRV_INVALID_CH_MASK) != 0)    // checking exist channel
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+    if ((p_cmpwin->inside_window_mask | p_cmpwin->compare_mask)
+    != p_cmpwin->compare_mask)  // checking compare channel combination
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+    if (1 == p_regs->ADCSR.BIT.DBLE)                            // Comparison disable when Double trigger mode
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+    if (0 != p_regs->ADCER.BIT.DIAGM)                           // Comparison disable when Self-diagnosis mode
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+    if ((ADC_MODE_SS_TEMPERATURE == g_dcb.mode) && (ADC_MASK_TEMP != p_cmpwin->compare_mask))   // checking use channel
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+    if ((ADC_MODE_SS_INT_REF_VOLT == g_dcb.mode) && (ADC_MASK_VOLT != p_cmpwin->compare_mask))  // checking use channel
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+#endif
+
+    if (1 == p_regs->ADCSR.BIT.TRGE)
+    {
+        return ADC_ERR_TRIG_ENABLED;    // ADST must be 0 to configure comparator
+    }
+
+    /* CONFIGURE COMPARATOR */
+    if (true == p_cmpwin->windowa_enable) // COMPARATOR A
+    {
+        p_regs->ADCMPCR.BIT.CMPAE = 0;          // Compare window A operation is disabled
+
+        p_regs->ADCMPDR0 = p_cmpwin->level_lo;      // set lo end of window or set level
+        if (1 == p_regs->ADCMPCR.BIT.WCMPE)
+        {
+            p_regs->ADCMPDR1 = p_cmpwin->level_hi;  // set hi end of window
+        }
+
+        p_regs->ADCMPANSR0.WORD = p_cmpwin->compare_mask & 0x00FF;      // Select channels to compare.  Channels 0 to 7.
+        p_regs->ADCMPLR0.WORD = p_cmpwin->inside_window_mask & 0x00FF;  // Select the CoMPare Level. Channels 0 to 7.
+
+        S12AD.ADCMPANSR1.WORD = (p_cmpwin->compare_mask>>16) & 0xFFFF;  // Select channels to compare. 16 to 31.
+        S12AD.ADCMPLR1.WORD = (p_cmpwin->inside_window_mask>>16) & 0xFFFF;
+
+        S12AD.ADCMPANSER.BIT.CMPTSA = (p_cmpwin->compare_mask & ADC_MASK_TEMP) ? 1 : 0;
+        S12AD.ADCMPANSER.BIT.CMPOCA = (p_cmpwin->compare_mask & ADC_MASK_VOLT) ? 1 : 0;
+
+        S12AD.ADCMPLER.BIT.CMPLTSA = (p_cmpwin->inside_window_mask & ADC_MASK_TEMP) ? 1 : 0;
+        S12AD.ADCMPLER.BIT.CMPLOCA = (p_cmpwin->inside_window_mask & ADC_MASK_VOLT) ? 1 : 0;
+
+        p_regs->ADCMPCR.BIT.CMPAE = 1;          // Compare window A operation is enabled
+    }
+    else
+    {
+        p_regs->ADCMPCR.BIT.CMPAE = 0;          // Compare window A operation is disabled
+    }
+
+    return ADC_SUCCESS;
+} /* End of function adc_en_comparator_level0() */
+
+/*****************************************************************************
+* Function Name: adc_get_and_clr_cmpi_flags
+* Description  : Returns flags for all channels/sensors that met comparator
+*                condition and clears the flags for next interrupt.
+* Arguments    : none
+* Return Value : channels/sensors that met comparator condition
+******************************************************************************/
+static uint32_t adc_get_and_clr_cmpi_flags(void)
+{
+    uint32_t    flags;
+
+    /* Get flags for channels AN00 to AN07 */
+    flags = (uint32_t)S12AD.ADCMPSR0.WORD;
+    S12AD.ADCMPSR0.WORD = 0;
+
+    /* Get flags for channels AN16 to AN31 */
+    flags |= ((uint32_t)S12AD.ADCMPSR1.WORD << 16);
+    S12AD.ADCMPSR1.WORD = 0;
+
+    /* Get flags for Temperature sensor and internal Voltage Reference */
+    flags |= ((1 == S12AD.ADCMPSER.BIT.CMPSTTSA) ? ADC_MASK_TEMP : 0);
+    flags |= ((1 == S12AD.ADCMPSER.BIT.CMPSTOCA) ? ADC_MASK_VOLT : 0);
+    S12AD.ADCMPSER.BYTE = 0;
+
+    return flags;
+} /* End of function adc_get_and_clr_cmpi_flags() */
+
+/******************************************************************************
+* Function Name: adc_configure_scan
+* Description  : This function does extensive checking on channel mask
+*                settings based upon operational mode. Mask registers are
+*                initialized and interrupts enabled in peripheral. Interrupts
+*                are also enabled in ICU if corresponding priority is not 0.
+*
+* Arguments    : p_config -
+*                    Pointer to channel config structure containing masks
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*******************************************************************************/
+static adc_err_t adc_configure_scan(adc_ch_cfg_t   *p_config)
+{
+    uint16_t  i=0;
+    uint32_t  tmp_mask=0;
+
+    /* Get S12AD register address */
+    aregs_t   *p_regs = (aregs_t *)&S12AD;
+    uint16_t  trig_a;
+    uint16_t  trig_b;
+
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+    adc_err_t   err;
+
+    err = adc_check_scan_config(p_config);
+    if (ADC_SUCCESS != err)
+    {
+        return err;
+    }
+#endif /* ADC_CFG_PARAM_CHECKING_ENABLE == 1 */
+
+    /* SET MASKS FOR CHANNELS AND SENSORS */
+    /* Select the channels from among Ch0 to Ch7 for conversion */
+    p_regs->ADANSA0.WORD = (uint16_t) (p_config->chan_mask & 0x00FF);            //CH0 to CH7
+    p_regs->ADANSB0.WORD = (uint16_t) (p_config->chan_mask_groupb & 0x00FF);     //CH0 to CH7
+
+    /* Select the channels for Addition/Averaging (ch0 to ch7) */
+    p_regs->ADADS0.WORD  = (uint16_t) (p_config->add_mask & 0x00FF);             //CH0 to CH7
+
+    /* Select the channels from among Ch16 to Ch31 for conversion */
+    S12AD.ADANSA1.WORD = (uint16_t) ((p_config->chan_mask >> 16) & 0xFFFFF);      //CH16 to CH31
+
+    /* Select the channels from among Ch16 to Ch31 for conversion */
+    S12AD.ADANSB1.WORD = (uint16_t) ((p_config->chan_mask_groupb >> 16) & 0xFFFF);
+
+    /* Select the channels for Addition/Averaging (Ch16 to Ch31) */
+    S12AD.ADADS1.WORD  = (uint16_t) ((p_config->add_mask >> 16) & 0xFFFF);
+
+    /* SET GROUP A PRIORITY ACTION (not interrupt priority!) */
+
+    if (ADC_GRPA_PRIORITY_OFF != p_config->priority_groupa)
+    {
+        trig_a = p_regs->ADSTRGR.BIT.TRSA;              // save TRSA
+        trig_b = p_regs->ADSTRGR.BIT.TRSB;              // save TRSB
+        p_regs->ADSTRGR.BIT.TRSA = ADC_TRIG_NONE;
+        p_regs->ADSTRGR.BIT.TRSB = ADC_TRIG_NONE;
+        if (ADC_TRIG_NONE != p_regs->ADSTRGR.BIT.TRSA)  // bus wait for ADSTRGR write
+        {
+            R_BSP_NOP();
+        }
+        if (ADC_TRIG_NONE != p_regs->ADSTRGR.BIT.TRSB)  // bus wait for ADSTRGR write
+        {
+            R_BSP_NOP();
+        }
+
+        p_regs->ADGSPCR.WORD = p_config->priority_groupa;
+
+        p_regs->ADSTRGR.BIT.TRSA = trig_a;             // restore TRSA
+        if (1 != p_regs->ADGSPCR.BIT.GBRP)
+        {
+            p_regs->ADSTRGR.BIT.TRSB = trig_b;         // restore TRSB
+        }
+    }
+    else
+    {
+        p_regs->ADGSPCR.WORD = p_config->priority_groupa;
+    }
+
+    /* SET SELF DIAGNOSIS REGISTERS (VIRTUAL CHANNEL) */
+    if (ADC_DIAG_OFF == p_config->diag_method)
+    {
+        p_regs->ADCER.BIT.DIAGM = 0;
+    }
+    else
+    {
+
+        /* NOTE: Using Self Diagnosis adds 15(resolution) + (ch0 SST) ADCLKS to scan time.
+           (ch0 can still be used with self diagnosis on) */
+        if (ADC_DIAG_ROTATE_VOLTS == p_config->diag_method)
+        {
+            p_regs->ADCER.BIT.DIAGLD = 0;    //Rotate test voltages
+            p_regs->ADCER.BIT.DIAGVAL = 1;   //Start with 0 V
+        }
+        else
+        {
+
+            /* Make sure DIAGVAL bits are not zero before setting the DIAGLD bit */
+            p_regs->ADCER.BIT.DIAGVAL = (uint8_t)(p_config->diag_method & 0x3);   //Select diag. voltage
+            p_regs->ADCER.BIT.DIAGLD = 1;    //Do not rotate test voltages
+        }
+        p_regs->ADCER.BIT.DIAGM = 1;         //Enable self diagnosis
+    }
+
+    /* SET DOUBLE TRIGGER CHANNEL */
+    if (1 == p_regs->ADCSR.BIT.DBLE)         // If double-trigger mode is already selected.
+    {
+        tmp_mask = p_config->chan_mask;      // tmp_mask is non-Group/Group A chans
+
+        /* WAIT_LOOP */
+        while (tmp_mask >>= 1)               // determine bit/ch number
+        {
+            i++;
+        }
+        p_regs->ADCSR.BIT.DBLANS = i;
+    }
+
+    p_regs->ADELCCR.BIT.ELCC = p_config->signal_elc;
+
+    /* ENABLE INTERRUPTS */
+    adc_enable_s12adi0();
+    if (ADC_ADCS_GROUP_SCAN == p_regs->ADCSR.BIT.ADCS)
+    {
+        adc_enable_s12gbadi();
+    }
+
+    return ADC_SUCCESS;
+} /* End of function adc_configure_scan() */
+
+
+/******************************************************************************
+* Function Name: adc_check_scan_config
+* Description  : This function does extensive checking on channel mask
+*                settings based upon operational mode.
+*
+* NOTE: A negative number is stored in two's complement form.
+*       A quick way to change a binary number into two's complement is to
+*       start at the right (LSB) and moving left, don't change any bits
+*       until after the first "1" is reached.
+*       Number          2's complement
+*       0010 0110       1101 1010
+*       Another way is to do a 1's complement on the number, then add 1 to that.
+*       Number          1's complement  + 1
+*       0010 0110       1101 1001       1101 1010
+*
+* Arguments    : p_config
+*                    Pointer to channel config structure containing masks
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*                ADC_ERR_INVALID_ARG-
+*                    reg_id contains an invalid value.
+*                ADC_ERR_ILLEGAL_ARG-
+*                    an argument is illegal based upon rest of configuration
+*******************************************************************************/
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+static adc_err_t adc_check_scan_config(adc_ch_cfg_t   *p_config)
+{
+    uint32_t    tmp_mask=0;
+
+    /* Get S12AD register address */
+    aregs_t     *p_regs = (aregs_t *)&S12AD;
+
+    /* Verify at least one bonded channel is selected */
+    if ((0 == p_config->chan_mask)
+    || ((p_config->chan_mask & ADC_PRV_INVALID_CH_MASK) != 0)
+    || ((ADC_MODE_SS_TEMPERATURE == g_dcb.mode) && (ADC_MASK_TEMP != p_config->chan_mask))
+    || ((ADC_MODE_SS_INT_REF_VOLT == g_dcb.mode) && (ADC_MASK_VOLT != p_config->chan_mask)))
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+
+    /* Verify at least one unique bonded channel is selected for Group B
+     * and GroupA priority setting is valid.
+     */
+    if (ADC_ADCS_GROUP_SCAN == p_regs->ADCSR.BIT.ADCS)
+    {
+        if ((0 == p_config->chan_mask_groupb)
+        || ((p_config->chan_mask_groupb & ADC_PRV_INVALID_CH_MASK) != 0)
+        || ((ADC_MODE_SS_TEMPERATURE == g_dcb.mode) && (ADC_MASK_TEMP != p_config->chan_mask_groupb))
+        || ((ADC_MODE_SS_INT_REF_VOLT == g_dcb.mode) && (ADC_MASK_VOLT != p_config->chan_mask_groupb)))
+        {
+            return ADC_ERR_INVALID_ARG;
+        }
+        else if ((p_config->chan_mask & p_config->chan_mask_groupb) != 0)
+        {
+            return ADC_ERR_ILLEGAL_ARG;         // same chan in both groups
+        }
+        else
+        {
+            tmp_mask = p_config->chan_mask_groupb;
+        }
+    }
+    else
+    {
+
+        /* for addition mask checking */
+        if (0 != p_config->chan_mask_groupb)
+        {
+            return ADC_ERR_INVALID_ARG;
+        }
+
+        /* PGS bit must be set when group scan mode */
+        if (ADC_GRPA_PRIORITY_OFF != p_config->priority_groupa)
+        {
+            return ADC_ERR_INVALID_ARG;
+        }
+    }
+
+    /* If sensors specified, verify in legal configuation */
+    if ((ADC_MODE_SS_TEMPERATURE == g_dcb.mode) || (ADC_MODE_SS_INT_REF_VOLT == g_dcb.mode))
+    {
+        if ((1 == S12AD.ADCSR.BIT.DBLE)       // Select double trigger mode
+        || (0 != S12AD.ADDISCR.BYTE))        // disconnect detection assist enabled
+        {
+            return ADC_ERR_ILLEGAL_ARG;
+        }
+    }
+
+    /* Addition mask should not include bits from inactive channels */
+    if (ADC_ADD_OFF != p_regs->ADADC.BIT.ADC)
+    {
+        tmp_mask |= p_config->chan_mask;        // tmp_mask is Group A and B combined
+
+        /* Bit-AND with 1s-complement */
+        if ((p_config->add_mask & (~tmp_mask)) != 0)
+        {
+            return ADC_ERR_INVALID_ARG;
+        }
+    }
+    else
+    {
+
+        /* WARNING! Other features messed up if add_mask is non-zero when addition is turned off! */
+        p_config->add_mask = 0;
+    }
+
+    /* Verify only 1 bit is set in default/Group A mask */
+    if ((ADC_MODE_SS_ONE_CH == g_dcb.mode)
+    || (ADC_MODE_CONT_ONE_CH == g_dcb.mode)
+    || (1 == p_regs->ADCSR.BIT.DBLE))          // double trigger mode
+    {
+        tmp_mask = p_config->chan_mask;         // tmp_mask is non-Group/Group A chans
+
+        /* Bit-AND with 2s-complement (see note in function header) */
+        if ((tmp_mask & ((~tmp_mask) + 1)) != tmp_mask)
+        {
+            return ADC_ERR_ILLEGAL_ARG;
+        }
+    }
+
+    if ((ADC_DIAG_OFF != p_config->diag_method)
+    && ((0 != p_regs->ADADC.BIT.ADC)           // addition
+    ||  (1 == p_regs->ADCSR.BIT.DBLE)))        // double trigger mode
+    {
+        return ADC_ERR_ILLEGAL_ARG;
+    }
+
+    return ADC_SUCCESS;
+} /* End of function adc_check_scan_config() */
+#endif/* ADC_CFG_PARAM_CHECKING_ENABLE == 1 */
+
+
+/******************************************************************************
+* Function Name: adc_enable_s12gbadi
+* Description  : This function clears the S12GBADI interrupt flag and enables
+*                interrupts in the peripheral (for IR flag usage). If priority
+*                is not 0, interrupts are enabled in the ICU.
+*                NOTE: This has nothing to do with enabling triggers.
+* Arguments    : none
+* Return Value : none
+*******************************************************************************/
+static void adc_enable_s12gbadi(void)
+{
+    IR(S12AD,GBADI) = 0;            // clear flag
+    S12AD.ADCSR.BIT.GBADIE = 1;     // enable in peripheral
+    if (0 != IPR(S12AD,GBADI))
+    {
+        R_BSP_InterruptRequestEnable(VECT(S12AD,GBADI));       // enable in ICU
+    }
+} /* End of function adc_enable_s12gbadi() */
+
+
+/******************************************************************************
+* Function Name: adc_close
+* Description  : This is the RX130 implementation of R_ADC_Close().
+*                This function ends any scan in progress, disables interrupts,
+*                and removes power to the A/D peripheral.
+* Arguments    : unit - This argument is ignored for the RX130.
+* Return Value : ADC_SUCCESS - Successful
+*                ADC_ERR_INVALID_ARG - unit contains an invalid value.
+*******************************************************************************/
+adc_err_t adc_close(uint8_t const  unit)
+{
+    volatile uint8_t i;
+
+    /* Get S12AD register address */
+    aregs_t     *p_regs = (aregs_t *)&S12AD;
+
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    bsp_int_ctrl_t int_ctrl;
+#endif
+
+#if ADC_CFG_PARAM_CHECKING_ENABLE == 1
+    if (unit > 0)
+    {
+        return ADC_ERR_INVALID_ARG;
+    }
+#endif
+
+    /* Stop triggers & conversions, and disable peripheral interrupts */
+    R_BSP_InterruptRequestDisable(VECT(S12AD,S12ADI0));     // disable interrupts in ICU
+    IR(S12AD,S12ADI0) = 0;      // clear interrupt flag
+    R_BSP_InterruptRequestDisable(VECT(S12AD,GBADI));       // disable interrupts in ICU
+    IR(S12AD,GBADI) = 0;        // clear interrupt flag
+
+    p_regs->ADGSPCR.BIT.PGS = 0;
+    if (ADC_ADCS_GROUP_SCAN == p_regs->ADCSR.BIT.ADCS)
+    {
+        p_regs->ADSTRGR.WORD = 0x3F3F;
+    }
+    else
+    {
+        p_regs->ADSTRGR.BIT.TRSA = 0x3F;
+    }
+
+    p_regs->ADCSR.WORD = p_regs->ADCSR.WORD & 0x0400;
+    if (0x0000 == (p_regs->ADCSR.WORD & 0xFBFF))   // dummy read for waiting until set the value of ADCSR
+    {
+        R_BSP_NOP();
+    }
+
+    /* Wait for 2 ADCLK cycles (MAX: 128 ICLK cycles) */
+    /* WAIT_LOOP */
+    for (i = 0; i < 128; i++)
+    {
+        R_BSP_NOP();
+    }
+
+    /* Power down peripheral */
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_LPC_CGC_SWR);
+
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_DISABLE, &int_ctrl);
+#endif
+    MSTP(S12AD) = 1;
+#if ((R_BSP_VERSION_MAJOR == 5) && (R_BSP_VERSION_MINOR >= 30)) || (R_BSP_VERSION_MAJOR >= 6)
+    R_BSP_InterruptControl(BSP_INT_SRC_EMPTY, BSP_INT_CMD_FIT_INTERRUPT_ENABLE, &int_ctrl);
+#endif
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_CGC_SWR);
+
+    /* Show driver as closed */
+
+    g_dcb.opened = false;
+
+    return ADC_SUCCESS;
+} /* End of function adc_close() */
+
+
+/******************************************************************************
+* Function Name: adc_read_all
+* Description  : This is the RX130 implementation of R_ADC_ReadAll().
+*                It reads conversion results from all potential sources,
+*                enabled or not.
+* Arguments    : p_all_data-
+*                    Pointer to structure to load register values into.
+* Return Value : ADC_SUCCESS-
+*                    Successful
+*******************************************************************************/
+adc_err_t adc_read_all(adc_data_t * const  p_all_data)
+{
+    p_all_data->chan[ADC_REG_CH0]  = S12AD.ADDR0;
+    p_all_data->chan[ADC_REG_CH1]  = S12AD.ADDR1;
+    p_all_data->chan[ADC_REG_CH2]  = S12AD.ADDR2;
+    p_all_data->chan[ADC_REG_CH3]  = S12AD.ADDR3;
+    p_all_data->chan[ADC_REG_CH4]  = S12AD.ADDR4;
+    p_all_data->chan[ADC_REG_CH5]  = S12AD.ADDR5;
+    p_all_data->chan[ADC_REG_CH6]  = S12AD.ADDR6;
+    p_all_data->chan[ADC_REG_CH7]  = S12AD.ADDR7;
+
+    p_all_data->chan[ADC_REG_CH16] = S12AD.ADDR16;
+    p_all_data->chan[ADC_REG_CH17] = S12AD.ADDR17;
+    p_all_data->chan[ADC_REG_CH18] = S12AD.ADDR18;
+    p_all_data->chan[ADC_REG_CH19] = S12AD.ADDR19;
+    p_all_data->chan[ADC_REG_CH20] = S12AD.ADDR20;
+    p_all_data->chan[ADC_REG_CH21] = S12AD.ADDR21;
+    p_all_data->chan[ADC_REG_CH22] = S12AD.ADDR22;
+    p_all_data->chan[ADC_REG_CH23] = S12AD.ADDR23;
+    p_all_data->chan[ADC_REG_CH24] = S12AD.ADDR24;
+    p_all_data->chan[ADC_REG_CH25] = S12AD.ADDR25;
+    p_all_data->chan[ADC_REG_CH26] = S12AD.ADDR26;
+    p_all_data->chan[ADC_REG_CH27] = S12AD.ADDR27;
+    p_all_data->chan[ADC_REG_CH28] = S12AD.ADDR28;
+    p_all_data->chan[ADC_REG_CH29] = S12AD.ADDR29;
+    p_all_data->chan[ADC_REG_CH30] = S12AD.ADDR30;
+    p_all_data->chan[ADC_REG_CH31] = S12AD.ADDR31;
+
+    p_all_data->temp               = S12AD.ADTSDR;
+    p_all_data->volt               = S12AD.ADOCDR;
+
+    p_all_data->dbltrig            = S12AD.ADDBLDR;
+    p_all_data->self_diag          = S12AD.ADRD.WORD;
+
+    return ADC_SUCCESS;
+} /* End of function adc_read_all() */
+
+
+#endif /* #if defined BSP_MCU_RX130 */
+

--- a/drivers/rx/rdp/src/r_s12ad_rx/src/targets/rx130/r_s12ad_rx130_if.h
+++ b/drivers/rx/rdp/src/r_s12ad_rx/src/targets/rx130/r_s12ad_rx130_if.h
@@ -1,0 +1,341 @@
+/***********************************************************************************************************************
+* Copyright (c) 2016 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/**********************************************************************************************************************
+* File Name    : r_s12ad_rx130_if.h
+* Description  : 12-bit A/D Converter driver interface file.
+***********************************************************************************************************************
+* History : DD.MM.YYYY Version Description
+*           01.03.2016 1.00    Initial Release.
+*           01.10.2016 2.20    Define name commoditize for the same meaning but different name define.
+*                              Delete parameter check by the enum value.
+*                              Comparison parameter change.(adjust the parameter structure to RX65N)
+*           03.04.2017 2.30    Added RX130-512KB support.
+*           05.04.2019 4.00    Modified comment.
+*           20.03.2025 5.41    Changed the disclaimer in program sources.
+***********************************************************************************************************************/
+
+/******************************************************************************
+Includes   <System Includes> , "Project Includes"
+*******************************************************************************/
+#include "platform.h"
+
+#ifndef S12AD_PRV_RX130_IF_H
+#define S12AD_PRV_RX130_IF_H
+
+/******************************************************************************
+Macro definitions
+*******************************************************************************/
+#define ADC_SST_CNT_MIN     (5)     /* For PCLKB:ADCLK = 1:1, 1:2, 1:4, 1:8 */
+#define ADC_SST_CNT_MAX     (255)
+#define ADC_SST_CNT_DEFAULT (13)
+
+#define ADC_DDA_STATE_CNT_MIN       (2)  /* ADDISCR.ADNDIS[0..3] bits. */
+#define ADC_DDA_STATE_CNT_MAX       (15)
+
+
+/* for ADC_CMD_ENABLE_CHANS */
+/* Bitwise OR these masks together for desired channels and sensors
+   Used for all commands containing a "mask" or "flags" field */
+#define ADC_MASK_CH0    (1<<0)
+#define ADC_MASK_CH1    (1<<1)
+#define ADC_MASK_CH2    (1<<2)
+#define ADC_MASK_CH3    (1<<3)
+#define ADC_MASK_CH4    (1<<4)
+#define ADC_MASK_CH5    (1<<5)
+#define ADC_MASK_CH6    (1<<6)
+#define ADC_MASK_CH7    (1<<7)
+#define ADC_MASK_CH16   (1<<16)
+#define ADC_MASK_CH17   (1<<17)
+#define ADC_MASK_CH18   (1<<18)
+#define ADC_MASK_CH19   (1<<19)
+#define ADC_MASK_CH20   (1<<20)
+#define ADC_MASK_CH21   (1<<21)
+#define ADC_MASK_CH22   (1<<22)
+#define ADC_MASK_CH23   (1<<23)
+#define ADC_MASK_CH24   (1<<24)
+#define ADC_MASK_CH25   (1<<25)
+#define ADC_MASK_CH26   (1<<26)
+#define ADC_MASK_CH27   (1<<27)
+#define ADC_MASK_CH28   (1<<28)
+#define ADC_MASK_CH29   (1<<29)
+#define ADC_MASK_CH30   (1<<30)
+#define ADC_MASK_CH31   (1<<31)
+#define ADC_MASK_TEMP   (1<<8)     /* temperature sensor */
+#define ADC_MASK_VOLT   (1<<9)     /* internal reference voltage sensor */
+
+#define ADC_MASK_SENSORS            (ADC_MASK_TEMP | ADC_MASK_VOLT)
+#define ADC_MASK_GROUPB_OFF         (0)
+#define ADC_MASK_ADD_OFF            (0)
+#define ADC_MASK_SAMPLE_HOLD_OFF    (0)
+
+
+/*****************************************************************************
+Typedef definitions
+******************************************************************************/
+
+/***** ADC_OPEN() ARGUMENT DEFINITIONS *****/
+
+typedef enum e_adc_mode
+{
+    ADC_MODE_SS_TEMPERATURE,        // single scan temperature sensor
+    ADC_MODE_SS_INT_REF_VOLT,       // single scan internal ref voltage sensor
+    ADC_MODE_SS_ONE_CH,             // single scan one channel
+    ADC_MODE_SS_MULTI_CH,           // 1 trigger source, scan multiple channels
+    ADC_MODE_CONT_ONE_CH,           // continuous scan one channel
+    ADC_MODE_CONT_MULTI_CH,         // continuous scan multiple channels
+    ADC_MODE_SS_ONE_CH_DBLTRIG,     // on even triggers save to ADDBLDR & interrupt
+    ADC_MODE_SS_MULTI_CH_GROUPED,   // 2 trigger sources, scan multiple channels
+    ADC_MODE_SS_MULTI_CH_GROUPED_DBLTRIG_A,
+    ADC_MODE_MAX                    // This definition DO NOT USE for R_ADC_Open() argument
+} adc_mode_t;
+
+typedef enum e_adc_align
+{
+    ADC_ALIGN_RIGHT = 0x0000,
+    ADC_ALIGN_LEFT  = 0x8000
+} adc_align_t;
+
+typedef enum e_adc_add               // Addition and averaging of sampled data.
+{
+    ADC_ADD_OFF             = 0,     // addition is turned off for chans/sensors
+    ADC_ADD_TWO_SAMPLES     = 1,     // Two samples are added,Register ADADC.ADC[1,0]
+    ADC_ADD_THREE_SAMPLES   = 2,     // Three samples are added
+    ADC_ADD_FOUR_SAMPLES    = 3,     // Four samples are added
+    ADC_ADD_SIXTEEN_SAMPLES = 5,     // Sixteen samples are added
+    ADC_ADD_AVG_2_SAMPLES   = 0x81,  // average 2 samples
+    ADC_ADD_AVG_4_SAMPLES   = 0x83,  // average 4 samples
+} adc_add_t;
+
+typedef enum e_adc_clear
+{
+    ADC_CLEAR_AFTER_READ_OFF = 0x0000,
+    ADC_CLEAR_AFTER_READ_ON  = 0x0020
+} adc_clear_t;
+
+
+typedef enum e_adc_trig              // trigger sources (set to TRSA bit or TRSB bit)
+{
+    ADC_TRIG_ASYNC_ADTRG            = 0,    /* external asynchronous trigger; not for Group modes
+                                               nor double trigger modes */
+    ADC_TRIG_SYNC_TRG0AN            = 1,    // MTU0 TRGA
+    ADC_TRIG_SYNC_TRG0BN            = 2,    // MTU0 TRGB
+    ADC_TRIG_SYNC_TRGAN_OR_UDF4N    = 3,    // MTUx TRGA or MTU4 underflow(complementary PWM mode)
+    ADC_TRIG_SYNC_TRG0EN            = 4,    // MTU0 TRGE
+    ADC_TRIG_SYNC_TRG0FN            = 5,    // MTU0 TRGF
+    ADC_TRIG_SYNC_TRG4AN            = 6,    // MTU4 TADCORA
+    ADC_TRIG_SYNC_TRG4BN            = 7,    // MTU4 TADCORB
+    ADC_TRIG_SYNC_TRG4AN_AND_TRG4BN = 8,    // MTU4 TADCORA and MTU4 TADCORB
+    ADC_TRIG_SYNC_ELC               = 9,    // ELC
+
+    ADC_TRIG_SOFTWARE               = 10,   /* software trigger; not for Group modes
+                                               nor double trigger modes
+                                               This is not set to TRSA or TRSB */
+    ADC_TRIG_NONE                   = 0x3F
+} adc_trig_t;
+
+typedef enum e_adc_speed
+{
+    ADC_CONVERT_SPEED_DEFAULT = 0,
+    ADC_CONVERT_SPEED_HIGH    = 0,
+    ADC_CONVERT_CURRENT_LOW   = 1
+} adc_speed_t;
+
+typedef struct st_adc_cfg
+{
+    adc_speed_t     conv_speed;      // ADCSR.ADHSC, rx130 has two conversion speeds
+    adc_align_t     alignment;       // ADCER.ADRFMT, Left or Right alignment,ignored if addition used
+    adc_add_t       add_cnt;         // ADADC.ADC, Addition/average count select.
+    adc_clear_t     clearing;        // ADCER.ACE, Automatic clearing enable/disable after read
+    adc_trig_t      trigger;         // ADSTRGR.TRSA, default and Group A trigger source
+    adc_trig_t      trigger_groupb;  // valid only for group modes
+    uint8_t         priority;        // for S12ADIO int; 1=lo 15=hi 0=off/polled
+    uint8_t         priority_groupb; // S12GBADI interrupt priority; 0-15
+} adc_cfg_t;
+
+
+/***** ADC_CONTROL() ARGUMENT DEFINITIONS *****/
+
+typedef enum e_adc_cmd
+{
+    /* Commands for special hardware configurations */
+    ADC_CMD_USE_VREFL0,             // Low reference. Default is to use AVSS0.
+    ADC_CMD_USE_VREFH0,             // High reference. Default is to use AVCC0.
+    ADC_CMD_SET_DDA_STATE_CNT,      // For Disconnect Detection Assist
+    ADC_CMD_SET_SAMPLE_STATE_CNT,   // Set the conversion time
+
+    /* Command to configure channels, sensors, and comparator */
+    ADC_CMD_ENABLE_CHANS,           // Configure channels to scan
+    ADC_CMD_ENABLE_TEMP_SENSOR,     // "configure" temperature sensor
+    ADC_CMD_ENABLE_VOLT_SENSOR,     // "configure" internal ref voltage sensor
+    ADC_CMD_EN_COMPARATOR_LEVEL,    // Enable comparator for threshold compare
+    ADC_CMD_EN_COMPARATOR_WINDOW,   // Enable comparator for range compare
+
+    /* Commands to enable hardware triggers or cause software trigger */
+    ADC_CMD_ENABLE_TRIG,            // ADCSR.TRGE=1 for sync/asynchronous triggers
+    ADC_CMD_SCAN_NOW,               // Software trigger start scan
+
+    /* Commands to poll for scan completion and comparator results */
+    ADC_CMD_CHECK_SCAN_DONE,        // For Normal or GroupA scan
+    ADC_CMD_CHECK_SCAN_DONE_GROUPA,
+    ADC_CMD_CHECK_SCAN_DONE_GROUPB,
+    ADC_CMD_CHECK_CONDITION_MET,    // comparator condition
+
+    /* Advanced control commands */
+    ADC_CMD_DISABLE_TRIG,           // ADCSR.TRGE=0 for sync/async trigs
+    ADC_CMD_DISABLE_INT,            // interrupt disable; ADCSR.ADIE=0
+    ADC_CMD_ENABLE_INT,             // interrupt enable;  ADCSR.ADIE=1
+    ADC_CMD_DISABLE_INT_GROUPB,     // interrupt disable; ADCSR.GBADIE=0
+    ADC_CMD_ENABLE_INT_GROUPB       // interrupt enable;  ADCSR.GBADIE=1
+} adc_cmd_t;
+
+
+/* for ADC_CMD_SET_DDA_STATE_CNT */
+
+typedef enum e_adc_charge           // Disconnection Detection Assist (DDA)
+{
+    ADC_DDA_DISCHARGE = 0x00,
+    ADC_DDA_PRECHARGE = 0x01,
+    ADC_DDA_OFF       = 0x02
+} adc_charge_t;
+
+
+typedef struct st_adc_dda
+{
+    adc_charge_t    method;         // Discharge or Precharge
+    uint8_t         num_states;     // 2-15 (0 = DISABLED, 1 is invalid)
+} adc_dda_t;
+
+
+/* for ADC_CMD_SET_SAMPLE_STATE_CNT */
+
+typedef enum e_adc_sst_reg          // sample state registers
+{
+    ADC_SST_CH0 = 0,
+    ADC_SST_CH1,
+    ADC_SST_CH2,
+    ADC_SST_CH3,
+    ADC_SST_CH4,
+    ADC_SST_CH5,
+    ADC_SST_CH6,
+    ADC_SST_CH7,
+    ADC_SST_CH16_TO_21_CH24_TO_CH26,                        // Use for ADSSTRL register(except RX130-512KB)
+    ADC_SST_CH16_TO_31 = ADC_SST_CH16_TO_21_CH24_TO_CH26,   // Use for ADSSTRL register(RX130-512KB)
+    ADC_SST_TEMPERATURE,
+    ADC_SST_VOLTAGE,
+    ADC_SST_REG_MAX = ADC_SST_VOLTAGE
+} adc_sst_reg_t;
+
+
+typedef struct st_adc_sst
+{
+    adc_sst_reg_t   reg_id;
+    uint8_t         num_states;     // ch16-21, 24-26 use the same value
+} adc_sst_t;
+
+
+typedef enum e_adc_grpa                 // action when groupa interrupts groupb scan
+{
+    ADC_GRPA_PRIORITY_OFF = 0,          // groupa ignored and does not interrupt groupb
+    ADC_GRPA_GRPB_WAIT_TRIG = 1,        // groupb restarts at next trigger
+    ADC_GRPA_GRPB_RESTART_SCAN = 3,     // groupb restarts immediately
+    ADC_GRPA_GRPB_CONT_SCAN= 0x8001,    // groupb restarts immediately and scans continuously
+} adc_grpa_t;
+
+typedef enum e_adc_diag                 // Self-Diagnosis Channel
+{
+    ADC_DIAG_OFF          = 0x00,
+    ADC_DIAG_0_VOLT       = 0x01,
+    ADC_DIAG_HALF_VREFH0  = 0x02,
+    ADC_DIAG_VREFH0       = 0x03,
+    ADC_DIAG_ROTATE_VOLTS = 0x04
+} adc_diag_t;
+
+typedef enum e_adc_elc
+{
+    ADC_ELC_SCAN_DONE = 0,              // normal scan or Group A scan complete
+    ADC_ELC_GROUPB_SCAN_DONE,
+    ADC_ELC_ALL_SCANS_DONE
+} adc_elc_t;
+
+typedef struct st_adc_ch_cfg
+{
+    uint32_t        chan_mask;          // channels/bits 0-7, 16-21, 24-26
+    uint32_t        chan_mask_groupb;   // valid for group modes
+    adc_grpa_t      priority_groupa;    // valid for group modes
+    uint32_t        add_mask;           // valid if add enabled in Open()
+    adc_diag_t      diag_method;        // self-diagnosis virtual channel
+    adc_elc_t       signal_elc;         //
+} adc_ch_cfg_t;
+
+
+/* for ADC_CMD_EN_COMPARATOR_LEVEL and ADC_CMD_EN_COMPARATOR_WINDOW */
+
+typedef struct st_adc_cmpwin_cfg        // bit-OR ADC_MASK_xxx to indicate channels/sensors
+{
+    uint32_t        compare_mask;       // channels/sensors to compare
+    uint32_t        inside_window_mask; /* condition met when within range
+                                           default=0 met when outside range */
+    uint16_t        level_lo;           // Low-value of window
+    uint16_t        level_hi;           // High-value of window
+    bool            windowa_enable;     // comparison window A enable
+} adc_cmpwin_t;
+
+
+/* for ADC_CMD_CHECK_CONDITION_MET use uint32_t */
+
+/***** ADC_READ() ARGUMENT DEFINITIONS *****/
+typedef enum e_adc_reg
+{
+    ADC_REG_CH0  = 0,     // Channel 0
+    ADC_REG_CH1,
+    ADC_REG_CH2,
+    ADC_REG_CH3,
+    ADC_REG_CH4,
+    ADC_REG_CH5,
+    ADC_REG_CH6,
+    ADC_REG_CH7,          // Channel 7
+    ADC_REG_CH16,         // Channel 16
+    ADC_REG_CH17,
+    ADC_REG_CH18,
+    ADC_REG_CH19,
+    ADC_REG_CH20,
+    ADC_REG_CH21,
+    ADC_REG_CH22,
+    ADC_REG_CH23,
+    ADC_REG_CH24,
+    ADC_REG_CH25,
+    ADC_REG_CH26,
+    ADC_REG_CH27,
+    ADC_REG_CH28,
+    ADC_REG_CH29,
+    ADC_REG_CH30,
+    ADC_REG_CH31,
+    ADC_REG_TEMP,         // A/D Temperature sensor output
+    ADC_REG_VOLT,         // A/D Internal Voltage Reference
+    ADC_REG_DBLTRIG,      // Data Duplication register
+    ADC_REG_SELF_DIAG,    // self-diagnosis register
+    ADC_REG_MAX = ADC_REG_SELF_DIAG
+} adc_reg_t;
+
+/* ADC_READALL() ARGUMENT DEFINITIONS */
+
+typedef struct st_adc_data
+{
+    uint16_t    chan[24];
+    uint16_t    temp;
+    uint16_t    volt;
+    uint16_t    dbltrig;
+    uint16_t    self_diag;
+} adc_data_t;
+
+
+
+/*****************************************************************************
+Public Functions
+******************************************************************************/
+
+#endif /* S12AD_PRV_RX130_IF_H */
+

--- a/zephyr/rx/rdp_cfg/r_config/r_s12ad_rx_config.h
+++ b/zephyr/rx/rdp_cfg/r_config/r_s12ad_rx_config.h
@@ -1,0 +1,30 @@
+/***********************************************************************************************************************
+* Copyright (c) 2013 Renesas Electronics Corporation and/or its affiliates
+*
+* SPDX-License-Identifier: BSD-3-Clause
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name     : r_s12ad_rx_config.h
+* Description   : Configures the 12-bit A/D driver
+************************************************************************************************************************
+* History : DD.MM.YYYY Version Description
+*           22.07.2013 1.00    Initial Release.
+*           21.04.2014 1.20    Updated for RX210 advanced features; RX110/63x support.
+*           05.04.2019 4.00    Deleted the macro definition of ADC_CFG_PGA_GAIN.
+*           20.03.2025 5.41    Changed the disclaimer in program sources.
+***********************************************************************************************************************/
+#ifndef S12AD_CONFIG_H
+#define S12AD_CONFIG_H
+
+/***********************************************************************************************************************
+Configuration Options
+***********************************************************************************************************************/
+
+/*
+ * SPECIFY WHETHER TO INCLUDE CODE FOR API PARAMETER CHECKING
+ * Setting to BSP_CFG_PARAM_CHECKING_ENABLE utilizes the system default setting.
+ * Setting to 1 includes parameter checking; 0 compiles out parameter checking.
+ */
+#define ADC_CFG_PARAM_CHECKING_ENABLE   BSP_CFG_PARAM_CHECKING_ENABLE
+
+#endif /* S12AD_CONFIG_H */


### PR DESCRIPTION
Add HAL support for ADC on Renesas RX, the first target is for RX130 MCU
This was based on r_s12ad_rx of RDP v1.47
