### PR TITLE
hal: renesas: ra: Add support for 5-pipe USBFS peripherals (RA2L2, RA2A1, RA4E2, RA6E2, RA6T3)

### DIFF
--- a/drivers/ra/fsp/src/r_usb_device/r_usb_device.c
+++ b/drivers/ra/fsp/src/r_usb_device/r_usb_device.c
@@ -600,7 +600,7 @@ fsp_err_t R_USBD_EdptClearStall (usbd_ctrl_t * const p_api_ctrl, uint8_t ep_addr
     }
     else
     {
-#ifdef USB_HIGH_SPEED_MODULE
+#if defined(USB_HIGH_SPEED_MODULE)
         if (USB_IS_USBHS(p_ctrl->p_cfg->module_number))
         {
             R_USB_HS0->PIPESEL = num;
@@ -652,6 +652,15 @@ static inline uint16_t get_edpt_packet_size (usbd_instance_ctrl_t * const p_ctrl
 /* get the available pipe can be used to configure for new endpoint */
 static uint32_t find_pipe (usbd_instance_ctrl_t * const p_ctrl, uint32_t xfer_type)
 {
+#if BSP_FEATURE_USB_HAS_PIPE04567
+    const uint8_t pipe_idx_arr[4][2] =
+    {
+        {0, 0},                        // Control
+        {7, 7},                        // Isochronous
+        {4, 5},                        // Bulk
+        {6, 6},                        // Interrupt
+    };
+#else
     const uint8_t pipe_idx_arr[4][2] =
     {
         {0, 0},                        // Control
@@ -659,6 +668,7 @@ static uint32_t find_pipe (usbd_instance_ctrl_t * const p_ctrl, uint32_t xfer_ty
         {1, 5},                        // Bulk
         {6, 9},                        // Interrupt
     };
+#endif
 
     /* find backward since only pipe 1, 2 support ISO */
     const uint8_t idx_first = pipe_idx_arr[xfer_type][0];
@@ -780,10 +790,17 @@ static inline void pipe_wait_for_ready (usbd_instance_ctrl_t * const p_ctrl, uin
     }
     else
 #endif
+#if BSP_FEATURE_USB_HAS_PIPE04567
+    {
+        FSP_HARDWARE_REGISTER_WAIT(R_USB_FS0->CFIFOSEL_b.CURPIPE, num);
+        FSP_HARDWARE_REGISTER_WAIT(R_USB_FS0->CFIFOCTR_b.FRDY, 1);
+    }
+#else
     {
         FSP_HARDWARE_REGISTER_WAIT(R_USB_FS0->D0FIFOSEL_b.CURPIPE, num);
         FSP_HARDWARE_REGISTER_WAIT(R_USB_FS0->D0FIFOCTR_b.FRDY, 1);
     }
+#endif
 }
 
 /* write data buffer --> hw fifo */
@@ -931,11 +948,15 @@ static inline bool pipe0_xfer_out (usbd_instance_ctrl_t * const p_ctrl)
 /* process IN direction transfer for common pipe */
 static inline bool pipe_xfer_in (usbd_instance_ctrl_t * const p_ctrl, uint8_t num)
 {
-#ifdef USB_HIGH_SPEED_MODULE
+#if defined(USB_HIGH_SPEED_MODULE)
     bool                hs_module = USB_IS_USBHS(p_ctrl->p_cfg->module_number);
     volatile uint16_t * d0fifosel = hs_module ? &R_USB_HS0->D0FIFOSEL : &R_USB_FS0->D0FIFOSEL;
     volatile void     * d0fifo    = hs_module ? &R_USB_HS0->D0FIFO : &R_USB_FS0->D0FIFO;
     volatile uint16_t * d0fifoctr = hs_module ? &R_USB_HS0->D0FIFOCTR : &R_USB_FS0->D0FIFOCTR;
+#elif BSP_FEATURE_USB_HAS_PIPE04567
+    volatile uint16_t * d0fifosel = &R_USB_FS0->CFIFOSEL;
+    volatile void     * d0fifo    = &R_USB_FS0->CFIFO;
+    volatile uint16_t * d0fifoctr = &R_USB_FS0->CFIFOCTR;
 #else
     volatile uint16_t * d0fifosel = &R_USB_FS0->D0FIFOSEL;
     volatile void     * d0fifo    = &R_USB_FS0->D0FIFO;
@@ -983,14 +1004,18 @@ static inline bool pipe_xfer_in (usbd_instance_ctrl_t * const p_ctrl, uint8_t nu
 /* process OUT direction transfer for common pipe */
 static inline bool pipe_xfer_out (usbd_instance_ctrl_t * const p_ctrl, uint8_t num)
 {
-#ifdef USB_HIGH_SPEED_MODULE
+#if defined(USB_HIGH_SPEED_MODULE)
     bool                hs_module = USB_IS_USBHS(p_ctrl->p_cfg->module_number);
     volatile uint16_t * d0fifosel = hs_module ? &R_USB_HS0->D0FIFOSEL : &R_USB_FS0->D0FIFOSEL;
-    volatile uint32_t * d0fifo    = hs_module ? &R_USB_HS0->D0FIFO : &R_USB_FS0->D0FIFO;
+    volatile void     * d0fifo    = hs_module ? &R_USB_HS0->D0FIFO : &R_USB_FS0->D0FIFO;
     volatile uint16_t * d0fifoctr = hs_module ? &R_USB_HS0->D0FIFOCTR : &R_USB_FS0->D0FIFOCTR;
+#elif BSP_FEATURE_USB_HAS_PIPE04567
+    volatile uint16_t * d0fifosel = &R_USB_FS0->CFIFOSEL;
+    volatile void     * d0fifo    = &R_USB_FS0->CFIFO;
+    volatile uint16_t * d0fifoctr = &R_USB_FS0->CFIFOCTR;
 #else
     volatile uint16_t * d0fifosel = &R_USB_FS0->D0FIFOSEL;
-    volatile uint32_t * d0fifo    = &R_USB_FS0->D0FIFO;
+    volatile void     * d0fifo    = &R_USB_FS0->D0FIFO;
     volatile uint16_t * d0fifoctr = &R_USB_FS0->D0FIFOCTR;
 #endif
 
@@ -1002,8 +1027,10 @@ static inline bool pipe_xfer_out (usbd_instance_ctrl_t * const p_ctrl, uint8_t n
     const uint16_t mps = edpt_max_packet_size(p_ctrl, num);
     pipe_wait_for_ready(p_ctrl, num);
 
-#ifdef USB_HIGH_SPEED_MODULE
+#if defined(USB_HIGH_SPEED_MODULE)
     const uint16_t vld = hs_module ? R_USB_HS0->D0FIFOCTR_b.DTLN : R_USB_FS0->D0FIFOCTR_b.DTLN;
+#elif BSP_FEATURE_USB_HAS_PIPE04567
+    const uint16_t vld = R_USB_FS0->CFIFOCTR_b.DTLN;
 #else
     const uint16_t vld = R_USB_FS0->D0FIFOCTR_b.DTLN;
 #endif
@@ -1219,10 +1246,13 @@ static inline fsp_err_t process_pipe_xfer (usbd_instance_ctrl_t * const p_ctrl,
                                            void                       * buffer,
                                            uint16_t                     total_bytes)
 {
-#ifdef USB_HIGH_SPEED_MODULE
+#if defined(USB_HIGH_SPEED_MODULE)
     bool                hs_module = USB_IS_USBHS(p_ctrl->p_cfg->module_number);
     volatile uint16_t * d0fifosel = hs_module ? &R_USB_HS0->D0FIFOSEL : &R_USB_FS0->D0FIFOSEL;
     volatile uint16_t * d0fifoctr = hs_module ? &R_USB_HS0->D0FIFOCTR : &R_USB_FS0->D0FIFOCTR;
+#elif BSP_FEATURE_USB_HAS_PIPE04567
+    volatile uint16_t * d0fifosel = &R_USB_FS0->CFIFOSEL;
+    volatile uint16_t * d0fifoctr = &R_USB_FS0->CFIFOCTR;
 #else
     volatile uint16_t * d0fifosel = &R_USB_FS0->D0FIFOSEL;
     volatile uint16_t * d0fifoctr = &R_USB_FS0->D0FIFOCTR;


### PR DESCRIPTION
## Add support for 5-pipe USBFS peripherals (RA2L2, RA2A1, RA4E2, RA6E2, RA6T3)

I'm a big fan of the FSP and Renesas hardware. I recently picked up an RA4E2 devkit for a project and ran into issues getting USB working out of the box. Digging into the driver, I noticed the 5-pipe USBFS variant wasn't supported, but most of the code was already in place, it just needed some hardware-specific touch-ups to handle the different pipe layout and FIFO access pattern.

Since I had some spare time over the weekend, I figured I'd try to fill in the gaps. The change is fairly minimal and gated behind a feature macro, so it shouldn't affect any existing supported boards.

Hope this is useful! Happy to make any adjustments based on your feedback!

### Problem

The existing `r_usb_device.c` driver only supported the 10-pipe USBFS peripheral variant. On MCUs with the 5-pipe USBFS module (RA2L2, RA2A1, RA4E2, RA6E2, RA6T3), the driver failed in two ways:

1. **Pipe allocation**:  `find_pipe()` returned pipe numbers (1–3, 8–9) that don't physically exist on 5-pipe hardware. According to the RA4E2 datasheet (Section 25.1), the 5-pipe USBFS module exposes only **pipes 0, 4, 5, 6, and 7**, with pipes 4–7 being configurable for endpoints.

2. **FIFO access**: The driver used the `D0FIFO`/`D1FIFO` ports for common-pipe data transfers. On the 5-pipe USBFS variant, common-pipe transfers must go through the `CFIFO` port instead.

### Fix

Introduced a `BSP_FEATURE_USB_HAS_PIPE04567` feature macro to gate the hardware-specific code paths. When set:

- **`find_pipe()`** uses a 5-pipe lookup table:
  ```c
  {0, 0},   // Control      → Pipe 0
  {7, 7},   // Isochronous  → Pipe 7
  {4, 5},   // Bulk         → Pipes 4–5
  {6, 6},   // Interrupt    → Pipe 6
  ```
- **`pipe_xfer_in()` / `pipe_xfer_out()` / `process_pipe_xfer()` / `pipe_wait_for_ready()`** route through `CFIFOSEL` / `CFIFO` / `CFIFOCTR` instead of `D0FIFO*`.

The original 10-pipe code path is preserved verbatim under `#else`, so existing supported MCUs are unaffected.

### Testing

Verified the change works on both peripheral variants and does not introduce regressions:

-  **5-pipe USBFS** — RA4E2 devkit (new support)
-  **10-pipe USBFS** — RA8M1 (regression check)

Tested via USB CDC ACM sample code with bidirectional data transfer (host→device and device→host) confirmed working on both peripherals.

### Affected MCUs

Adds support for these MCU groups (5-pipe USBFS):
- RA2L2
- RA2A1
- RA4E2
- RA6E2
- RA6T3