### PR TITLE
hal: renesas: add REUSE.toml and LICENSES/

### DIFF
--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,194 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship made available under
+   the License, as indicated by a copyright notice that is included in
+   or attached to the work (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean, as to the Licensor, the original version of
+   the Work and any additions or modifications to that Work or Derivative
+   Works of that Work that are intentionally submitted to the Licensor for
+   inclusion in the Work by the copyright owner or by an individual or
+   Legal Entity authorized to submit on behalf of the copyright owner. For
+   the purposes of this definition, "submitted" means any form of
+   electronic, verbal, or written communication sent to the Licensor or
+   its representatives, including but not limited to communication on
+   electronic mailing lists, source code control systems, and issue
+   tracking systems that are managed by, or on behalf of, the Licensor for
+   the purpose of discussing and improving the Work, but excluding
+   communication that is conspicuously marked or otherwise designated in
+   writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any Legal Entity on behalf of
+   whom a Contribution has been received by the Licensor and subsequently
+   incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a cross-claim
+   or counterclaim in a lawsuit) alleging that the Work or a Contribution
+   incorporated within the Work constitutes direct or contributory patent
+   infringement, then any patent licenses granted to You under this License
+   for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work
+   or Derivative Works thereof in any medium, with or without modifications,
+   and in Source or Object form, provided that You meet the following
+   conditions:
+
+   (a) You must give any other recipients of the Work or Derivative Works
+       a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works that
+       You distribute, all copyright, patent, trademark, and attribution
+       notices from the Source form of the Work, excluding those notices
+       that do not pertain to any part of the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, You must include a readable copy of the attribution
+       notices contained within such NOTICE file, in at least one of the
+       following places: within a NOTICE text file distributed as part of
+       the Derivative Works; within the Source form or documentation, if
+       provided along with the Derivative Works; or, within a display
+       generated by the Derivative Works, if and wherever such third-party
+       notices normally appear. The contents of the NOTICE file are for
+       informational purposes only and do not modify the License. You may
+       add Your own attribution notices within Derivative Works that You
+       distribute, alongside or as an addendum to the NOTICE text from the
+       Work, provided that such additional attribution notices cannot be
+       construed as modifying the License.
+
+   You may add Your own license statement for Your modifications and
+   may provide additional grant of rights to use, reproduce, modify, and
+   distribute such modifications, provided that your use, reproduction,
+   modification, and distribution of the Work otherwise complies with the
+   conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work by
+   You to the Licensor shall be under the terms and conditions of this
+   License, without any additional terms or conditions. Notwithstanding
+   the above, nothing herein shall supersede or modify the terms of any
+   separate license agreement you may have executed with Licensor regarding
+   such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or exemplary damages of any character arising as a result
+   of this License or out of the use or inability to use the Work
+   (including but not limited to damages for loss of goodwill, work
+   stoppage, computer failure or malfunction, or all other commercial
+   damages or losses), even if such Contributor has been advised of the
+   possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer, and
+   charge a fee for, acceptance of support, warranty, indemnity, or other
+   liability obligations and/or rights consistent with this License.
+   However, in accepting such obligations, You may offer such support only
+   on Your own behalf and on Your sole responsibility, not on behalf of any
+   other Contributor, and only if You agree to indemnify, defend, and hold
+   each Contributor harmless for any liability incurred by, or claims
+   asserted against, such Contributor by reason of your accepting any such
+   warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!) The text should be enclosed in the appropriate
+   comment syntax for the file format in use. We also recommend that
+   a file or class name and a description of its purpose be included on
+   the same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/LicenseRef-Renesas-Open-License.txt
+++ b/LICENSES/LicenseRef-Renesas-Open-License.txt
@@ -1,0 +1,44 @@
+## Renesas Open License v1.0
+
+Copyright (c) 2020 - 2025, Renesas Electronics Corporation and/or its affiliates
+
+
+By installing, copying, downloading, accessing, or otherwise using this software
+or any part thereof and the related documentation from Renesas Electronics Corporation
+and/or its affiliates ("Renesas"), You, either individually  or on behalf of an entity
+employing or engaging You, agree to be bound by this Software License Agreement. If you
+do not agree or no longer agree, you are not permitted to use this software or related
+documentation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form, except as embedded into a Renesas
+   integrated circuit in a product or a software update for
+   such product, must reproduce the above copyright notice, this list of
+   conditions and the following disclaimer in the documentation and/or other
+   materials provided with the distribution.
+
+3. Neither the name of Renesas nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+4. This software, with or without modification, must only be used with a
+   Renesas integrated circuit, or other such integrated circuit permitted by Renesas in writing.
+
+5. Any software provided in binary form under this license must not be reverse
+   engineered, decompiled, modified and/or disassembled.
+
+THIS SOFTWARE IS PROVIDED BY RENESAS "AS IS" AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL RENESAS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# REUSE.toml — REUSE Specification 3.3 bulk annotations for binary blobs
+# https://reuse.software/spec-3.3/
+#
+# This file provides SPDX license and copyright metadata for west-fetched
+# binary blobs (zephyr/blobs/), which cannot carry in-file SPDX tags.
+# License text is taken from the blob license-path in zephyr/module.yml.
+# Paths below do not overlap (REUSE combines overlapping annotations with AND).
+# In-file tags always take precedence over entries below (REUSE spec §3.3).
+#
+# Licenses referenced here must have their full text under LICENSES/.
+
+version = 1
+
+# ---------------------------------------------------------------------------
+# Binary blobs — Apache-2.0 (CMAC: zephyr/blobs/license.txt)
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "zephyr/blobs/smartbond/**",
+  "zephyr/blobs/license.txt",
+]
+SPDX-FileCopyrightText = "Copyright (c) Renesas Electronics Corporation and/or its affiliates"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ---------------------------------------------------------------------------
+# Binary blobs — Renesas Open License v1.0 (D/AVE 2D)
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "zephyr/blobs/dave2d/**",
+  "zephyr/blobs/renesas_open_license.txt",
+]
+SPDX-FileCopyrightText = "Copyright (c) 2020 - 2025, Renesas Electronics Corporation and/or its affiliates"
+SPDX-License-Identifier = "LicenseRef-Renesas-Open-License"


