### PR TITLE
hal: renesas: ra: Fix ZLP being sent after every full packet

### DIFF
--- a/drivers/ra/fsp/src/r_usb_device/r_usb_device.c
+++ b/drivers/ra/fsp/src/r_usb_device/r_usb_device.c
@@ -986,7 +986,10 @@ static inline bool pipe_xfer_in (usbd_instance_ctrl_t * const p_ctrl, uint8_t nu
         pipe->buf = (uint8_t *) buf + len;
     }
 
-    *d0fifoctr = R_USB_D0FIFOCTR_BVAL_Msk;
+    if (len < mps)
+    {
+        *d0fifoctr = R_USB_D0FIFOCTR_BVAL_Msk;
+    }
 
     *d0fifosel = 0;
 


### PR DESCRIPTION
Fix a bug in pipe_xfer_in() introduced in https://github.com/zephyrproject-rtos/hal_renesas/pull/218 that results in a ZLP being sent after every full packet. Writing data into the FIFO with the maximum packet size automatically enables transmission. Setting the BVAL flag then causes an additional packet to be transmitted.
<img width="659" height="99" alt="image" src="https://github.com/user-attachments/assets/ba0cd687-6f59-4789-923f-8548ab4fa89a" />
Instead, the BVAL flag should only be set for short packets instead of unconditionally