### PR TITLE
hal: renesas: ra: Update the condition for assigning OFS value

### DIFF
--- a/drivers/ra/README
+++ b/drivers/ra/README
@@ -181,3 +181,5 @@ Patch List:
       Impacted files:
          drivers/ra/fsp/src/bsp/mcu/ra8d2/bsp_linker.c
          drivers/ra/fsp/src/bsp/mcu/ra8m2/bsp_linker.c
+         drivers/ra/fsp/src/bsp/mcu/ra8p1/bsp_linker.c
+         drivers/ra/fsp/src/bsp/mcu/ra8t2/bsp_linker.c

--- a/drivers/ra/fsp/src/bsp/mcu/ra8p1/bsp_linker.c
+++ b/drivers/ra/fsp/src/bsp/mcu/ra8p1/bsp_linker.c
@@ -9,7 +9,7 @@
 /* UNCRUSTIFY-OFF */
 
 /* boot loaded applications cannot set ofs registers (only do so in the boot loader) */
-#ifndef BSP_BOOTLOADED_APPLICATION
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
 /** configuration register output to sections */
 #if defined BSP_CFG_OPTION_SETTING_OFS0 && !BSP_TZ_NONSECURE_BUILD && (BSP_CFG_CPU_CORE == 0)
 BSP_DONT_REMOVE static const uint32_t BSP_PLACE_IN_SECTION(".option_setting_ofs0") g_bsp_cfg_option_setting_ofs0[] = {BSP_CFG_OPTION_SETTING_OFS0};

--- a/drivers/ra/fsp/src/bsp/mcu/ra8t2/bsp_linker.c
+++ b/drivers/ra/fsp/src/bsp/mcu/ra8t2/bsp_linker.c
@@ -9,7 +9,7 @@
 /* UNCRUSTIFY-OFF */
 
 /* boot loaded applications cannot set ofs registers (only do so in the boot loader) */
-#ifndef BSP_BOOTLOADED_APPLICATION
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
 /** configuration register output to sections */
 #if defined BSP_CFG_OPTION_SETTING_OFS0 && !BSP_TZ_NONSECURE_BUILD && (BSP_CFG_CPU_CORE == 0)
 BSP_DONT_REMOVE static const uint32_t BSP_PLACE_IN_SECTION(".option_setting_ofs0") g_bsp_cfg_option_setting_ofs0[] = {BSP_CFG_OPTION_SETTING_OFS0};


### PR DESCRIPTION
Update `bsp_linker.c` condition to check `CONFIG_BOOTLOADER_MCUBOOT` and `CONFIG_SOC_RA_SECOND_CORE_BUILD`