### PR TITLE
cmac, da1469x_hal: add define guards around min

### DIFF
--- a/smartbond/cmac/mbox.c
+++ b/smartbond/cmac/mbox.c
@@ -23,7 +23,9 @@
 #include <shm.h>
 #include <mbox.h>
 
+#ifndef min
 #define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
 
 static struct cmac_shm_mbox *
 mbox_src_get(uint16_t *size)

--- a/smartbond/da1469x_hal/da1469x_trimv.c
+++ b/smartbond/da1469x_hal/da1469x_trimv.c
@@ -24,7 +24,9 @@
 #include <da1469x_trimv.h>
 #include <da1469x_otp.h>
 
+#ifndef min
 #define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
 
 #define GROUP_ID_MAX            (MCU_TRIMV_GROUP_ID_MAX)
 


### PR DESCRIPTION
Add define guards around the min definition so it does not colled with the upstream one.