### PR DESCRIPTION
## Summary
Add [REUSE Specification 3.3](https://reuse.software/spec-3.3/) compliance infrastructure so west-fetched binary blobs have machine-readable license information that can be accurately reflected in an SBOM (Software Bill of Materials).

Binary blobs cannot carry in-file SPDX tags. Previously their licenses were described only via `license-path` in `zephyr/module.yml`:
- `Apache-2.0`: `zephyr/blobs/smartbond/**` (CMAC)
- `LicenseRef-Renesas-Open-License`: `zephyr/blobs/dave2d/**` (D/AVE 2D)

Without REUSE annotations, SBOM generators such as `west spdx` report `NOASSERTION` for those files.

Changes:
- Add `REUSE.toml` with path-glob annotations mapping each blob tree to its SPDX license expression, per REUSE spec §3.3.
- Add `LICENSES/` directory with canonical full-text copies of:
  * `Apache-2.0.txt`
  * `LicenseRef-Renesas-Open-License.txt` (copied from `zephyr/blobs/renesas_open_license.txt`)

> [!NOTE]
> It would probably make sense to also update the `license-path:` entries in `zephyr/module.yml` so they point to the new REUSE-compliant location(s) under `LICENSES/`.

## Test plan
- [x] Confirm `REUSE.toml` path globs match blob `license-path` entries in `zephyr/module.yml`
- [x] Confirm `LICENSES/` contains the full text for every SPDX id referenced in `REUSE.toml`
- [x] After `west blobs fetch`, `west spdx --spdx-version 3.0` reports the annotated license instead of `NOASSERTION` for linked blobs
  - [x] `west build -b da1469x_dk_pro samples/bluetooth/beacon -- -DCONFIG_BUILD_OUTPUT_META=y` (links `libcmac.a`)
  - [x] `west build -b ek_ra8d1` dummy app importing `libdave2d.a` from `zephyr/blobs/dave2d/` (`-DCONFIG_BUILD_OUTPUT_META=y`)
  - [x] `west spdx -d <build> --spdx-version 3.0`
- [x] Load `zephyr.jsonld` in https://kartben.github.io/spdx3_viz/ and confirm blob `File` entries (`license`, `copyright`, `module.yml` `comment`/`description`)


<img width="1074" height="558" alt="image" src="https://github.com/user-attachments/assets/8d0b08c1-63eb-4ec1-b63d-8e3de7c1b6bc" />


<img width="1125" height="688" alt="image" src="https://github.com/user-attachments/assets/1d8225ae-3a4b-4cee-96e9-ceb6a733db47" />
