### PR TITLE
hal: renesas: ra: Update CONFIG_USE_RA_FSP_I2C_IIC to align with Zephyr rule

### DIFF
--- a/drivers/ra/CMakeLists.txt
+++ b/drivers/ra/CMakeLists.txt
@@ -50,9 +50,9 @@ zephyr_library_sources_ifdef(CONFIG_USE_RA_FSP_TIMER_ULPT
 	fsp/src/r_ulpt/r_ulpt.c)
 zephyr_library_sources_ifdef(CONFIG_USE_RA_FSP_LPM
 	fsp/src/r_lpm/r_lpm.c)
-zephyr_library_sources_ifdef(CONFIG_USE_RA_FSP_I2C_IIC_MASTER
+zephyr_library_sources_ifdef(CONFIG_USE_RA_FSP_I2C_IIC_CONTROLLER
 	fsp/src/r_iic_master/r_iic_master.c)
-zephyr_library_sources_ifdef(CONFIG_USE_RA_FSP_I2C_IIC_SLAVE
+zephyr_library_sources_ifdef(CONFIG_USE_RA_FSP_I2C_IIC_TARGET
 	fsp/src/r_iic_slave/r_iic_slave.c)
 zephyr_library_sources_ifdef(CONFIG_USE_RA_FSP_SCI_I2C
 	fsp/src/r_sci_i2c/r_sci_i2c.c)

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2a1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2a1/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_QFN
 #define BSP_PACKAGE_PINS (40)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2l1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra2l1/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_HWQFN
 #define BSP_PACKAGE_PINS (48)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4c1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4c1/bsp_mcu_device_pn_cfg.h
@@ -19,8 +19,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 2)
 #define BSP_PACKAGE_LQFP
 #define BSP_PACKAGE_PINS (100)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e1/bsp_mcu_device_pn_cfg.h
@@ -19,8 +19,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 2)
 #define BSP_PACKAGE_QFN
 #define BSP_PACKAGE_PINS (48)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4e2/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_BGA
 #define BSP_PACKAGE_PINS (36)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4l1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4l1/bsp_mcu_device_pn_cfg.h
@@ -34,8 +34,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 7)
 #define BSP_PACKAGE_WLCSP
 #define BSP_PACKAGE_PINS (72)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m1/bsp_mcu_device_pn_cfg.h
@@ -34,8 +34,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 7)
 #define BSP_PACKAGE_QFN
 #define BSP_PACKAGE_PINS (40)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m2/bsp_mcu_device_pn_cfg.h
@@ -25,8 +25,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 4)
 #define BSP_PACKAGE_LQFP
 #define BSP_PACKAGE_PINS (48)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m3/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4m3/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_LQFP
 #define BSP_PACKAGE_PINS (100)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4t1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra4t1/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_QFN
 #define BSP_PACKAGE_PINS (32)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e1/bsp_mcu_device_pn_cfg.h
@@ -22,8 +22,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 3)
 #define BSP_PACKAGE_QFN
 #define BSP_PACKAGE_PINS (48)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6e2/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_BGA
 #define BSP_PACKAGE_PINS (36)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m1/bsp_mcu_device_pn_cfg.h
@@ -25,8 +25,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 4)
 #define BSP_PACKAGE_QFN
 #define BSP_PACKAGE_PINS (64)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m2/bsp_mcu_device_pn_cfg.h
@@ -22,8 +22,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 3)
 #define BSP_PACKAGE_LGA
 #define BSP_PACKAGE_PINS (145)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m3/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m3/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_LGA
 #define BSP_PACKAGE_PINS (145)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m4/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m4/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_LQFP
 #define BSP_PACKAGE_PINS (100)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m5/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra6m5/bsp_mcu_device_pn_cfg.h
@@ -28,8 +28,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 5)
 #define BSP_PACKAGE_LQFP
 #define BSP_PACKAGE_PINS (100)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d1/bsp_mcu_device_pn_cfg.h
@@ -18,8 +18,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 2)
 #define BSP_PACKAGE_LQFP
 #define BSP_PACKAGE_PINS (176)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8d2/bsp_mcu_device_pn_cfg.h
@@ -22,8 +22,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 3)
 #define BSP_PACKAGE_LFBGA
 #define BSP_PACKAGE_PINS (303)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m1/bsp_mcu_device_pn_cfg.h
@@ -24,8 +24,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 4)
 #define BSP_PACKAGE_LQFP
 #define BSP_PACKAGE_PINS (100)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8m2/bsp_mcu_device_pn_cfg.h
@@ -25,8 +25,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 4)
 #define BSP_PACKAGE_HLQFP
 #define BSP_PACKAGE_PINS (176)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8p1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8p1/bsp_mcu_device_pn_cfg.h
@@ -22,8 +22,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 3)
 #define BSP_PACKAGE_LFBGA
 #define BSP_PACKAGE_PINS (303)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t1/bsp_mcu_device_pn_cfg.h
@@ -24,8 +24,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 4)
 #define BSP_PACKAGE_LQFP
 #define BSP_PACKAGE_PINS (100)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */

--- a/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t2/bsp_mcu_device_pn_cfg.h
+++ b/zephyr/ra/ra_cfg/fsp_cfg/bsp/ra8t2/bsp_mcu_device_pn_cfg.h
@@ -25,8 +25,6 @@
 #elif (CONFIG_RENESAS_PN_PACKAGE_TYPE == 4)
 #define BSP_PACKAGE_HLQFP
 #define BSP_PACKAGE_PINS (176)
-#else
-#error "Invalid Package type"
 #endif
 
 #endif /* BSP_MCU_DEVICE_PN_CFG_H_ */


### PR DESCRIPTION
- Update `CONFIG_USE_RA_FSP_I2C_IIC` since the old name is not appropriate with the Zephyr rule (https://github.com/zephyrproject-rtos/zephyr/pull/102082#discussion_r2681088220)
- Since the PR updating the part number in Zephyr has not been merged yet, all current PRs that update `hal_renesas` revision to latest will conflict with the `hal_renesas` updates of `i2c_target` and `bsp_mcu_device_pn_cfg`. As a workaround, I updated `bsp_mcu_device_pn_cfg` to resolve the `i2c_target` conflict