### PR TITLE
hal: renesas: ra: fix ZLP never transmitted on non-control IN endpoints

### DIFF
--- a/drivers/ra/fsp/src/r_usb_device/r_usb_device.c
+++ b/drivers/ra/fsp/src/r_usb_device/r_usb_device.c
@@ -1283,10 +1283,9 @@ static inline fsp_err_t process_pipe_xfer (usbd_instance_ctrl_t * const p_ctrl,
             /* ZLP */
             *d0fifosel = num;
 
-            if ((*d0fifoctr & R_USB_CFIFOCTR_BVAL_Msk) != 0)
-            {
-                *d0fifoctr = R_USB_CFIFOCTR_BVAL_Msk;
-            }
+            pipe_wait_for_ready(p_ctrl, num);
+
+            *d0fifoctr = R_USB_CFIFOCTR_BVAL_Msk;
 
             *d0fifosel = 0;
 


### PR DESCRIPTION
A recent Zephyr commit (zephyrproject-rtos/zephyr#110225) added echo mitigation for USB CDC-ACM by sending a ZLP on the bulk IN endpoint at configuration time. This exposed two bugs in process_pipe_xfer() that prevented non-control IN ZLPs from ever being transmitted on RA devices with USBFS.

1. pipe_wait_for_ready() was not called before writing BVAL, so the FIFO had not yet latched the pipe selection or asserted FRDY=1 and the write was silently dropped.
2. BVAL was only written when already set (inverted condition), making it a no-op at fresh boot when the bit is still cleared.

Because no BRDY interrupt fires without BVAL being committed, the TX complete callback never runs, leaving CDC-ACM TX permanently stalled.