### PR TITLE
drivers: ra: r_usb_device: commit bulk IN zero-length packets

### DIFF
--- a/drivers/ra/fsp/src/r_usb_device/r_usb_device.c
+++ b/drivers/ra/fsp/src/r_usb_device/r_usb_device.c
@@ -1280,13 +1280,22 @@ static inline fsp_err_t process_pipe_xfer (usbd_instance_ctrl_t * const p_ctrl,
         }
         else
         {
-            /* ZLP */
-            *d0fifosel = num;
+            /* ZLP: commit an empty buffer so the controller transmits a
+             * zero-length packet. Select the pipe FIFO, wait until it is
+             * ready for CPU access, then set BVAL - exactly as pipe_xfer_in()
+             * does for a short final packet. The previous code only
+             * re-asserted BVAL when it was already set, so for a freshly
+             * selected (empty) buffer the ZLP was never actually sent and the
+             * BRDY / transfer-complete interrupt never arrived: a bulk IN
+             * endpoint stalls forever after its first ZLP. usbd_cdc_acm
+             * enqueues a ZLP on enable, so CDC-ACM TX never starts.
+             */
+            *d0fifosel = num | R_USB_FIFOSEL_MBW_16BIT |
+                         (BYTE_ORDER == BIG_ENDIAN ? R_USB_FIFOSEL_BIGEND : 0);
 
-            if ((*d0fifoctr & R_USB_CFIFOCTR_BVAL_Msk) != 0)
-            {
-                *d0fifoctr = R_USB_CFIFOCTR_BVAL_Msk;
-            }
+            pipe_wait_for_ready(p_ctrl, num);
+
+            *d0fifoctr = R_USB_D0FIFOCTR_BVAL_Msk;
 
             *d0fifosel = 0;
 


### PR DESCRIPTION
### Summary

`process_pipe_xfer()` never commits a bulk-IN zero-length packet, so a bulk IN endpoint stalls permanently after its first ZLP. On `ek_ra8d1` (USB high-speed) this wedges CDC-ACM TX completely.

### Detail

In the IN path for `total_bytes == 0`:

```c
*d0fifosel = num;
if ((*d0fifoctr & R_USB_CFIFOCTR_BVAL_Msk) != 0) {
    *d0fifoctr = R_USB_CFIFOCTR_BVAL_Msk;
}
```

For a freshly selected, empty pipe buffer `BVAL` is 0, so the body is skipped and `BVAL` is never written. The controller never commits the empty buffer, no ZLP goes out, and no `BRDY` interrupt fires — so `process_pipe_brdy()` never delivers `USBD_EVENT_XFER_COMPLETE`.

The non-ZLP path in the same function (`pipe_xfer_in()`) sets `*d0fifoctr = R_USB_D0FIFOCTR_BVAL_Msk` **unconditionally** for a short final packet. This change makes the ZLP branch do the same (select FIFO, `pipe_wait_for_ready()`, set `BVAL`).

### How it manifests

`usbd_cdc_acm_enable()` primes a zero-length IN transfer, so any CDC-ACM device on this stack hits it immediately: `CDC_ACM_TX_FIFO_BUSY` latches, and bytes written with `uart_fifo_fill()` pile up in the class TX ring and never reach the host.

### Testing

- Board: EK-RA8D1 (R7FA8D1BHECBD), USB-HS, `CONFIG_USB_DEVICE_STACK_NEXT`.
- **Before:** host reads 0 bytes from the CDC port, indefinitely — reproduces with the unmodified `zephyr/samples/subsys/usb/cdc_acm`.
- **After:** host receives the data the device sends on DTR; host→device bulk OUT was already fine and still works.
- Zephyr tree `66e5135ffc3` + this change.

### Note

This is vendored Renesas FSP code (`r_usb_device`). If it's preferred to route the fix through Renesas FSP first, I'm happy to do that — raising it here because the Zephyr-side impact (CDC-ACM unusable on RA USB-HS) is significant.
