### PR TITLE
hal: renesas: rx: replace the MHZ with FL_MHZ in flash source

### DIFF
--- a/drivers/rx/README
+++ b/drivers/rx/README
@@ -45,6 +45,7 @@ Patch List:
       drivers/rx/rdp/src/r_bsp/mcu/all/r_rx_compiler.h
       drivers/rx/rdp/src/r_flash_rx/src/r_flash_group.c
       drivers/rx/rdp/src/r_flash_rx/src/r_flash_nofcu.h
+      drivers/rx/rdp/src/r_flash_rx/src/r_flash_nofcu.c
       drivers/rx/rdp/src/r_flash_rx/src/r_flash_rx.c
       drivers/rx/rdp/src/r_flash_rx/src/r_flash_rx.h
 

--- a/drivers/rx/rdp/src/r_flash_rx/src/r_flash_nofcu.c
+++ b/drivers/rx/rdp/src/r_flash_rx/src/r_flash_nofcu.c
@@ -95,7 +95,7 @@ static void flash_df_pe_mode_enter(void)
     flash_write_fpmcr(DATAFLASH_PE_MODE);
 
     FLASH.FISR.BIT.PCKA = (FLASH_FISR_FCLK_FREQ < MCU_CFG_FCLK_HZ) ? 
-        (FCLK_MHZ - (((FCLK_MHZ - (FLASH_FISR_FCLK_FREQ / MHZ)) / 2)) - 1) : FCLK_MHZ - 1;
+        (FCLK_MHZ - (((FCLK_MHZ - (FLASH_FISR_FCLK_FREQ / FL_MHZ)) / 2)) - 1) : FCLK_MHZ - 1;
 #else
     if (OPCCR_HIGH_SPEED_MODE == SYSTEM.OPCCR.BIT.OPCM)
     {
@@ -702,7 +702,7 @@ static void flash_cf_pe_mode_enter(void)
     flash_write_fpmcr(CODEFLASH_PE_MODE);
 
     FLASH.FISR.BIT.PCKA = (FLASH_FISR_FCLK_FREQ < MCU_CFG_FCLK_HZ) ? 
-        (FCLK_MHZ - (((FCLK_MHZ - (FLASH_FISR_FCLK_FREQ / MHZ)) / 2)) - 1) : FCLK_MHZ - 1;
+        (FCLK_MHZ - (((FCLK_MHZ - (FLASH_FISR_FCLK_FREQ / FL_MHZ)) / 2)) - 1) : FCLK_MHZ - 1;
 #else
     flash_write_fpmcr(DISCHARGE_1);
 


### PR DESCRIPTION
Commit [cc6dd8c ](https://github.com/zephyrproject-rtos/hal_renesas/pull/96/commits/5fa8537d52bfd6d11bd554fdcb1be634ba44f126) replaced MHZ by FL_MHZ to fix the build warning related to re-defined but the `r_flash_nofcu.c` not updated yet.
Fixes #96 