### PR TITLE
hal: renesas: rx: Made the group interrupt handler global

### DIFF
--- a/drivers/rx/README
+++ b/drivers/rx/README
@@ -86,6 +86,7 @@ Patch List:
    * Made the group interrupt handler a global variable.
    Impacted files:
       drivers/rx/rdp/src/r_bsp/mcu/all/r_bsp_interrupts.c
+      drivers/rx/rdp/src/r_bsp/mcu/rx26t/mcu_interrupts.c
 
    * Added a new function based on R_BSP_InterruptWrite
    that allows passing a user-defined argument to the registered interrupt handler.

--- a/drivers/rx/rdp/src/r_bsp/mcu/rx26t/mcu_interrupts.c
+++ b/drivers/rx/rdp/src/r_bsp/mcu/rx26t/mcu_interrupts.c
@@ -213,7 +213,7 @@ bsp_int_err_t bsp_interrupt_enable_disable (bsp_int_src_t vector, bool enable)
 * Arguments    : None
 * Return Value : None
 ***********************************************************************************************************************/
-R_BSP_ATTRIB_STATIC_INTERRUPT void group_bl0_handler_isr (void)
+void group_bl0_handler_isr (void)
 {
     /* BL0 IS3 */
     if (1 == ICU.GRPBL0.BIT.IS3)
@@ -338,7 +338,7 @@ R_BSP_ATTRIB_STATIC_INTERRUPT void group_bl0_handler_isr (void)
 * Arguments    : None
 * Return Value : None
 ***********************************************************************************************************************/
-R_BSP_ATTRIB_STATIC_INTERRUPT void group_bl1_handler_isr (void)
+void group_bl1_handler_isr (void)
 {
     /* BL1 IS0 */
     if (1 == ICU.GRPBL1.BIT.IS0)
@@ -505,7 +505,7 @@ R_BSP_ATTRIB_STATIC_INTERRUPT void group_bl1_handler_isr (void)
 * Arguments    : None
 * Return Value : None
 ***********************************************************************************************************************/
-R_BSP_ATTRIB_STATIC_INTERRUPT void group_bl2_handler_isr (void)
+void group_bl2_handler_isr (void)
 {
     /* BL2 IS1 */
     if (1 == ICU.GRPBL2.BIT.IS1)
@@ -560,7 +560,7 @@ R_BSP_ATTRIB_STATIC_INTERRUPT void group_bl2_handler_isr (void)
 * Arguments    : None
 * Return Value : None
 ***********************************************************************************************************************/
-R_BSP_ATTRIB_STATIC_INTERRUPT void group_al0_handler_isr (void)
+void group_al0_handler_isr (void)
 {
     /* AL0 IS13 */
     if (1 == ICU.GRPAL0.BIT.IS13)
@@ -622,7 +622,7 @@ R_BSP_ATTRIB_STATIC_INTERRUPT void group_al0_handler_isr (void)
 * Arguments    : None
 * Return Value : None
 ***********************************************************************************************************************/
-R_BSP_ATTRIB_STATIC_INTERRUPT void group_al1_handler_isr (void)
+void group_al1_handler_isr (void)
 {
     /* AL1 IS13 */
     if (1 == ICU.GRPAL1.BIT.IS13)


### PR DESCRIPTION
PR #142 is missing the removal of `R_BSP_ATTRIB_STATIC_INTERRUPT` from mcu_interrupt.c to make the function non-static.