### PR TITLE
zephyr: ra: agt: agtcmbi and agtcmai changed to clear only their AGTCR flag

### DIFF
--- a/zephyr/ra/portable/src/rp_agt/rp_agt.c
+++ b/zephyr/ra/portable/src/rp_agt/rp_agt.c
@@ -22,8 +22,6 @@
                                                                         ? &(p_instance_ctrl)->p_reg->AGT32.CTRL \
                                                                         : &(p_instance_ctrl)->p_reg->AGT16.CTRL))
 
-#define AGT_PRV_AGTCR_STATUS_FLAGS    (0xF0U)
-
 /**********************************************************************************************************************
  * Typedef definitions
  **********************************************************************************************************************/
@@ -166,7 +164,7 @@ void agtcmai_isr (void)
     agt_prv_reg_ctrl_ptr_t p_reg_ctrl      = AGT_PRV_CTRL_PTR(p_instance_ctrl);
 
     /* Clear flags in AGTCR. */
-    p_reg_ctrl->AGTCR &= ~AGT_PRV_AGTCR_STATUS_FLAGS;
+    p_reg_ctrl->AGTCR &= ~R_AGTX0_AGT16_CTRL_AGTCR_TCMAF_Msk;
 
     /* Restore context if RTOS is used */
     FSP_CONTEXT_RESTORE
@@ -187,7 +185,7 @@ void agtcmbi_isr (void)
     agt_prv_reg_ctrl_ptr_t p_reg_ctrl      = AGT_PRV_CTRL_PTR(p_instance_ctrl);
 
     /* Clear flags in AGTCR. */
-    p_reg_ctrl->AGTCR &= ~AGT_PRV_AGTCR_STATUS_FLAGS;
+    p_reg_ctrl->AGTCR &= ~R_AGTX0_AGT16_CTRL_AGTCR_TCMBF_Msk;
 
     /* Restore context if RTOS is used */
     FSP_CONTEXT_RESTORE


### PR DESCRIPTION
agtcmai_isr() and agtcmbi_isr() have both been clearing TEDGF, TUNDF, TCMAF and TCMBF, so a compare match interrupt could clear another event's flag before RP_AGT_EventGet() read it and declare the flag as not raised.

Clear only TCMAF in agtcmai_isr() and only TCMBF in agtcmbi_isr().

This PR is linked to another PR I am working on which requires independent clears.
https://github.com/zephyrproject-rtos/zephyr/pull/115060

Tested on EK-RA6M5. agtcmai_isr() now clears TCMAF and agtcmbi_isr() clears only TCMBF. TUNDF is left untouched by both and cleared by agt_int_isr().