### PR TITLE
hal: renesas: rz: Improve GTM ISR Prototype for RZ/G, RZ/V

### DIFF
--- a/drivers/rz/README
+++ b/drivers/rz/README
@@ -81,3 +81,10 @@ Patch List:
    Impacted files:
       drivers/rz/fsp/src/rzg/r_adc_c/r_adc_c.c
       drivers/rz/fsp/inc/instances/rzg/r_adc_c.h
+
+   * Modify the ISR prototype from void gtm_int_isr(void) to void gtm_int_isr(IRQn_Type const intid)
+     in the GTM FSP driver to unify with rza-fsp, making the Zephyr Counter driver and System Timer
+     driver generic
+   Impacted files:
+      drivers/rz/fsp/src/rzg/r_gtm/r_gtm.c
+      drivers/rz/fsp/src/rzv/r_gtm/r_gtm.c

--- a/drivers/rz/fsp/src/rzg/r_gtm/r_gtm.c
+++ b/drivers/rz/fsp/src/rzg/r_gtm/r_gtm.c
@@ -40,7 +40,7 @@ static fsp_err_t r_gtm_open_param_checking(gtm_instance_ctrl_t * p_instance_ctrl
 #endif
 
 /* ISRs. */
-void gtm_int_isr(void);
+void gtm_int_isr(IRQn_Type const intid);
 
 /***********************************************************************************************************************
  * Private global variables
@@ -522,10 +522,12 @@ static uint32_t r_gtm_clock_frequency_get (R_GTM0_Type * p_gtm_regs)
 /*********************************************************************************************************************
  * GTM counter underflow interrupt.
  **********************************************************************************************************************/
-void gtm_int_isr (void)
+void gtm_int_isr (IRQn_Type const intid)
 {
     /* Save context if RTOS is used */
     FSP_CONTEXT_SAVE
+
+    FSP_PARAMETER_NOT_USED(intid);
 
     IRQn_Type irq = R_FSP_CurrentIrqGet();
 

--- a/drivers/rz/fsp/src/rzv/r_gtm/r_gtm.c
+++ b/drivers/rz/fsp/src/rzv/r_gtm/r_gtm.c
@@ -40,7 +40,7 @@ static fsp_err_t r_gtm_open_param_checking(gtm_instance_ctrl_t * p_instance_ctrl
 #endif
 
 /* ISRs. */
-void gtm_int_isr(void);
+void gtm_int_isr(IRQn_Type const intid);
 
 /***********************************************************************************************************************
  * Private global variables
@@ -567,10 +567,12 @@ static uint32_t r_gtm_clock_frequency_get (R_GTM0_Type * p_gtm_regs)
 /*********************************************************************************************************************
  * GTM counter underflow interrupt.
  **********************************************************************************************************************/
-void gtm_int_isr (void)
+void gtm_int_isr (IRQn_Type const intid)
 {
     /* Save context if RTOS is used */
     FSP_CONTEXT_SAVE
+
+    FSP_PARAMETER_NOT_USED(intid);
 
     IRQn_Type irq = R_FSP_CurrentIrqGet();
 


### PR DESCRIPTION
Standardize the gtm isr prototype to `void gtm_int_isr(IRQn_Type const irq);` for rzg-fsp and rzv-fsp to unify with rza-fsp according to community feedback