### PR TITLE
hal: renesas: ra: Update FAST_MODE_PLUS_CHANNELS_MASK for RA6M5

### DIFF
--- a/drivers/ra/README
+++ b/drivers/ra/README
@@ -213,3 +213,7 @@ Patch List:
       Impacted files:
          drivers/ra/fsp/src/r_layer3_switch/r_layer3_switch.c
          zephyr/ra/ra_cfg/fsp_cfg/r_layer3_switch_cfg.h
+
+   * Update BSP_FEATURE_IIC_FAST_MODE_PLUS_CHANNELS_MASK for RA6M5
+      Impacted files:
+         drivers/ra/fsp/src/bsp/mcu/ra6m5/bsp_feature.h

--- a/drivers/ra/fsp/src/bsp/mcu/ra6m5/bsp_feature.h
+++ b/drivers/ra/fsp/src/bsp/mcu/ra6m5/bsp_feature.h
@@ -362,7 +362,7 @@
 #define BSP_FEATURE_IIC_B_CHECK_SCILV_BEFORE_MASTER_WRITE_TX_DATA (0UL)             // SCL status needs to be checked before writing the transmission data in master mode.
 #define BSP_FEATURE_IIC_B_FAST_MODE_PLUS_CHANNELS_MASK            (0x00UL)          // Mask of channels which support "Fast Mode Plus": up to 1 Mbps bit rates.
 #define BSP_FEATURE_IIC_B_VALID_CHANNEL_MASK                      (0x00UL)          // Mask of available IIC_B or compatible I3C channels.
-#define BSP_FEATURE_IIC_FAST_MODE_PLUS_CHANNELS_MASK              (1UL)             // Mask of channels which support "Fast Mode Plus": up to 1 Mbps bit rates.
+#define BSP_FEATURE_IIC_FAST_MODE_PLUS_CHANNELS_MASK              (3UL)             // Mask of channels which support "Fast Mode Plus": up to 1 Mbps bit rates.
 #define BSP_FEATURE_IIC_HAS_CLOCK                                 (0UL)             // Indicates there is a separate IIC clock.
 #define BSP_FEATURE_IIC_VALID_CHANNEL_MASK                        (0x07UL)          // Mask of available IIC channels.
 


### PR DESCRIPTION
Since the HW manual of RA6M5 indicates that `iic1` supports 1 MHz operation, but `BSP_FEATURE_IIC_FAST_MODE_PLUS_CHANNELS_MASK` got value `1UL`, mean that it doesn't include channel 1. This commit update the `BSP_FEATURE_IIC_FAST_MODE_PLUS_CHANNELS_MASK` for RA6M5 to value `3UL`